### PR TITLE
Steg 2.6: lås teknisk takeover-baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # Incheckad – Next.js app
 
-Detta repo innehåller Incheckads Next.js‑applikation för fordonsincheckningar, skadehantering och notifieringar.
+Detta repo innehåller Incheckads Next.js-applikation för fordonsincheckningar, skadehantering och notifieringar.
+
+> **Aktuell teknisk takeover-baseline (2026-08-18):** [docs/TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md](docs/TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md). Använd den tillsammans med aktuell kod när äldre wiki-/handover-material skiljer sig från dagens system.
 
 ## Snabböversikt
-- Frontend: Next.js (App Router)
-- Auth/Storage: Supabase (public bucket: `damage-photos`)
-- E‑post: Resend
-- Hosting: Vercel (preview är skyddat av Vercel Authentication)
-- Media‑visning:
+- Frontend: Next.js `16.3.1` (App Router) + React `19.2.8`
+- Auth/Storage/DB: Supabase (public bucket: `damage-photos`)
+- E-post: Resend
+- Hosting: Vercel (preview kan skyddas av Vercel Authentication)
+- Server-API: `/api/*` skyddas server-side via `proxy.ts` + Supabase-verifiering; `/api/health` är undantag
+- Media-visning:
   - Intern route: `/media/...` (kräver inloggning)
-  - Publik route: `/public-media/...` (ingen inloggning – används i e‑post)
+  - Publik route: `/public-media/...` (ingen inloggning – används i e-post)
 
 ## Kom igång (lokalt)
-1. Klona repot och installera:
+1. Klona repot och installera exakt dependency-graf från lockfilen:
    ```bash
-   pnpm install
-   # eller
-   npm install
+   npm ci
    ```
+
 2. Skapa `.env.local`:
    ```bash
    cp .env.example .env.local
@@ -31,10 +33,20 @@ Detta repo innehåller Incheckads Next.js‑applikation för fordonsincheckninga
 
 3. Starta:
    ```bash
-   pnpm dev
-   # eller
    npm run dev
    ```
+
+## Lokala kvalitetskontroller
+
+```bash
+npm run typecheck
+npm run lint
+npm run test:regression
+npm run build
+npm run test:security-runtime
+```
+
+`test:security-runtime` förutsätter en byggd app och använder samma dummy-miljöprincip som CI när det körs som del av den obligatoriska GitHub Actions-grinden.
 
 ## Miljövariabler
 | Nyckel | Beskrivning |
@@ -42,51 +54,59 @@ Detta repo innehåller Incheckads Next.js‑applikation för fordonsincheckninga
 | NEXT_PUBLIC_SUPABASE_URL | Supabase URL |
 | NEXT_PUBLIC_SUPABASE_ANON_KEY | Supabase anon key (klient) |
 | SUPABASE_SERVICE_ROLE_KEY | Service Role (server, API) |
-| RESEND_API_KEY | Resend API Key för e‑post |
+| RESEND_API_KEY | Resend API Key för e-post |
 | NEXT_PUBLIC_SITE_URL | Bas-URL (prod/preview). Om ej angiven så byggs dynamiskt från request |
 
 ## Deploy
-- Preview: Vercel (skyddad av Vercel Authentication om "Standard Protection" är aktiv)
+- Preview: Vercel (kan vara skyddad av Vercel Authentication)
 - Production: [incheckad.se](https://www.incheckad.se)
+- `main` ska ändras via PR och required checks ska vara gröna före merge.
+- Den permanenta `typecheck`-jobben kör install, TypeScript, ESLint, säkerhetsregression, production build och byggd Next-runtime-smoke.
 
-Notera att Vercel‑skydd i preview ligger "framför" hela deploymenten – även publika routes. För att testa publika länkar i preview måste du logga in i Vercel (eller tillfälligt stänga av skyddet på just den deployen). I produktion krävs ingen inloggning för `/public-media`.
+Notera att Vercel-skydd i preview ligger "framför" hela deploymenten – även publika routes. För att testa publika länkar i en skyddad preview måste du vara inloggad i Vercel eller använda en uttryckligen avsedd testkonfiguration. I produktion krävs ingen app-inloggning för `/public-media`.
 
 ## Publik media – design
-- E‑postlänkar pekar till `/public-media/<REGNR>/<mapp>/...`
-- Samma galleri‑UI som `/media`, men utan LoginGate
+- E-postlänkar pekar till `/public-media/<REGNR>/<mapp>/...`
+- Samma galleri-UI som `/media`, men utan LoginGate
 - Breadcrumbs bevarar kontexten (stannar i `/public-media`)
-- Bucket `damage-photos` är publik; åtkomst styrs av route‑nivå
+- Bucket `damage-photos` är publik; åtkomst till publikt innehåll ska därför behandlas som avsiktlig publicering
 
-## Notifieringar (e‑post)
+## Notifieringar (e-post)
 - API: `app/api/notify/route.ts`
-- Bygger HTML (svenskt UI), inkluderar "(Visa media 🔗)" endast när det finns faktiska filer
-- Mottagare:
-  - Bilkontroll: lista (t.ex. `per@incheckad.se`, `latif@incheckad.se`)
-  - Huvudstation: dynamisk lista via ort‑karta (Helsingborg m.fl.)
-- Serverlogg: skriver sammanfattningar (media counts m.m.) i Vercel Logs
+- Route-wrapper verifierar server-side användare/audit-identitet innan befintlig affärslogik körs i `legacy-handler.ts`
+- Bygger HTML (svenskt UI), inkluderar media-länkar när det finns faktiska filer
+- Serverlogg skriver sammanfattningar för felsökning i Vercel Logs
 
 ## Databas – snabbguide
-Se Wiki för detaljer. Kort:
-- `public.damages` – normaliserar både "nya" skador och dokumenterade BUHS‑skador
-- `public.checkins` – en rad per incheckning
-- `public.checkin_damages` – en rad per position för nya skador (statistik)
-- Index/idempotens:
-  - Unika index för (regnr, legacy_damage_source_text) och `legacy_loose_key`
-  - `legacy_loose_key` = `REGNR|original_damage_date` (låser dokumenterad BUHS även om legacy‑text ändras)
+Se Wiki för historiska detaljer och takeover-baselinen för aktuell revisionsstatus. Databasstrukturen ska revalideras i **Steg 3 — datamodell/databas** innan schema-cleanup eller normalisering.
 
-## Vanliga tester
-- Öppna e‑postlänk till `/public-media/...` i inkognito → ska fungera utan inloggning
-- Breadcrumb "uppåt" i inkognito → ska stanna inom `/public-media`
-- Uppladdningsfel → blockerar submit, tydligt fel, scrollar till sektion
-- Serverlogg i Vercel → sök "Media counts received" eller "CHECKIN INSERT OK"
+Historiskt centrala tabeller/källor omfattar bland annat:
+- `public.damages` – skadehistorik, inklusive legacy/BUHS och användarskapade skador
+- `public.checkins` – incheckningar
+- `public.checkin_damages` – skador kopplade till incheckningar/statistik
+- `public.nybil_inventering` – nybilsinventering
+- `public.vehicles` – fordonsdata
+
+## Vanliga säkra kontroller
+- `npm run typecheck` → inga TypeScript-fel
+- `npm run lint` → inga nya/ökade blockerande ESLint-träffar
+- `npm run test:regression` → authgräns/accesskontrakt
+- `npm run build` + `npm run test:security-runtime` → byggd Next-runtime och API-säkerhets-smoke
+- Öppna e-postlänk till `/public-media/...` i inkognito → ska fungera utan app-inloggning
+- Serverlogg i Vercel → filtrera på berörd route vid felsökning
+
+Undvik riskfyllda write-probes mot Production eller preview som kan dela Production-Supabase. Större write-ändringar ska verifieras med isolerad testdata/testmiljö eller uttryckligen kontrollerat testobjekt.
 
 ## Support & felsökning
-- Preview kräver Vercel‑inloggning (inte app‑inloggning) när deployment security är på
-- 404 på `/public-media` i prod innan merge är förväntat
+- Preview kan kräva Vercel-inloggning utöver appens egen auth
+- Skyddade `/api/*` ska utan giltig Bearer-token svara med authfel; `/api/health` är uttryckligt offentligt undantag
 - Loggar: Vercel → Logs → filtrera på route (t.ex. `/api/notify`)
+- Vid konflikt mellan äldre wiki/handover och aktuell kod: börja i takeover-baselinen och verifiera mot Production innan förändring
 
 ## Länkar
 - Produktion: [incheckad.se](https://www.incheckad.se)
-- Publik media (exempel): `/public-media/REGNR/...`
+- Teknisk takeover-baseline: [docs/TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md](docs/TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md)
+- Arkitektur: [docs/wiki/Architecture.md](docs/wiki/Architecture.md)
+- PR-process: [docs/wiki/Contributing.md](docs/wiki/Contributing.md)
 
-Mer detaljer i Wiki.
+Mer historiska detaljer finns i Wiki.

--- a/docs/TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md
+++ b/docs/TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md
@@ -1,0 +1,232 @@
+# Invisto / Incheckad — teknisk takeover-baseline
+
+**Datum:** 2026-08-18  
+**Stabiliseringsbas:** `main` på `bd95f477f8e9b48a82d3257c6220e4f1263e6a0e` före denna dokumentations-PR  
+**Produktionsdomän:** `https://www.incheckad.se`  
+**Princip:** **behålla → reparera → ta bort → addera**
+
+Detta dokument är den tekniska överlämningsbasen efter Steg 2.1–2.5. Det beskriver vad som är verifierat, vilka skydd som är permanenta och vilken skuld som medvetet lämnas till nästa revisionsfas. Dokumentet är inte ett påstående om att process-, databas- eller produktdesign är färdig.
+
+## 1. Slutbedömning för stabiliseringsfasen
+
+Plattformen bedöms som **tekniskt övertagbar och tillräckligt stabil för kontrollerad fortsatt utveckling**.
+
+Det innebär:
+
+- den tidigare kritiska server-API-exponeringen är stängd;
+- TypeScript-fel kan inte längre passera build genom ignore-inställning;
+- dependency-grafen har migrerats till Next 16 / React 19 och senaste verifierade `npm audit` är 0 fynd;
+- ESLint är en permanent kvalitetsgrind;
+- en obligatorisk regressions- och byggd runtime-smoke finns i CI;
+- ordinarie Vercel-deploy är fortsatt del av leveransgrinden.
+
+Det innebär **inte**:
+
+- att full RBAC finns;
+- att alla legacy-typer/hook-varningar är reparerade;
+- att datamodellen är normaliserad;
+- att alla write-flöden är E2E-testade mot en isolerad testdatabas;
+- att äldre wiki-/handover-dokument automatiskt är aktuell sanning.
+
+Inom Steg 2:s scope finns inget kvarvarande verifierat **rött stoppfynd** som kräver att fortsatt utveckling fryses. Kvarvarande tekniska risker är dokumenterade nedan som kontrollerad skuld.
+
+## 2. Runtime- och stackbaseline
+
+Aktuell teknisk huvudstack:
+
+- Next.js `16.3.1` (App Router, `proxy.ts`-konvention)
+- React / React DOM `19.2.8`
+- TypeScript med strict kontroll och `ignoreBuildErrors: false`
+- Supabase för Auth, PostgreSQL och Storage
+- Resend för e-post
+- Vercel för preview och Production
+- ESLint 9 + `eslint-config-next` 16.3.1
+
+### Säkerhetskedja
+
+Den kritiska serverkedjan ska förstås som:
+
+`användare → LoginGate → autentiserad klient-fetch → /api → proxy.ts → verifyApiUser → route/legacy-handler → service role → Supabase`
+
+Viktiga egenskaper:
+
+1. `LoginGate` är UI-gate och använder Supabase-session.
+2. Klienten injicerar Bearer-token på same-origin `/api/*` utom `/api/health`.
+3. `proxy.ts` verifierar alla `/api/*` utom `/api/health` server-side.
+4. `verifyApiUser` verifierar Supabase-token och tillåter användaren om e-post finns i central whitelist **eller** `employees.is_active` är sann.
+5. Verifierad identitet skickas vidare i serverheaders (`x-invisto-user-id`, `x-invisto-user-email`).
+6. Centrala write-wrappers skriver över klientlevererade audit-identiteter med verifierad användares e-post innan legacy-logiken körs.
+7. Flera routes använder fortfarande Supabase service role. Service role kan arbeta utanför RLS; därför är server-API-gränsen en kritisk invariant och får inte kringgås.
+
+`/public-media` är avsiktligt publik för länkar i e-post. `/media` är intern/inloggningsskyddad. Publik media ska därför behandlas som en uttrycklig publiceringsyta, inte som intern lagring.
+
+## 3. Permanent leverans- och CI-grind
+
+Den permanenta GitHub Actions-jobben heter fortsatt `typecheck` och kör i ordning:
+
+1. `npm ci`
+2. `npm run typecheck`
+3. `npm run lint`
+4. `npm run test:regression`
+5. `npm run build`
+6. `npm run test:security-runtime`
+
+Runtime-smoken startar den faktiskt byggda Next-servern med dummy-konfiguration och verifierar bland annat:
+
+- `401` + `Authentication required` för centrala skyddade API-routes utan token;
+- `200` för `/api/health`;
+- att centrala app-routes kan renderas i byggd runtime.
+
+Repository-ruleset **Protect main** verifierades manuellt under stabiliseringen och ska behållas som operativ kontroll: PR krävs, required checks omfattar `typecheck / GitHub Actions` och `Vercel / Vercel`, branch ska vara uppdaterad före merge, force-push och deletion är blockerade. Ingen bypass-lista ska användas utan uttryckligt governance-beslut.
+
+## 4. Vad som reparerades i Steg 2
+
+### 2.1 — server-API, access och audit-identitet
+
+PR #306, merge `ea0aa9c1f1b541653ea95c20a31f6945a5544287`.
+
+- server-side autentisering infördes för `/api/*` utom health;
+- Supabase-session skickas som Bearer-token från klienten;
+- central accesskontroll etablerades;
+- servern blev auktoritativ för centrala auditfält;
+- befintlig service-role-baserad affärslogik behölls bakom säkerhetsgränsen;
+- Production verifierades read-only: direkt skyddad route utan token gav `Authentication required`.
+
+### 2.2 — TypeScript/build-stabilisering
+
+PR #308, merge `4b773ecda7a5f2df1ef70b7be1452ac25154a735`.
+
+- baseline: 105 TypeScript-fel i 7 filer;
+- resultat: 0 TypeScript-fel i strict typecheck;
+- `npm run typecheck` och permanent GitHub Actions-gate infördes;
+- `typescript.ignoreBuildErrors` sattes till `false`;
+- runtime-kontrakt reparerades utan avsedd affärslogikändring.
+
+### 2.3A — kritisk dependency-patch
+
+PR #312, merge `e3783a57c0444c43232ba7cefa4fc1095b66d0ae`.
+
+- `npm audit`: 10 fynd (9 high + 1 critical) → 2 high + 0 critical;
+- kritisk Next/middleware-relaterad dependency-risk stängdes utan major-migrering.
+
+### 2.3B — frameworkmigrering
+
+PR #313, merge `dc4c7911b272573ac3f76db03d31fd180ad3fd77`.
+
+- Next 14 / React 18 → Next `16.3.1` / React `19.2.8`;
+- `middleware.ts` migrerades till `proxy.ts` med authlogiken bevarad;
+- senaste verifierade dependency-audit efter migreringen: **0 fynd**;
+- byggd Next-runtime verifierade att skyddad API-route fortsatt gav 401 utan token;
+- Production custom domain verifierades read-only efter merge.
+
+### 2.4 — ESLint/kodkvalitetsgrind
+
+PR #314, merge `ceeacc724375ef690d60d2959bef79eea1bf6e4b`.
+
+- baseline: 170 errors + 64 warnings i 24 filer;
+- säkra blockerare reparerades;
+- befintlig legacy-skuld i fyra error-regler frystes med `eslint-suppressions.json` i stället för massrefaktorering;
+- ESLint-resultat efter stabilisering: **0 errors, 64 warnings**;
+- nya/ökade error-träffar ska blockera lint.
+
+Viktigt: suppression betyder **kontrollerad skuld**, inte att underliggande legacy-kod är omskriven.
+
+### 2.5 — automatiserat regressionsskydd
+
+PR #315, merge `bd95f477f8e9b48a82d3257c6220e4f1263e6a0e`.
+
+- permanent kodnivåtest av authgräns och whitelist;
+- permanent production build i required CI-jobb;
+- permanent byggd Next-runtime-smoke;
+- inga nya dependencies;
+- inga riktiga Supabase-anrop eller write probes i testsviten.
+
+## 5. Produktionsverifiering som ingår i basen
+
+Följande har verifierats under stabiliseringen:
+
+- Vercel Production grön på låsta merge-commits;
+- custom production domain blockerar skyddad `/api/vehicle-info` utan Bearer-token;
+- startsida, `/check`, `/rapport` och `/status` har manuellt smoke-testats efter stabiliseringsändringarna;
+- `/status` kräver normal app-inloggning innan användaren kommer in;
+- CI:s byggda Next-runtime verifierar centrala routes utan att skriva mot Production-data.
+
+Ingen riskfylld write-probe har använts som del av stabiliseringen.
+
+## 6. Kvarvarande teknisk skuld och risk
+
+### A. Write-E2E saknar isolerad testmiljö — GUL
+
+Centrala write-routes är kodgranskade och deras auth/audit-wrapper är testad, men fulla affärswrites har inte automatiserats E2E mot isolerad Supabase-testdata. Preview kan dela Production-resurser och ska därför inte användas för destruktiva verifieringar.
+
+**Konsekvens:** framtida större ändringar i Check, Nybil, Ankomst, Status-edit eller notifieringspersistens bör kompletteras med en uttryckligt isolerad testdatabas/testprojekt eller ett kontrollerat testobjekt.
+
+### B. Service role är fortsatt en högprivilegierad servermekanism — GUL
+
+Detta är avsiktligt bevarat för att inte riva fungerande affärslogik. Nya API-routes får inte skapa en parallell väg runt `proxy.ts` / `verifyApiUser`.
+
+### C. Ingen full RBAC — GUL
+
+Accessmodellen är whitelist eller aktiv `employees`-post. Den skiljer inte robust mellan roller/behörighetsnivåer för olika processer. Ny rollmodell ska inte smygas in som kodstädning; den kräver ett verksamhetsbeslut.
+
+### D. Legacy lint/type-skuld — GUL
+
+`eslint-suppressions.json` innehåller befintliga träffar, främst `no-explicit-any` samt vissa React hook-regler. De 64 warnings är fortfarande synliga. Reparera inkrementellt när berörd kod ändå ändras; gör inte en bred cleanup som samtidigt riskerar processlogik.
+
+### E. Datamodell och identifierare — GUL / Steg 3
+
+Appen har historiskt vuxit med flera tabeller, vyer, RPC:er, `regnr`-baserade joins/fallbacks och legacyfält. Särskilt BUHS-skador har en känd ID-/matchningsfråga där kommentarskoppling inte säkert kan skapas om en RPC-rad inte kan mappas till korrekt `damages.id`.
+
+Databasnormalisering, FK-strategi, identifierare och legacyfält hör till Steg 3 och ska inte lösas genom gissning i UI-koden.
+
+### F. Hårdkodad special-/testlogik — GUL
+
+Registreringsnummer som `GEU29F` förekommer både i dokumentation/test och i viss applikationslogik. Hårdkodade historiska specialfall ska inventeras separat och klassificeras som **behåll / reparera / ta bort** innan de rensas.
+
+`LoginGate` innehåller dessutom en exakt, äldre security-preview-origin för OTP-flöde. Den påverkar inte normal Production-magic-link men är teknisk restskuld som kan tas bort först när ingen operativ preview är beroende av den.
+
+### G. Dokumentation och gamla handover-issues — GUL
+
+Äldre wiki och issues är värdefull historik men inte automatiskt aktuell sanning. Exempelvis beskriver `docs/wiki/OVERVIEW.md` fortfarande Next 14 och äldre driftantaganden.
+
+Öppna handover-issues måste därför revalideras innan de behandlas som backlog:
+
+- #118: datalagring/checklist-destillat — relevant kandidat för Steg 3-utvärdering;
+- #119: historisk handover med flera TODOs — använd som evidens, inte direkt körplan;
+- #138: blandar ett gammalt checkin-regressionsläge med framtida Nybil-krav — måste jämföras mot dagens Production innan åtgärd;
+- #45: historisk hotfix-handover — inte aktuell merge-checklista.
+
+## 7. Operativa regler efter takeover
+
+1. Ändringar ska gå via fokuserad PR; merge endast när required checks är gröna.
+2. `typecheck`-jobbet och Vercel-checken får inte kringgås för att få igenom en förändring.
+3. Nya `/api/*`-vägar ska som standard ligga bakom samma serververifierade authgräns. `/api/health` är uttryckligt undantag.
+4. Klientdata får inte vara auktoritativ källa för audit-identitet när servern kan härleda användaren från verifierad session.
+5. Ingen `npm audit fix --force` eller major dependency-migrering utan separat analys och regression.
+6. Ingen bred refaktorering av stora legacyfiler bara för kosmetisk kodkvalitet.
+7. Inga destruktiva Production-write-tester utan uttrycklig testplan/testdata.
+8. Databasschema, RLS, views, RPC, FKs och identifierare ska granskas samlat i Steg 3 innan cleanup/drop/migrering.
+9. Vid konflikt mellan gammal wiki/handover och aktuell kod + verifierad Production gäller aktuell verifierad baseline tills motsatsen är bevisad.
+
+## 8. Nästa steg — Steg 3: datamodell/databas
+
+Steg 3 ska börja med inventering och evidens, inte schemaändring.
+
+Ordning:
+
+1. **Behålla:** identifiera tabeller, vyer, RPC:er, constraints, historik och fält som bär verkligt verksamhetsvärde.
+2. **Reparera:** hitta brutna/otydliga relationer, identifierare, RLS/view-säkerhet, BUHS-mappning, `regnr`-normalisering och data-kontrakt mellan app och DB.
+3. **Ta bort:** först efter verifierad oanvändning och migrations-/rollbackplan klassificera legacyfält, dubbla källor och död struktur.
+4. **Addera:** först därefter nya FK:er, kanoniska modeller, event/process-stöd eller annan struktur som behövs för den framtida verksamhetskedjan.
+
+Första DB-arbetet får **inte** vara att droppa eller massmigrera tabeller. Målet är en verifierad nulägeskarta som skyddar historik, evidens och fungerande processdata.
+
+## 9. Takeover-konklusion
+
+Steg 2 har flyttat systemet från **funktionellt men tekniskt riskfyllt att ta över** till **kontrollerbart och tekniskt övertagbart med kända gula skulder**.
+
+Den fortsatta revisionslinjen är därför:
+
+**behålla → reparera → ta bort → addera**
+
+Nästa revisionspunkt är **Steg 3 — datamodell/databas**, inte ny funktionsutveckling eller bred kodstädning.

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,62 +1,103 @@
 # Arkitektur och komponenter
 
+> **Aktuell teknisk takeover-baseline:** [TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md](../TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md). Äldre wiki-sidor kan innehålla historiska antaganden och ska inte ensamma användas som drift- eller säkerhetskälla.
+
 ## Översikt
-- Next.js (App Router) för UI och routes
-- Supabase för Auth/Storage/DB
-- Resend för e‑post
-- Vercel för hosting/deploy
-- Två media‑routes:
-  - `/media`: inloggningsskyddad, intern
-  - `/public-media`: publik, för e‑postlänkar
+
+- Next.js `16.3.1` (App Router, `proxy.ts`)
+- React / React DOM `19.2.8`
+- TypeScript med strict typecheck och build-blockering vid typfel
+- Supabase för Auth, Storage och PostgreSQL
+- Resend för e-post
+- Vercel för preview och Production
+- ESLint 9 + Next-konfiguration som permanent CI-grind
+
+## Runtime- och säkerhetskedja
+
+Den kritiska kedjan är:
+
+`användare → LoginGate → klient → /api → proxy.ts → verifyApiUser → route/legacy-handler → service role → Supabase`
+
+### UI-auth
+
+`components/LoginGate.tsx` använder Supabase-session och samma centraliserade accessmodell som servern.
+
+Godkänd användare är i nuläget antingen:
+
+- e-post i `lib/access-control.ts`, eller
+- en matchande rad i `employees` där `is_active = true`.
+
+Detta är en accessmodell, inte full RBAC. Roll-/processbehörighet kräver separat verksamhets- och säkerhetsbeslut.
+
+### Server-API
+
+- `proxy.ts` verifierar alla `/api/*` utom `/api/health`.
+- Bearer-token verifieras i `lib/server-auth.ts` mot Supabase Auth.
+- Verifierad identitet förs vidare i `x-invisto-user-id` och `x-invisto-user-email`.
+- Centrala write-routes gör servern auktoritativ för audit-identitet innan legacy-handler körs.
+- Flera routes använder fortsatt Supabase service role. Den kan arbeta utanför RLS, vilket gör server-authgränsen till en kritisk invariant.
+
+Nya API-routes får inte skapa parallella, oskyddade service-role-vägar.
+
+## Media
+
+Två avsiktligt olika media-ytor finns:
+
+- `/media/...` — intern/inloggningsskyddad visning.
+- `/public-media/...` — publik visning för länkar som skickas i e-post.
+
+Supabase-bucketen `damage-photos` är publik enligt befintlig design. Innehåll som placeras i den publika flödeskedjan ska därför behandlas som publicerbart material.
 
 ## Nyckelkomponenter
-- `app/check/...`: Incheckningsformulär
-- `app/api/notify/route.ts`: Serverroute som:
-  - Skriver checkin + skador till DB (PR #105)
-  - Bygger och skickar mejl (Resend)
-  - Loggar sammanfattningar
-- `app/public-media/[...path]/page.tsx`: Publikt galleri
-- `app/media/[...path]/media-viewer.tsx`: Gemensam gallerikomponent
-  - Känner av om den körs under `/public-media` eller `/media` och bygger breadcrumbs därefter
 
-## Säkerhet
-- Preview: Vercel Authentication kan vara på (kräver Vercel‑inloggning)
-- Produktion: `/public-media` är öppen, `/media` kräver inloggning (LoginGate)
-- Supabase RLS: bucket är publik; åtkomst kontrolleras via appens routes
-
-## E‑postmottagare
-- Huvudstation: primär + ortspecifik via mappning
-- Bilkontroll: lista av mottagare
-
-# UPPDATERING 2025-12-05
+- `app/check/...` — incheckningsflöde.
+- `app/nybil/...` — nybilsinventering.
+- `app/ankomst/...` — ankomstflöde.
+- `app/status/...` — fordonsstatus och historik/edit-funktioner.
+- `app/rapport/...` — rapportering.
+- `app/api/notify/route.ts` — auth/audit-wrapper för incheckningsnotifiering och persistens; befintlig affärslogik ligger i `legacy-handler.ts`.
+- `app/api/notify-arrival/route.ts` — auth/audit-wrapper för Ankomst.
+- `app/api/vehicle-edits/route.ts` — auth/audit-wrapper för statusändringar.
+- `app/api/damage-comments/route.ts` — auth/audit-wrapper för skadekommentarer.
+- `lib/access-control.ts` — central whitelist.
+- `lib/server-auth.ts` — server-side token- och accessverifiering.
+- `lib/api-auth-client.ts` — injicerar Bearer-token för skyddade same-origin API-anrop.
+- `proxy.ts` — Next 16 servergräns för `/api`.
 
 ## Datakällor
 
-| Tabell/Källa | Beskrivning | Används av |
-|--------------|-------------|------------|
-| `vehicles` | Bilkontroll-filen (CSV-import) | `/status` |
-| `damages` | Skador (BUHS + nya från /check) | `/status`, `/check` |
-| `nybil_inventering` | Nybilsregistreringar | `/status`, `/nybil` |
-| `checkins` | Incheckningar | `/status`, `/check` |
-| RPC `get_damages_by_trimmed_regnr` | BUHS-skador (legacy) | `/status`, `/check` |
+Historiskt centrala källor omfattar bland annat:
 
-## Mejlrouting
+| Tabell/källa | Beskrivning | Exempel på användning |
+|---|---|---|
+| `vehicles` | fordonsdata/Bilkontroll-import | `/status`, fordonsuppslag |
+| `damages` | konsoliderad skadehistorik | `/status`, `/check` |
+| `nybil_inventering` | nybilsregistreringar | `/status`, `/nybil` |
+| `checkins` | incheckningshistorik | `/status`, `/check`, rapport |
+| `checkin_damages` | skador per incheckning | historik/statistik |
+| RPC `get_damages_by_trimmed_regnr` | legacy/BUHS-uppslag | `/status`, `/check` |
 
-### /nybil
-| Fabrikat | Mejladress |
-|----------|------------|
-| Opel | opel@incheckad.se → opel@mabi.se |
-| Peugeot, Citroën, DS | peugeot@incheckad. se → peugeot@mabi. se |
-| Övriga | info@incheckad.se → per. andersson@mabi. se |
+Databasbeskrivningar i wikin är historiskt värdefulla men ska revalideras mot verkligt schema i **Steg 3 — datamodell/databas** innan schema-cleanup eller migrationsbeslut.
 
-### /check (baserat på "Var är bilen nu?")
-| Ort | Mejladress |
-|-----|------------|
-| Helsingborg, Ängelholm | helsingborg@incheckad.se |
-| Varberg | varberg@incheckad.se |
-| Malmö, Trelleborg, Lund | malmo@incheckad.se |
+## CI och deploy
 
-## Godkända användare
+Den obligatoriska GitHub Actions-jobben `typecheck` kör:
 
-Definieras i `components/LoginGate.tsx`
+1. `npm ci`
+2. TypeScript
+3. ESLint
+4. säkerhetsregression
+5. Production build
+6. byggd Next-runtime-smoke
 
+Vercel-preview/Production är fortsatt deploygrind. Repository-ruleset `Protect main` ska kräva PR, `typecheck / GitHub Actions` och `Vercel / Vercel` före merge.
+
+## Kända avgränsningar
+
+- ingen full RBAC;
+- ingen bred legacy-refaktorering av `any`/React hook-skuld;
+- ingen full write-E2E mot isolerad Supabase-testmiljö ännu;
+- service-role-baserad serverlogik är bevarad bakom authgränsen;
+- databasnormalisering, BUHS-ID/mappning och legacyfält ligger i Steg 3.
+
+Se takeover-baselinen för full riskklassning och nästa revisionsordning.

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -1,18 +1,75 @@
-# Contributing & PR‑process
+# Contributing & PR-process
+
+> Se även [teknisk takeover-baseline 2026-08-18](../TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md).
+
+## Grundprincip
+
+Arbeta i små, fokuserade PR:er enligt:
+
+**behålla → reparera → ta bort → addera**
+
+Stabil fungerande affärslogik, data och historik ska skyddas före cleanup eller nyutveckling.
 
 ## Branch & PR
-- Feature branches: `feat/...`, `fix/...`, `chore/...`
-- Små, fokuserade PR:er
-- Beskriv syfte, risker och testplan
 
-## Testplan i PR‑beskrivning (mall)
-- Vad ska testas (manuellt)
-- Vilka rutter påverkas
-- Edge cases
-- Checklista före merge
+- Arbeta på separat branch; inga avsiktliga direktändringar på `main`.
+- Håll PR:en avgränsad till ett tekniskt eller funktionellt syfte.
+- Beskriv syfte, risk, avgränsning och verifiering.
+- Blanda inte dependency-major, databasmigrering, processändring och bred refaktorering i samma PR.
+- Merge endast när required checks är gröna och PR-diffen är förstådd.
 
-## Checklista (exempel)
-- [ ] E‑postlänkar → `/public-media`
-- [ ] Breadcrumbs bevarar kontext
-- [ ] Inga konsolfel i submit
-- [ ] Vercel Logs visar "CHECKIN INSERT OK"
+Repository-ruleset **Protect main** ska kräva PR samt statuschecks `typecheck / GitHub Actions` och `Vercel / Vercel`. Branch ska vara uppdaterad före merge; force-push och deletion ska förbli blockerade.
+
+## Obligatorisk CI-grind
+
+Jobben `typecheck` kör i ordning:
+
+1. `npm ci`
+2. `npm run typecheck`
+3. `npm run lint`
+4. `npm run test:regression`
+5. `npm run build`
+6. `npm run test:security-runtime`
+
+En PR ska inte mergas genom att stänga av en regel, ta bort test eller kringgå buildgrinden bara för att få grönt resultat.
+
+## Testplan i PR-beskrivningen
+
+Ange:
+
+- vilka routes/flöden som påverkas;
+- vilka kontrakt som ska förbli oförändrade;
+- automatiska tester som täcker ändringen;
+- eventuell manuell smoke;
+- om data skrivs, exakt testdata/testmiljö och cleanup/rollback;
+- vilka delar som **inte** verifierats.
+
+## Säkerhetsregler för API
+
+- Nya `/api/*`-routes ska som standard skyddas av befintlig `proxy.ts` / `verifyApiUser`-kedja. `/api/health` är uttryckligt undantag.
+- Klientlevererad e-post/användaridentitet får inte behandlas som serververifierad audit-identitet.
+- Service-role-logik ska ligga bakom serververifierad accessgräns.
+- Skyddade same-origin API-anrop ska använda den etablerade autentiserade klient-fetchen.
+
+## Production och data
+
+- Gör inte riskfyllda write probes mot Production eller preview som kan dela Production-Supabase.
+- För större write-förändringar: använd isolerad testdatabas/testprojekt eller uttryckligen kontrollerat testobjekt.
+- Databasschema, RLS, views, RPC, FKs och legacyfält ska inte massändras utan separat datamodellrevision och rollbackplan.
+
+## Kodkvalitet
+
+- TypeScript-fel är blockerande.
+- ESLint-error är blockerande.
+- Befintliga legacy-suppressions är teknisk skuld, inte tillstånd att skapa nya träffar.
+- 64 kända warnings från stabiliseringsbasen ska repareras inkrementellt när berörd kod ändå ändras.
+- Undvik bred `any`-/React-hook-refaktorering utan funktionsspecifik regressionstäckning.
+
+## Dependency-ändringar
+
+- Ingen `npm audit fix --force`.
+- Major framework/dependency-upgrade ska göras som egen, avgränsad migration med TypeScript, lint, audit, production build, runtime-smoke och Vercel verifierade.
+
+## Dokumentation och historik
+
+Äldre wiki/issue-handover kan vara historiskt värdefulla men är inte automatiskt aktuell sanning. Vid konflikt ska aktuell kod, verifierad Production och den tekniska takeover-baselinen vägas högre tills äldre krav har revaliderats.


### PR DESCRIPTION
## Syfte
Slutstänga den tekniska stabiliseringsfasen genom att göra den verifierade takeover-baselinen permanent och rätta den mest missvisande tekniska dokumentationen. Ingen affärslogik, databaslogik, dependency eller runtime-kod ändras.

## Baseline
Utgångspunkt: Production-`main` `bd95f477f8e9b48a82d3257c6220e4f1263e6a0e` efter Steg 2.5.

## Ändringar
Exakt 4 dokumentationsfiler:
1. Ny `docs/TECHNICAL_TAKEOVER_BASELINE_2026-08-18.md`.
2. `docs/wiki/Architecture.md` uppdateras från äldre LoginGate/Next-antaganden till dagens Next 16 / server-API-kedja.
3. `docs/wiki/Contributing.md` dokumenterar nu required CI, PR-process, API-säkerhetsregler och Production-data-regler.
4. `README.md` pekar till takeover-baselinen och beskriver nuvarande stack, kvalitetskommandon och säker deployprocess.

## Slutbedömning som dokumenteras
Plattformen är tekniskt övertagbar och tillräckligt stabil för kontrollerad fortsatt utveckling. Inget kvarvarande verifierat rött stoppfynd finns inom Steg 2-scope, men gula skulder är uttryckligt kvar: write-E2E/testmiljö, service-role-koncentration, ingen full RBAC, legacy lint/type-skuld, datamodell/BUHS-ID, hårdkodad speciallogik samt historiskt/stale dokumentationsmaterial.

## Avgränsning
- Ingen appkod.
- Ingen DB-migrering.
- Ingen dependency- eller lockfile-ändring.
- Ingen auth-/runtime-förändring.
- Inga Production-write probes.
- Äldre handover-issues stängs inte automatiskt; de klassificeras som evidens som måste revalideras.

## Verifiering på final head
Final head: `f6297f7bc057f642154564b4d4ca26394cf8d9d7`.

Obligatorisk `typecheck`-jobb:
1. `npm ci` — success
2. TypeScript — success
3. ESLint — success
4. Security regression — success
5. Production build — success
6. Built Next security smoke — success

Vercel preview på final head: success.

## Nästa steg efter merge
**Steg 3 — datamodell/databas**, med ordningen `behålla → reparera → ta bort → addera`. Första DB-arbetet ska vara inventering/evidens, inte drop eller massmigrering.

## Mergebeslut
PR:n är tekniskt redo för merge efter uttryckligt beslut.