### PR TITLE
Steg 2.5: automatiserat regressionsskydd

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: ESLint
         run: npm run lint
+
+      - name: Security regression
+        run: npm run test:regression

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,7 +12,13 @@ permissions:
 jobs:
   typecheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-anon-key
+      SUPABASE_SERVICE_ROLE_KEY: dummy-service-role-key
+      RESEND_API_KEY: re_dummy
+      NEXT_PUBLIC_SITE_URL: http://127.0.0.1:3127
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,3 +40,9 @@ jobs:
 
       - name: Security regression
         run: npm run test:regression
+
+      - name: Production build
+        run: npm run build
+
+      - name: Built Next security smoke
+        run: npm run test:security-runtime

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "typecheck": "tsc --noEmit",
     "generate-damage-options": "tsx scripts/generate-damage-options.ts",
     "lint": "eslint . --pass-on-unpruned-suppressions",
-    "lint:prune": "eslint . --prune-suppressions"
+    "lint:prune": "eslint . --prune-suppressions",
+    "test:regression": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "generate-damage-options": "tsx scripts/generate-damage-options.ts",
     "lint": "eslint . --pass-on-unpruned-suppressions",
     "lint:prune": "eslint . --prune-suppressions",
-    "test:regression": "tsx --test tests/*.test.ts"
+    "test:regression": "tsx --test tests/*.test.ts",
+    "test:security-runtime": "node scripts/security-runtime-smoke.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.0",

--- a/scripts/security-runtime-smoke.mjs
+++ b/scripts/security-runtime-smoke.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+
+const host = '127.0.0.1'
+const port = 3127
+const baseUrl = `http://${host}:${port}`
+
+const protectedApiPaths = [
+  '/api/checkin-damages',
+  '/api/damage-comments',
+  '/api/notify',
+  '/api/notify-arrival',
+  '/api/notify-nybil',
+  '/api/vehicle-edits',
+  '/api/vehicle-info?reg=GEU29F',
+]
+
+const publicPagePaths = [
+  '/',
+  '/check',
+  '/ankomst',
+  '/status',
+  '/nybil',
+  '/rapport',
+]
+
+const server = spawn(
+  process.platform === 'win32' ? 'npm.cmd' : 'npm',
+  ['run', 'start', '--', '-H', host, '-p', String(port)],
+  {
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  },
+)
+
+let serverOutput = ''
+let exitCode = null
+
+server.stdout.on('data', (chunk) => {
+  serverOutput += chunk.toString()
+})
+server.stderr.on('data', (chunk) => {
+  serverOutput += chunk.toString()
+})
+server.once('exit', (code) => {
+  exitCode = code
+})
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function waitForServer() {
+  const deadline = Date.now() + 20_000
+
+  while (Date.now() < deadline) {
+    if (exitCode !== null) {
+      throw new Error(`Next server exited before smoke test. Exit ${exitCode}.\n${serverOutput}`)
+    }
+
+    try {
+      const response = await fetch(`${baseUrl}/api/health`)
+      if (response.status === 200) return
+    } catch {
+      // Server is still starting.
+    }
+
+    await delay(250)
+  }
+
+  throw new Error(`Timed out waiting for Next server.\n${serverOutput}`)
+}
+
+async function stopServer() {
+  if (exitCode !== null) return
+
+  server.kill('SIGTERM')
+  await Promise.race([
+    new Promise((resolve) => server.once('exit', resolve)),
+    delay(5_000),
+  ])
+
+  if (exitCode === null) server.kill('SIGKILL')
+}
+
+try {
+  await waitForServer()
+
+  for (const path of protectedApiPaths) {
+    const response = await fetch(`${baseUrl}${path}`)
+    assert.equal(response.status, 401, `${path} must reject unauthenticated access`)
+    assert.deepEqual(
+      await response.json(),
+      { error: 'Authentication required' },
+      `${path} must return the canonical authentication error`,
+    )
+  }
+
+  const health = await fetch(`${baseUrl}/api/health`)
+  assert.equal(health.status, 200, '/api/health must remain reachable without authentication')
+
+  for (const path of publicPagePaths) {
+    const response = await fetch(`${baseUrl}${path}`)
+    assert.equal(response.status, 200, `${path} must render successfully`)
+  }
+
+  console.log('Built Next security smoke passed')
+} finally {
+  await stopServer()
+}

--- a/scripts/security-runtime-smoke.mjs
+++ b/scripts/security-runtime-smoke.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
+import path from 'node:path'
 
 const host = '127.0.0.1'
 const port = 3127
@@ -24,9 +25,10 @@ const publicPagePaths = [
   '/rapport',
 ]
 
+const nextBin = path.resolve('node_modules/next/dist/bin/next')
 const server = spawn(
-  process.platform === 'win32' ? 'npm.cmd' : 'npm',
-  ['run', 'start', '--', '-H', host, '-p', String(port)],
+  process.execPath,
+  [nextBin, 'start', '-H', host, '-p', String(port)],
   {
     env: process.env,
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -35,15 +37,18 @@ const server = spawn(
 
 let serverOutput = ''
 let exitCode = null
+const serverExited = new Promise((resolve) => {
+  server.once('exit', (code) => {
+    exitCode = code
+    resolve(code)
+  })
+})
 
 server.stdout.on('data', (chunk) => {
   serverOutput += chunk.toString()
 })
 server.stderr.on('data', (chunk) => {
   serverOutput += chunk.toString()
-})
-server.once('exit', (code) => {
-  exitCode = code
 })
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -73,12 +78,12 @@ async function stopServer() {
   if (exitCode !== null) return
 
   server.kill('SIGTERM')
-  await Promise.race([
-    new Promise((resolve) => server.once('exit', resolve)),
-    delay(5_000),
-  ])
+  await Promise.race([serverExited, delay(5_000)])
 
-  if (exitCode === null) server.kill('SIGKILL')
+  if (exitCode === null) {
+    server.kill('SIGKILL')
+    await Promise.race([serverExited, delay(2_000)])
+  }
 }
 
 try {

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -1,0 +1,72 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { NextRequest } from 'next/server'
+
+import { EMAIL_WHITELIST, isWhitelistedEmail } from '../lib/access-control'
+import { verifyApiUser } from '../lib/server-auth'
+import { proxy } from '../proxy'
+
+const protectedApiPaths = [
+  '/api/checkin-damages',
+  '/api/damage-comments',
+  '/api/notify',
+  '/api/notify-arrival',
+  '/api/notify-nybil',
+  '/api/vehicle-edits',
+  '/api/vehicle-info?reg=GEU29F',
+]
+
+test('all central protected API paths reject unauthenticated requests', async (t) => {
+  for (const path of protectedApiPaths) {
+    await t.test(path, async () => {
+      const response = await proxy(new NextRequest(`http://localhost${path}`))
+
+      assert.equal(response.status, 401)
+      assert.deepEqual(await response.json(), { error: 'Authentication required' })
+    })
+  }
+})
+
+test('/api/health stays outside the API authentication boundary', async () => {
+  const response = await proxy(new NextRequest('http://localhost/api/health'))
+
+  assert.equal(response.status, 200)
+})
+
+test('non-API application routes stay outside the API authentication boundary', async () => {
+  for (const path of ['/', '/check', '/ankomst', '/status', '/nybil', '/rapport']) {
+    const response = await proxy(new NextRequest(`http://localhost${path}`))
+    assert.equal(response.status, 200)
+  }
+})
+
+test('server auth rejects missing and empty bearer credentials before any Supabase lookup', async () => {
+  const missing = await verifyApiUser(new Request('http://localhost/api/vehicle-info'))
+  assert.deepEqual(missing, {
+    ok: false,
+    status: 401,
+    error: 'Authentication required',
+  })
+
+  const emptyBearer = await verifyApiUser(new Request('http://localhost/api/vehicle-info', {
+    headers: { authorization: 'Bearer   ' },
+  }))
+  assert.deepEqual(emptyBearer, {
+    ok: false,
+    status: 401,
+    error: 'Authentication required',
+  })
+})
+
+test('whitelist lookup stays case-insensitive and rejects unknown identities', () => {
+  assert.equal(isWhitelistedEmail('INGEMAR.CARQUEIJA@MABI.SE'), true)
+  assert.equal(isWhitelistedEmail('unknown@example.com'), false)
+  assert.equal(isWhitelistedEmail(null), false)
+  assert.equal(isWhitelistedEmail(undefined), false)
+})
+
+test('whitelist entries remain normalized to lowercase', () => {
+  for (const email of EMAIL_WHITELIST) {
+    assert.equal(email, email.toLowerCase())
+  }
+})


### PR DESCRIPTION
## Syfte
Etablera permanent automatiserat regressionsskydd för den kritiska säkerhetsgränsen och Next-runtime utan produktionsskrivningar, nya dependencies eller funktionsutveckling.

## Omfattning
- Lägger till `npm run test:regression` via redan installerade `tsx` + Node test runner.
- Lägger till `tests/security-boundary.test.ts`.
- Lägger till `scripts/security-runtime-smoke.mjs` som startar den byggda Next-servern lokalt i CI med dummy-konfiguration.
- Utökar den redan obligatoriska GitHub Actions-jobben `typecheck` med regression, production build och built-runtime smoke. Befintligt `Protect main` gör därmed hela kedjan merge-blockerande utan ruleset-ändring.

## Automatiskt verifierade kontrakt
### Kodnivå
- Centrala skyddade `/api`-paths returnerar 401 utan bearer-token.
- `/api/health` förblir undantagen.
- Vanliga app-routes förblir utanför API-authgränsen.
- `verifyApiUser` avvisar saknad/tom bearer innan Supabase-lookup.
- Whitelist är case-insensitive, nekar okända identiteter och hålls normaliserad till lowercase.

### Byggd Next 16-runtime
Efter riktig `next build` startas den byggda servern och verifierar automatiskt:
- 401 + canonical `Authentication required` för `/api/checkin-damages`, `/api/damage-comments`, `/api/notify`, `/api/notify-arrival`, `/api/notify-nybil`, `/api/vehicle-edits` och `/api/vehicle-info` utan token.
- 200 för `/api/health`.
- 200 för `/`, `/check`, `/ankomst`, `/status`, `/nybil` och `/rapport`.

## Avgränsning
- Ingen riktig Supabase-anslutning.
- Inga write probes.
- Ingen ändring i affärslogik, databaslogik eller authimplementation.
- Inga nya dependencies eller lockfile-ändringar.
- Dummy-miljön används endast i CI:s lokala build/runtime-test.

## Final verifiering
Final head: `be774fa0563c0a2d52422c965438b54582b94e2d`.

Obligatorisk `typecheck`-jobb på final head:
1. `npm ci` — success
2. TypeScript — success
3. ESLint — success
4. Security regression — success
5. Production build — success
6. Built Next security smoke — success

Vercel preview på final head: success.

## Resultat
Efter merge kan en PR inte passera den befintliga obligatoriska `typecheck`-statusen om TypeScript, ESLint, säkerhetsregression, production build eller den byggda Next-runtime-smoken fallerar.

## Mergebeslut
Tekniskt redo för merge efter uttryckligt beslut.