### PR TITLE
TEMP: build gate audit

### DIFF
--- a/.github/workflows/build-audit-temp.yml
+++ b/.github/workflows/build-audit-temp.yml
@@ -1,0 +1,49 @@
+name: Temporary build gate audit
+
+on:
+  push:
+    branches:
+      - audit-build-gates
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Show available quality gates
+        shell: bash
+        run: |
+          echo '--- npm scripts ---'
+          npm run
+          echo '--- eslint package ---'
+          npm ls eslint --depth=0 || true
+
+      - name: Measure TypeScript errors without changing code
+        shell: bash
+        run: |
+          set +e
+          npx tsc --noEmit --pretty false 2>&1 | tee tsc.log
+          TSC_STATUS=${PIPESTATUS[0]}
+          ERROR_COUNT=$(grep -c 'error TS' tsc.log || true)
+          FILE_COUNT=$(grep 'error TS' tsc.log | sed -E 's/^([^(:]+).*/\1/' | sort -u | wc -l | tr -d ' ')
+          echo "TSC_EXIT=$TSC_STATUS"
+          echo "TSC_ERROR_COUNT=$ERROR_COUNT"
+          echo "TSC_FILE_COUNT=$FILE_COUNT"
+          echo '--- files with TypeScript errors ---'
+          grep 'error TS' tsc.log | sed -E 's/^([^(:]+).*/\1/' | sort -u || true
+          exit 0

--- a/.github/workflows/build-audit-temp.yml
+++ b/.github/workflows/build-audit-temp.yml
@@ -47,6 +47,8 @@ jobs:
           echo "TSC_EXIT=$TSC_STATUS"
           echo "TSC_ERROR_COUNT=$ERROR_COUNT"
           echo "TSC_FILE_COUNT=$FILE_COUNT"
-          echo '--- files with TypeScript errors ---'
-          grep 'error TS' tsc.log | sed -E 's/^([^(:]+).*/\1/' | sort -u || true
+          echo '--- TypeScript errors by file ---'
+          grep 'error TS' tsc.log | sed -E 's/^([^(:]+).*/\1/' | sort | uniq -c | sort -nr || true
+          echo '--- TypeScript errors by code ---'
+          grep -oE 'TS[0-9]+' tsc.log | sort | uniq -c | sort -nr || true
           exit 0

--- a/.github/workflows/build-audit-temp.yml
+++ b/.github/workflows/build-audit-temp.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - audit-build-gates
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Tillfällig read-only kartläggning av TypeScript/build-gates på production-baseline. Ingen appkod ändrades.

Resultat:
- `npx tsc --noEmit` -> exit 2
- 105 TypeScript-fel i 7 filer
- 46 `app/status/form-client.tsx`
- 27 `app/check/form-client.tsx`
- 23 `lib/vehicle-status.ts`
- 3 `app/nybil/form-client.tsx`
- 3 `components/ImageAnnotator.tsx`
- 2 `lib/damages.ts`
- 1 `components/MediaGallery.tsx`
- inget lint-script och ingen top-level ESLint-installation
- `npm ci` rapporterade dessutom 10 kända dependency-vulnerabilities (9 high, 1 critical), separat fynd för senare dependency-review.

PR:n stängs utan merge. Audit-branchen återställs till Production-baseline efter mätningen.