### PR TITLE
Steg 3.1: lås Production-inventering av datamodellen

### DIFF
--- a/docs/DATA_MODEL_INVENTORY_2026-08-18.md
+++ b/docs/DATA_MODEL_INVENTORY_2026-08-18.md
@@ -1,164 +1,94 @@
 # Steg 3.1 — Datamodell- och databasberoendeinventering
 
-**Status:** Read-only Production-baseline med öppet rött säkerhetsfynd — inga schemaändringar  
+**Status:** Read-only Production-baseline efter genomförd Steg 3.1A-säkerhetsreparation — redo för låsbeslut  
 **Datum:** 2026-08-18  
-**Kodbaseline:** `d1bbf5f318405028113f12c5dd162662b7065464` (`main` efter Steg 2.6)  
+**Kodbaseline:** `8b152db4d1dbfec202d0dc207ab3ff8fa499cc3f` (`main`)  
 **Production-projekt:** Supabase `incheckad` (`ufioaijcmaujlvmveyra`)  
 **Arbetsprincip:** `behålla → reparera → ta bort → addera`
 
 ## 1. Syfte och avgränsning
 
-Steg 3.1 ska fastställa vad datamodellen faktiskt bär, vad applikationen faktiskt använder och var relationer, källor eller accessgränser är otydliga innan någon databasmigrering, normalisering eller borttagning övervägs.
+Steg 3.1 fastställer vad Production-datamodellen faktiskt bär, vad aktuell applikation och dokumenterade driftprocesser faktiskt använder samt vilka relationer, källor och redundanser som måste förstås innan cleanup eller redesign.
 
-I detta steg har endast **read-only metadatafrågor** körts mot Production. Ingen DDL eller DML har körts och inga verksamhetsrader har ändrats.
+Själva inventeringen är read-only. Den har använt metadata- och SELECT-frågor mot Production samt läsning av aktuell kod och drift-/importdokumentation.
 
-Detta dokument gör därför **inte** följande:
+Steg 3.1 gör **inte** följande:
 
-- ändrar tabeller, vyer, funktioner, constraints, index, grants eller policies,
-- skapar eller applicerar migrationer,
-- raderar legacy-/backupobjekt,
-- redesignar domänmodellen,
-- ändrar app-, API- eller affärslogik,
-- utför write probes mot Production.
+- raderar tabeller, kolumner, historik eller media,
+- ändrar affärsdata,
+- skapar nya domänobjekt,
+- normaliserar schema i bulk,
+- byter processmotor,
+- gör write probes för att bevisa datamodellfynd.
 
-Ingen tabell eller kolumn är godkänd för borttagning genom detta dokument.
+Steg 3.1A var en separat säkerhetsreparation. Den är genomförd och verifierad; detta dokument beskriver dess slutläge men applicerar ingen säkerhetsmigration.
 
-## 2. Evidensnivåer
+Ingen tabell eller kolumn godkänns för DROP genom 3.1.
 
-Inventeringen bygger på tre separata evidenslager.
+## 2. Färsk Production-baseline
 
-### A. Aktuell kodevidens — 2026-08-18
-
-Exakt `main` på commit `d1bbf5f318405028113f12c5dd162662b7065464` har granskats för direkta Supabase-anrop, RPC-anrop, server-side service-role-vägar, klientskrivningar och datakällor i de centrala flödena.
-
-Detta är stark evidens för **vilka objekt den nuvarande applikationen refererar till**.
-
-### B. Historisk Production-schemaevidens — 2026-08-16
-
-Tidigare schemaexport gav omfattningen cirka **50 tabeller/vyer, 802 kolumndefinitioner, 59 index, 35 RLS-policies, 14 databasfunktioner och 6 foreign keys**. Den äldre rapportens constraint-tal byggde på en annan räknemetod och jämförs därför inte direkt med `pg_constraint` nedan.
-
-### C. Färsk live-metadata — 2026-08-18
-
-Supabase Production har nu inventerats direkt med read-only metadatafrågor.
-
-Verifierat live:
+Live-verifierat efter Steg 3.1A:
 
 | Mått | Production 2026-08-18 |
 |---|---:|
-| Vanliga/partitionerade tabeller i `public` | 44 |
-| Views/materialized views i `public` | 6 |
+| Tabeller i `public` | **44** |
+| Views i `public` | **6** |
 | Relationsobjekt totalt | **50** |
 | Kolumner | **802** |
 | Index | **59** |
 | Funktioner | **14** |
+| `SECURITY DEFINER`-funktioner | **7** |
 | Foreign keys | **9** |
-| RLS-policies | **35** |
+| RLS-policies | **25** |
 | Triggers | **3** |
+| Objekt med `regnr`-liknande kolumn | **41 av 50** |
 
-Detta bekräftar att repoets migrationsmapp **inte** är ett komplett facit för Production.
+Repoets migrationsmapp är därmed inte ensam source of truth för historisk Production-struktur. Live-metadata ska användas för varje förändringsbeslut.
 
-## 3. Nytt rött fynd — direkt Supabase-access kringgår `/api`-gränsen
+## 3. Steg 3.1A — den röda accessblockeraren är stängd
 
-Steg 2.1 reparerade den verifierade kedjan:
+Den tidigare 3.1-inventeringen upptäckte direkt Supabase-access som låg parallellt med det säkrade `/api`-lagret. Det reparerades separat i PR #318 och #319 och verifierades därefter i Production.
 
-`användare → klient → /api → verifierad serveridentitet → service role → Supabase`
+Aktuellt live-läge:
 
-Live-databasen visar nu en **separat accessväg** som inte passerar `/api`:
+- `anon` har inga tabellgrants i `public`,
+- `authenticated` har endast den verifierade browser-allowlisten,
+- `authenticated` har 11 SELECT-grants, 2 INSERT-grants, 1 UPDATE-grant och 0 DELETE-grants,
+- de tre browser-RPC:erna `get_all_allowed_plates`, `get_vehicle_by_trimmed_regnr` och `get_damages_by_trimmed_regnr` är `SECURITY INVOKER`,
+- `anon` kan inte exekvera någon av de 14 `public`-funktionerna,
+- de kvarvarande 7 `SECURITY DEFINER`-funktionerna är inte exekverbara av vanlig `authenticated`; service role behåller serverkontrakten.
 
-`extern klient → Supabase REST/RPC → RLS/grants → Production-data`
+Den röda accessblockeraren ska därför **inte** längre stå som ett öppet 3.1-fynd.
 
-Detta är ett nytt, separat säkerhetsfynd och innebär inte att Steg 2.1-reparationen var fel. API-gränsen fungerar som avsett; problemet är att vissa databaskontrakt fortfarande tillåter direkt access vid sidan av den.
+## 4. Huvudslutsats
 
-### 3.1 `checkins` — anonym läsning och skrivning är explicit tillåten
+Databasen bär en verklig operativ kärna och ska inte ersättas som om den vore tom eller misslyckad.
 
-Production har samtidigt table grants för `anon` och följande permissiva RLS-policies:
+Det centrala strukturfyndet är i stället:
 
-- `SELECT` för `anon` med `USING (true)`,
-- `INSERT` för `anon` med `WITH CHECK (true)`,
-- `UPDATE` för `anon` med `USING (true)` och `WITH CHECK (true)`.
+> Fordonets och skadans aktuella bild rekonstrueras från många objekt genom registreringsnummer, historiska textfält, RPC:er, fallbackkedjor, importer och manuella overrides. Databasen fungerar operativt, men relationell identitet och source-of-truth är inte konsekvent genom hela kedjan.
 
-`checkins` innehåller cirka **3 729 rader**.
+Att **41 av 50** `public`-objekt har ett `regnr`-liknande fält visar hur starkt registreringsnummer används som integrationsnyckel mellan delmodeller.
 
-Detta betyder att server-API-autentiseringen inte är den enda gränsen runt incheckningsdata.
+## 5. Operativ kärna — live snapshot
 
-**Klassning: RÖD — REPARERA före fortsatt datamodellstädning.**
+Row counts är ett ögonblicksfoto och kan ändras medan verksamheten använder Production.
 
-### 3.2 `checkin_damages` — anonym läsning och insert är explicit tillåten
-
-Production har cirka **1 289 rader** och permissiva `anon`-policies för:
-
-- `SELECT` med `USING (true)`,
-- `INSERT` med `WITH CHECK (true)`.
-
-**Klassning: RÖD — REPARERA.**
-
-### 3.3 Fler direktaccesskontrakt måste klassificeras
-
-Live-policyerna visar också bland annat:
-
-- `vehicles`: publik SELECT med `USING (true)`; cirka **1 261 rader**,
-- `nybil_inventering`: `authenticated` har `ALL` med `USING/WITH CHECK (true)`; cirka **26 rader**,
-- `arrivals`: autentiserade användare får SELECT/INSERT med `true`; cirka **18 rader**,
-- `checkin_damage_photos`: `anon` SELECT/INSERT med `true` (tabellen är tom nu),
-- `employees`: `anon` får läsa rader där `active` är true (tabellen är tom nu),
-- `checkin_drafts`: policies är kopplade till `user_email = auth.email()` och är därför inte samma typ av öppen `true`-policy.
-
-Att en tabell är tom idag gör inte en öppen policy säker för framtida data. Samtidigt ska inte alla publika reads automatiskt stängas utan att vi först verifierar vilka direkta klientflöden som fortfarande behöver dem.
-
-### 3.4 Anonyma `SECURITY DEFINER`-RPC:er
-
-Supabase Security Advisor flaggar att följande `SECURITY DEFINER`-funktioner kan exekveras av `anon` via `/rest/v1/rpc/...`:
-
-- `car_lookup_any`,
-- `damages_lookup_any`,
-- `get_all_allowed_plates`,
-- `get_damages_by_trimmed_regnr`,
-- `get_documented_legacy_texts`,
-- `get_vehicle_by_trimmed_regnr`,
-- `heartbeat_lock`,
-- `release_lock`,
-- `try_lock_checkin`,
-- `wheel_lookup_any`.
-
-Flera av dessa är gamla eller aktiva lookup-/lock-kontrakt. `get_vehicle_by_trimmed_regnr` och `get_damages_by_trimmed_regnr` är bekräftat använda av aktuell applikation.
-
-Detta måste repareras **kontraktsvis**, inte genom mass-revoke utan regressionstest.
-
-Supabase Advisor flaggar dessutom mutable `search_path` på flera funktioner och att aktuell Postgres-build har säkerhetspatchar tillgängliga. Dessa är separata säkerhetshärdningar och ska inte blandas ihop med den primära direkta anon-exponeringen.
-
-## 4. Huvudslutsats för datamodellen
-
-Databasen ska **inte** behandlas som ett tomt eller misslyckat schema som bör ersättas. Den bär verklig operativ data, historik, skadebevis, nybilsinventering, incheckningar, ankomster och ekonomiskt relevanta kvitton.
-
-Det huvudsakliga strukturfyndet är:
-
-> Applikationen rekonstruerar fordons- och skadebilden från flera källor med registreringsnummer, RPC-funktioner, fallbackkedjor, manuella overrides, text-/datum-matchning och applikationslogik. Datamodellen fungerar operativt, men en gemensam kanonisk relations- och precedensmodell är inte tydligt etablerad genom hela kedjan.
-
-**Men innan relationsstädning fortsätter måste den nyupptäckta direkta Supabase-accessgränsen repareras.**
-
-## 5. Live-inventering av aktiv kärna
-
-| Objekt | Live-rader | Aktuell användning | Klassning |
+| Objekt | Rader | Verifierad roll | Klassning |
 |---|---:|---|---|
-| `checkins` | 3 729 | Check skriver; Status/vehicle-info läser | **BEHÅLL / RÖD ACCESSREPARATION** |
-| `checkin_damages` | 1 289 | Check skriver; Status/vehicle-info läser | **BEHÅLL / RÖD ACCESSREPARATION / REPARERA relation** |
-| `damages` | 1 369 | Central skadehistorik | **BEHÅLL / REPARERA** |
-| `vehicles` | 1 261 | Fordonsmaster | **BEHÅLL / VERIFIERA publik read-intention** |
-| `nybil_inventering` | 26 | Nybil skriver direkt; flera flöden läser | **BEHÅLL / REPARERA access + alias** |
-| `arrivals` | 18 | Ankomst skriver; Status/vehicle-info läser | **BEHÅLL / REPARERA access** |
-| `vehicle_receipts` | 125 | Kvittoevidens från Check | **BEHÅLL / REPARERA relation** |
-| `vehicle_edits` | 0 | Kod stödjer manuell override/historik | **BEHÅLL KONTRAKT / VERIFIERA live-användning** |
-| `damage_comments` | 0 | Kod stödjer kommentarer | **BEHÅLL KONTRAKT / REPARERA relation** |
-| `damage_media` | 0 | Rapport läser tabellen | **VERIFIERA / REPARERA mediamodell** |
-| `employees` | 0 | Authz-källa tillsammans med whitelist | **BEHÅLL KONTRAKT / REPARERA accessmodell** |
-| `checkin_drafts` | 0 | Drafts-läsare finns i repo | **VERIFIERA livscykel** |
-| `vehicle_status_log` | 0 | Ingen aktuell reporeferens hittad | **VERIFIERA** |
+| `checkins` | 3 737 | Incheckningar och historik | **BEHÅLL / REPARERA relationell identitet** |
+| `checkin_damages` | 1 296 | Skador dokumenterade vid Check | **BEHÅLL** |
+| `damages` | 1 370 | Central skadehistorik från BUHS/CHECK/NYBIL | **BEHÅLL / REPARERA source-of-truth** |
+| `vehicles` | 1 261 | Fordonsmaster / Bilkontroll | **BEHÅLL** |
+| `nybil_inventering` | 195 | Nybilsinventering | **BEHÅLL / REPARERA alias** |
+| `arrivals` | 184 | Ankomsthistorik | **BEHÅLL** |
+| `vehicle_receipts` | 125 | Kvittoevidens | **BEHÅLL / REPARERA FK** |
+| `vehicle_edits` | 3 | Override-/ändringshistorik | **BEHÅLL** |
+| `employees` | 4 | DB-side accesskontrakt för aktiva employees | **BEHÅLL** |
 
-Row counts från Supabase-verktyget används här som aktuell metadata. Tomma tabeller är inte automatiskt borttagningskandidater.
+## 6. Foreign keys — strukturen finns, men används ojämnt
 
-## 6. Verifierade foreign keys — 9 totalt
-
-Production har följande FK-kontrakt:
+Production har 9 FK-kontrakt:
 
 1. `checkin_damages.checkin_id → checkins.id`
 2. `checkins.completed_by → auth.users.id`
@@ -170,76 +100,247 @@ Production har följande FK-kontrakt:
 8. `damage_positions.damage_id → damages.id`
 9. `damage_type_ref.parent_code → damage_type_ref.code`
 
-Tre viktiga relationer som appen behandlar som logiska kopplingar saknar däremot FK:
+Tre logiska relationer saknar FK, men deras nuvarande data är redan referentiellt ren:
 
-- `damage_comments.damage_id` är UUID men har **ingen FK** till `damages.id`,
-- `vehicle_receipts.checkin_id` är UUID men har **ingen FK** till `checkins.id`,
-- `damages.nybil_inventering_id` är UUID men har **ingen FK** till `nybil_inventering.id`.
+| Logisk relation | Populerade referenser | Orphans |
+|---|---:|---:|
+| `vehicle_receipts.checkin_id → checkins.id` | **125** | **0** |
+| `damages.nybil_inventering_id → nybil_inventering.id` | **5** | **0** |
+| `damage_comments.damage_id → damages.id` | **0** | **0** |
 
-Detta är nu live-verifierade **REPARERA-fynd**.
+Detta gör dem till tydliga **REPARERA-kandidater** för senare kontrollerad constraint-migration, utan att 3.1 själv lägger till constraints.
 
-## 7. Nybil-ID är nu live-verifierat
+## 7. `checkins`: relationell scaffolding är i praktiken oanvänd
 
-Production har:
+Live-data visar:
 
-- `nybil_inventering.id`: **UUID**, primary key, default `gen_random_uuid()`,
-- `damages.nybil_inventering_id`: **UUID**, nullable,
-- `duplicate_group_id`: UUID,
-- `original_registration_id`: fortfarande BIGINT och utan aktiv FK i live-schemat.
+- `employee_id`: 0 av 3 737 rader,
+- `started_by`: 0,
+- `completed_by`: 0,
+- `locked_by`: 0,
+- `station_id`: 0,
+- `completed_at`: 3 737.
 
-Den tidigare osäkerheten är därmed stängd: aktuell runtime-kod ligger i linje med UUID-PK:n, medan äldre migrationer beskriver historisk modellutveckling.
+Samtidigt är textkontrakten i aktiv användning:
 
-**Klassning: BEHÅLL UUID-kontraktet; REPARERA legacy/alias-relationer senare.**
+- `station`: 3 736 rader,
+- `current_station`: 3 737 rader,
+- `checker_email`: 3 729 rader,
+- `station_other`: 0 rader.
 
-## 8. Views — samtliga sex använder `security_invoker=true`
+Datamodellen har alltså relationsfält och FK:er för användare/station, men verksamhetshistoriken bärs fortfarande nästan helt av textfält.
 
-Live-verifierade views:
+**Klassning: REPARERA source-of-truth och identitet innan någon av de gamla eller nya fälten tas bort.**
 
-- `mabi_damage_view`,
-- `simple_mabi_damage`,
-- `tire_storage_summary`,
-- `v_nybil_baseline`,
-- `v_wheel_storage_precedence`,
-- `vehicle_damage_summary`.
+## 8. Stationer: två parallella modeller
 
-Samtliga sex har `security_invoker=true`. Det är positivt och innebär att de inte ska återklassificeras som ett gammalt security-definer-view-fynd.
+`public.stations` innehåller 6 aktiva huvudstationer: Halmstad, Helsingborg, Lund, Malmö, Trelleborg och Varberg.
 
-## 9. Funktioner — 14 totalt
+Aktuell kod har samtidigt en statisk `STATIONS`-struktur med betydligt mer granularitet, exempelvis verkstäder och underdestinationer per ort.
 
-Live-funktioner:
+`checkins.station_id` är aldrig populär i nuvarande 3 737 rader, medan `checkins.station` har 25 olika textvärden.
 
+Det betyder att `stations`-FK:n är **strukturell scaffolding**, inte faktisk nuvarande source of truth.
+
+**Klassning: REPARERA/VERIFIERA.** Ingen stationstabell eller statisk lista tas bort innan en kanonisk stationsmodell är beslutad.
+
+## 9. Nybil: aliasen är live-verifierat synkroniserade
+
+Nuvarande Nybil-kod dual-skriver flera semantiskt överlappande fält. Live-data visar att paren är fullständigt synkroniserade i nuvarande data:
+
+| Aliaspar | Populerat | Mismatch |
+|---|---:|---:|
+| `modell` / `bilmodell` | 195 / 195 | **0** |
+| `registreringsdatum` / `ankomstdatum` | 195 / 195 | **0** |
+| `hjultyp` / `monterade_dack` | 195 / 195 | **0** |
+| `hjul_ej_monterade` / `hjul_till_forvaring` | 195 / 195 | **0** |
+| `hjul_forvaring_ort` / `hjul_forvaring_station` | 173 / 173 | **0** |
+| `dackkompressor` / `kompressor` | 195 / 195 | **0** |
+
+Detta är stark evidens för att aliasen kan konsolideras senare, men endast efter att aktuell kod, views, notifieringar och historiska exportbehov flyttats till ett kanoniskt fält per betydelse.
+
+**Klassning: REPARERA; stark retirement-kandidat efter kodmigrering.**
+
+## 10. Check: flera gamla alias är nästan helt tomma
+
+Live-data visar en tydlig skillnad mellan nuvarande och äldre representationer:
+
+- `hjultyp`: 3 719 populära rader,
+- `wheel_type`: 1,
+- `tires_type`: 0,
+- `fuel_level`: 2 120,
+- `fuel_level_percent`: 0,
+- `charge_cables_count`: 749,
+- `charging_cables`: 1,
+- `chargers_count`: 0.
+
+Detta gör `wheel_type`, `tires_type`, `fuel_level_percent`, `charging_cables` och `chargers_count` till **starka retirement-kandidater**, men inte DROP-godkända i 3.1. Kodreferenser och historiska export-/rollbackkrav ska stängas först.
+
+## 11. BUHS: aktiv data dupliceras i två tabeller
+
+`damages` innehåller nu:
+
+- **727** BUHS-rader,
+- **638** CHECK-rader,
+- **5** NYBIL-rader.
+
+Senaste `imported_at` för BUHS-rader är 2026-01-16. Detta är ett freshness-observandum, inte i sig bevis på att processen är avslutad.
+
+`damages_external` innehåller samtidigt **727** rader. En symmetrisk read-only jämförelse av de sju BUHS-fälten visar:
+
+- BUHS-rader som saknas i `damages_external`: **0**,
+- rader i `damages_external` som inte finns i BUHS-delen av `damages`: **0**.
+
+`damages_external` är alltså i dagens snapshot en exakt kopia av BUHS-delen som den aktiva RPC:n `get_damages_by_trimmed_regnr` läser.
+
+Driftdokumentationen beskriver dessutom att `damages_external` ska tömmas och fyllas på manuellt efter BUHS-import.
+
+**Klassning: REPARERA.** Bevara RPC-kontraktet, men utvärdera senare om det kan härledas direkt från `damages WHERE source='BUHS'` via view/RPC i stället för manuell dubbel lagring.
+
+## 12. Manuell import och backup är fortfarande en del av dokumenterad drift
+
+Repoets CSV-importinstruktion beskriver explicit:
+
+- backup av `damages` före BUHS-import,
+- staging via `mabi_damage_data_raw_new`,
+- UPSERT till `damages`,
+- manuell synkning till `damages_external`,
+- backup av `vehicles` före Bilkontroll-import,
+- staging via `vehicles_staging`,
+- UPSERT till `vehicles`.
+
+Production innehåller **14 namngivna backup-tabeller med totalt 8 254 rader**. De är därför inte "tomma gamla tabeller".
+
+Aktuella staging/importobjekt innehåller bland annat:
+
+- `mabi_damage_data_raw_new`: 489 rader,
+- `skador_staging`: 521,
+- `vehicles_staging`: 1 004,
+- `mabi_damage_data`: 523,
+- `mabi_damage_data_raw`: 566.
+
+**Klassning: VERIFIERA/ARKIVERA senare.** Innan backup-/stagingtabeller flyttas eller tas bort måste importprocessen ersättas, retention definieras och återställningsbehov säkras utanför `public`.
+
+## 13. Legacy DB-side lager har dolda beroenden
+
+Tre service-only `SECURITY DEFINER`-funktioner — `car_lookup_any`, `damages_lookup_any` och `wheel_lookup_any` — bygger dynamisk SQL genom att inspektera `information_schema` och söka bland tabeller med matchande kolumnnamn.
+
+De har ingen nuvarande repo-konsument funnen i aktuell `main`, men deras design innebär att backup-, staging- och legacytabeller kan bli indirekta datakällor så länge funktionerna finns.
+
+Övriga DB-side kontrakt utan nuvarande reporeferens inkluderar bland annat:
+
+- `try_lock_checkin`, `heartbeat_lock`, `release_lock`,
+- `get_documented_legacy_texts`,
+- `get_nybil_baseline`,
+- `upsert_vehicles_from_staging`.
+
+Efter 3.1A är de inte browseröppna, vilket gör dem mindre akuta, men de ska **verifieras/retireras kontraktsvis** innan relaterade tabeller tas bort.
+
+## 14. Två konkreta legacy-/redundansfynd
+
+### 14.1 `allowed_plates` är inte source of truth för den aktiva allowlist-RPC:n
+
+`allowed_plates` innehåller 820 rader, men `get_all_allowed_plates()` använder inte tabellen. RPC:n härleder i stället plåtar från `vehicles`, `nybil_inventering` och `checkins`.
+
+Jämförelse mot dagens härledda mängd:
+
+- `allowed_plates`: 820,
+- härledd aktiv mängd: 1 289,
+- endast i `allowed_plates`: 10,
+- endast i härledd mängd: 479.
+
+**Klassning: VERIFIERA / stark retirement-kandidat.**
+
+### 14.2 `active_damages` är en projektion av `car_data`
+
+Både `active_damages` och `car_data` har 460 rader och samma 213 distinkta registreringsnummer. Multiset-jämförelse på de gemensamma fälten `regnr`, `brand_model`, `damage_text` ger 0 differenser åt båda håll.
+
+`vehicle_damage_summary` bygger på `active_damages`, men ingen aktuell reporeferens till vyn har hittats.
+
+**Klassning: VERIFIERA / konsolideringskandidat**, inte DROP ännu eftersom legacy DB-side dynamiska funktioner först måste stängas.
+
+## 15. Tomma och sparsamma kontrakt ska separeras från verkligt döda objekt
+
+| Objekt | Rader | Aktuell evidens | Klassning |
+|---|---:|---|---|
+| `checkin_drafts` | 0 | UI-läsare finns; dubbla update-triggers | **VERIFIERA / REPARERA trigger** |
+| `checkins_submissions` | 0 | Ingen aktuell reporeferens hittad | **VERIFIERA** |
+| `damage_comments` | 0 | Status/API-kontrakt finns | **BEHÅLL KONTRAKT / REPARERA FK** |
+| `damage_media` | 0 | Rapportkod läser tabellen | **BEHÅLL KONTRAKT / VERIFIERA media** |
+| `damage_positions` | 0 | Ingen aktuell appreferens hittad | **VERIFIERA** |
+| `damages_current` | 0 | Ingen aktuell reporeferens hittad | **VERIFIERA** |
+| `tire_storage` | 0 | DB-view finns; ingen aktuell appreferens hittad | **VERIFIERA** |
+| `vehicle_status_log` | 0 | Ingen aktuell reporeferens hittad | **VERIFIERA** |
+| `checkin_damage_photos` | 2 | Ingen aktuell appreferens; båda rader från 2025-08-26 | **BEHÅLL EVIDENS / VERIFIERA migration** |
+| `duplicates_to_delete` | 32 | Ingen aktuell reporeferens hittad | **VERIFIERA provenance** |
+| `damage_type_ref` | 8 | SQL/backfill-dokumentation, ingen aktuell appreferens | **VERIFIERA** |
+
+Tomhet är inte borttagningsbevis. Historisk media/evidens ska särskilt skyddas.
+
+## 16. Views — sex stycken, alla `security_invoker=true`
+
+- `mabi_damage_view` ← `mabi_damage_data_raw`
+- `simple_mabi_damage` ← `mabi_damage_data`
+- `tire_storage_summary` ← `tire_storage`
+- `v_nybil_baseline` ← `nybil_inventering`
+- `v_wheel_storage_precedence` ← `vehicles` + `v_nybil_baseline`
+- `vehicle_damage_summary` ← `active_damages`
+
+Alla sex kör med `security_invoker=true`.
+
+Flera saknar aktuell reporeferens och hör därför hemma i **VERIFIERA**, inte i automatisk BEHÅLL eller TA BORT.
+
+## 17. Funktioner — 14 stycken
+
+### Aktiva browserkontrakt
+
+- `get_all_allowed_plates`
+- `get_vehicle_by_trimmed_regnr`
+- `get_damages_by_trimmed_regnr`
+
+Dessa är nu `SECURITY INVOKER` och behålls.
+
+### Infrastruktur
+
+- `set_updated_at`
 - `_coalesce_expr`
+
+### Legacy/service-only att verifiera
+
 - `car_lookup_any`
 - `damages_lookup_any`
-- `get_all_allowed_plates`
-- `get_damages_by_trimmed_regnr`
+- `wheel_lookup_any`
 - `get_documented_legacy_texts`
 - `get_nybil_baseline`
-- `get_vehicle_by_trimmed_regnr`
+- `try_lock_checkin`
 - `heartbeat_lock`
 - `release_lock`
-- `set_updated_at`
-- `try_lock_checkin`
 - `upsert_vehicles_from_staging`
-- `wheel_lookup_any`
 
-Tio är `SECURITY DEFINER`; dessa är listade i det röda accessfyndet ovan eftersom de också är anropbara av `anon` enligt Supabase Advisor.
+## 18. Triggers — dubblering i drafts
 
-## 10. Triggers — 3 totalt
-
-Production har:
+Production har tre apptriggers:
 
 - `checkins.trg_set_updated_at` → `set_updated_at()` före UPDATE,
 - `checkin_drafts.trg_drafts_updated_at` → `set_updated_at()` före UPDATE,
 - `checkin_drafts.trg_set_updated_at` → `set_updated_at()` före UPDATE.
 
-`checkin_drafts` har alltså **två BEFORE UPDATE-triggers som båda kör samma funktion**. Tabellen är tom idag, men dupliceringen bör verifieras innan drafts-funktionen används eller repareras.
+`checkin_drafts` har alltså två BEFORE UPDATE-triggers som gör samma sak trots att tabellen nu har 0 rader.
 
-**Klassning: VERIFIERA / sannolik REPARERA.**
+**Klassning: REPARERA när drafts-kontraktet tas upp; inte akut Production-risk.**
 
-## 11. Hur Status faktiskt bygger fordonsbilden
+## 19. Exakta redundanta index
 
-`lib/vehicle-status.ts` hämtar i samma flöde data från:
+Live-indexdefinitionerna visar två verifierade dubletter:
+
+- `damages_regnr_idx` och `idx_damages_regnr` är båda vanliga btree-index på `damages(regnr)`,
+- `vehicles_pkey` och `vehicles_regnr_key` är båda unika btree-index på `vehicles(regnr)`.
+
+Detta är lågkomplex teknisk skuld, men index tas inte bort i 3.1. Constraint-/PK-semantik ska bevaras när `vehicles_regnr_key` bedöms.
+
+## 20. Status och vehicle-info visar den verkliga precedensproblematiken
+
+`lib/vehicle-status.ts` kombinerar i samma fordonsbild bland annat:
 
 1. `nybil_inventering`,
 2. `get_vehicle_by_trimmed_regnr`,
@@ -248,138 +349,38 @@ Production har:
 5. `checkins`,
 6. `arrivals`,
 7. `vehicle_edits`,
-8. därefter `damage_comments`,
-9. och `checkin_damages` via det skyddade server-API:t.
+8. `damage_comments`,
+9. `checkin_damages` via skyddat server-API.
 
-Detta är funktionellt värdefullt, men visar att "fordonets sanning" inte kommer från en enda relation eller ett enda livscykelobjekt.
+Vehicle-info kombinerar motsvarande kärnkällor server-side.
 
-BUHS-RPC-resultaten saknar det UUID som används i `damages`. Status bygger därför en matchningsnyckel av `regnr + datum + damage_type_raw + note_customer + note_internal` för att hitta motsvarande `damages.id`.
+BUHS-resultat saknar `damages.id` i det externa RPC-kontraktet, vilket gör att applikationen måste matcha BUHS-rader till `damages` med sammansatta text-/datumfält.
 
-Det är ett **REPARERA-fynd**, inte ett skäl att ta bort historiken.
+**Klassning: REPARERA precedens och kanonisk skadeidentitet.**
 
-## 12. Vehicle-info visar samma strukturella mönster
+## 21. Media är fortfarande fragmenterat
 
-Server-routen för vehicle-info kombinerar bland annat:
-
-- fordons-RPC,
-- BUHS-skade-RPC,
-- `damages`,
-- `nybil_inventering`,
-- `vehicles`,
-- `vehicle_edits`,
-- `arrivals`,
-- senaste `checkins`,
-- `checkin_damages`.
-
-För BUHS-hantering söker implementationen efter en "winning checkin" först bland 10 och sedan 30 senaste incheckningar. Det är stark evidens för att relationen mellan **ursprunglig BUHS-skada → dokumenterad skadehändelse → incheckning** behöver göras mer explicit.
-
-## 13. Nybil — verifierad semantisk dubblering
-
-Nuvarande kod dual-skriver flera semantiskt överlappande fält:
-
-- `modell` + `bilmodell`,
-- `registreringsdatum` + `ankomstdatum`,
-- `hjultyp` + `monterade_dack`,
-- `hjul_ej_monterade` + `hjul_till_forvaring`,
-- `hjul_forvaring_ort` + `hjul_forvaring_station`,
-- `dackkompressor` + `kompressor`.
-
-Live-schemat bekräftar att båda varianterna fortfarande finns.
-
-**Klassning: REPARERA.**
-
-Ingen alias-kolumn får tas bort innan datafyllnad, läsare, views/RPC och backfillbehov är verifierade.
-
-## 14. Check — affärshändelsen är inte en atomisk persistence-transaktion
-
-Nuvarande Check-persistens gör separata writes till bland annat:
-
-- `checkins`,
-- `vehicles`,
-- `damages`,
-- `checkin_damages`,
-- `vehicle_receipts`,
-- samt notifiering.
-
-Flera databasfel loggas medan flödet kan fortsätta. Det skyddar operationen mot totalstopp men kan ge delvis persisterad affärshändelse.
-
-**Klassning: REPARERA data-integritet**, men inte i 3.1.
-
-## 15. Ankomst har motsvarande integritetsgräns
-
-Ankomst skriver `arrivals`, kan uppdatera `vehicles.bransletyp` och skickar notifiering. DB-fel kan loggas som non-critical och mejl fortsätta.
-
-**Klassning: REPARERA.**
-
-## 16. Skade- och mediakällor är fragmenterade
-
-Aktuell kod använder flera representationer:
+Aktuell modell innehåller flera representationer:
 
 - `damages.uploads`,
 - `checkin_damages.photo_urls` / `video_urls`,
 - Storage-mappar,
 - `damage_media`,
 - Nybil `photo_urls` / `media_folder`,
-- `vehicle_receipts` för kvittofiler.
+- `vehicle_receipts` för kvittofiler,
+- legacy `checkin_damage_photos`.
 
-Live-rader visar att `damage_media` och `damage_positions` är tomma, medan `damages` och `checkin_damages` bär aktiv data. Rapportkoden försöker ändå läsa `damage_media`.
+`damage_media` är tom medan aktiv skadeevidens finns i andra representationer. `checkin_damage_photos` har två äldre rader.
 
-**Klassning: REPARERA/VERIFIERA**, inte radera ännu.
+**Klassning: REPARERA/VERIFIERA.** Ingen mediakälla tas bort innan evidensmigrering och läsare är verifierade.
 
-## 17. Stationer — source-of-truth-fråga kvarstår
+## 22. Atomitet är en separat integritetsfråga
 
-`stations` finns live men har 0 rader. Samtidigt använder aktuell kod statiska stationslistor och datafiler. `checkins.station_id` har ändå en FK mot `stations.id`.
+Check persisterar en affärshändelse över flera writes, bland annat `checkins`, `vehicles`, `damages`, `checkin_damages`, `vehicle_receipts` och notifiering. Ankomst har motsvarande flerledat flöde kring `arrivals`, fordonsuppdatering och notifiering.
 
-Detta är ett tydligt exempel på att ett schemaobjekt kan vara strukturellt närvarande men operationellt kringgånget.
+Detta är inte ett argument för schema-redesign i 3.1, men det är en senare **REPARERA data-integritet**-punkt: affärshändelser kan annars bli delvis persisterade vid fel.
 
-**Klassning: REPARERA/VERIFIERA source of truth.**
-
-## 18. Historik ska skyddas
-
-`vehicle_edits` och `vehicle_status_log` finns live men har 0 rader i aktuell metadata. Koden använder `vehicle_edits` som kontrakt för overrides/historik; `vehicle_status_log` saknar aktuell reporeferens.
-
-- `vehicle_edits`: **BEHÅLL KONTRAKT / VERIFIERA faktisk användning**.
-- `vehicle_status_log`: **VERIFIERA**, inte borttagningskandidat ännu.
-
-Tomhet idag är inte i sig tillräckligt borttagningsbevis.
-
-## 19. Legacy-kolumnskuld i `checkins`
-
-Nuvarande kod använder huvudsakligen bland annat:
-
-- `hjultyp`,
-- `fuel_level`,
-- `charge_cables_count`.
-
-Äldre överlappande representationer finns samtidigt kvar, exempelvis:
-
-- `wheel_type`,
-- `tires_type`,
-- `charging_cables`,
-- `chargers_count`,
-- `fuel_level_percent`.
-
-Dessa är **senare retirement-kandidater**, inte godkända att radera i 3.1.
-
-## 20. Tomma/staging/backupobjekt — endast kandidater
-
-Live-inventeringen visar många tabeller med 0 rader, bland annat äldre backup-, staging- och importobjekt. Exempel:
-
-- `damages_backup_*`,
-- `vehicles_backup_*`,
-- `damages_dedup_backup_*`,
-- `nybil_inventering_backup_20260425`,
-- `vehicles_staging`,
-- `skador_staging`,
-- `duplicates_to_delete`,
-- `mabi_damage_data*`,
-- `damages_external`,
-- `damages_current`,
-- `active_damages`.
-
-De är nu starkare kandidater för senare arkivering än tidigare, men **0 rader + ingen reporeferens är fortfarande inte samma sak som godkänt borttagande**. Views, RPC-definitioner, importprocesser, retention och rollbackbehov måste korsas innan drop.
-
-## 21. Klassning enligt revisionsordningen
+## 23. Klassning enligt revisionsordningen
 
 ### BEHÅLL
 
@@ -392,56 +393,51 @@ Operativ kärna och evidens:
 - `nybil_inventering`
 - `arrivals`
 - `vehicle_receipts`
-- skade-/statushistorikens kontrakt
-- aktiva fordons-/BUHS-lookup-kontrakt tills säkert ersatta
+- `vehicle_edits`
+- access-/historikkontrakt som aktuell kod faktiskt använder
+- befintlig media/evidens tills migrerad och verifierad
 
-### REPARERA — PRIORITET RÖD
+### REPARERA — nästa ordning
 
-1. **Direkt anonymous Supabase-access till `checkins` och `checkin_damages`.**
-2. **Anon-exekverbara `SECURITY DEFINER`-RPC:er**, särskilt aktiva fordons-/BUHS-lookups och lockfunktioner.
-3. Direkt `authenticated`-access måste harmoniseras med samma verkliga accessmodell som LoginGate/server-auth använder; UI-inloggning får inte vara enda behörighetskontrollen.
+1. **Relationell integritet:** förbered de tre saknade FK-kontrakten som nu har 0 orphans.
+2. **BUHS source of truth:** eliminera senare manuell dubbel lagring `damages` → `damages_external` utan att ändra RPC-beteende.
+3. **Station/användaridentitet:** avgör kanonisk modell innan textfält eller FK-scaffolding pensioneras.
+4. **Nybil-/Check-alias:** flytta läsare/skrivare till kanoniska fält och pensionera gamla alias stegvis.
+5. **Legacy DB-side kontrakt:** retire/ersätt dynamiska RPC:er och dokumentera importvägar innan legacytabeller arkiveras.
+6. **Redundanta index:** ta bort endast efter constraint-/query-verifiering.
+7. **Media och atomitet:** konsolidera utan att förlora evidens eller fungerande flöden.
 
-### REPARERA — DATAMODELL EFTER SÄKERHETSGRÄNSEN
+### VERIFIERA / ARKIVERA
 
-- BUHS-ursprung ↔ `damages.id`,
-- skadehändelse ↔ ursprungsskada,
-- `damage_comments.damage_id` FK/kontrakt,
-- `vehicle_receipts.checkin_id` FK/kontrakt,
-- `damages.nybil_inventering_id` FK/kontrakt,
-- Nybil-alias,
-- canonical media source,
-- station source of truth,
-- explicit precedens mellan Nybil/vehicles/checkins/arrivals/vehicle_edits,
-- atomitet/idempotens för Check och Ankomst.
+- 14 backup-tabeller och retention,
+- staging-/importtabeller,
+- `allowed_plates`,
+- `active_damages` / `car_data`,
+- tomma/sparsamma legacykontrakt,
+- views och service-only RPC:er utan aktuell repokonsument.
 
-### VERIFIERA
+### TA BORT
 
-- tomma DB-side objekt utan nuvarande reporeferens,
-- views/staging/importtabeller,
-- `vehicle_status_log`,
-- `checkin_drafts` och dess dubbla update-trigger,
-- backup-/dedupobjekt,
-- legacykolumner utan nuvarande runtime-referens.
+**0 objekt godkända för borttagning i Steg 3.1.**
 
-### TA BORT — INGET BESLUT ÄN
+### ADDERA
 
-Steg 3.1 godkänner **0** objekt för borttagning.
+**0 nya domänobjekt behövs för att stänga Steg 3.1.**
 
-### ADDERA — INGET NYTT DOMÄNOBJEKT ÄN
+## 24. Rekommenderat nästa steg — Steg 3.2
 
-Nya tabeller/engines ska inte skapas innan säkerhetsgräns, relationskarta och precedens är verifierade.
+Steg 3.1 har nu tillräcklig evidens för att stängas som inventeringsfas.
 
-## 22. Beslutspunkt efter live-inventeringen
+Nästa steg bör vara **Steg 3.2 — relationer och source-of-truth**, i små reversibla delsteg:
 
-Den färska Production-metadata som tidigare saknades är nu hämtad. 3.1 har därmed kunnat verifiera schemaomfattning, centrala datatyper, PK/FK, views, funktioner, triggers, RLS-policies och aktuella row counts på metadata-nivå.
+1. verifiera migrationsteknik för de tre saknade FK:erna och applicera först när CI/regression är definierad,
+2. designa en beteendebevarande ersättning för `damages_external`,
+3. besluta stations-/användaridentitet och precedens,
+4. därefter alias-/legacyretirement.
 
-**3.1 ska ändå inte låsas som “klar och mergebar” innan det röda accessfyndet har ett separat reparationsbeslut.** Att fortsätta med cleanup medan anonym direktaccess är öppen skulle bryta revisionsordningen.
+Backup-/stagingcleanup och större schemaförenkling ska komma **efter** dessa kontrakt, inte före.
 
-Nästa säkra arbetssteg är därför inte en drop, backfill eller redesign utan en fokuserad säkerhetsreparation av Supabase-gränsen med regression mot de klientflöden som fortfarande går direkt mot Supabase.
-
-Ingen reparation genomförs av denna inventerings-PR.
-
-## 23. Låst princip för Steg 3
+## 25. Låst princip
 
 > Historik, evidens och fungerande kärnflöden är tillgångar. Databasstädning får inte börja med namn, ålder eller upplevd redundans. Varje förändring ska först visa vilken aktuell konsument, relation, accessgräns, datahistorik och fallback den ersätter.
 

--- a/docs/DATA_MODEL_INVENTORY_2026-08-18.md
+++ b/docs/DATA_MODEL_INVENTORY_2026-08-18.md
@@ -1,28 +1,31 @@
 # Steg 3.1 — Datamodell- och databasberoendeinventering
 
-**Status:** Preliminär read-only baseline — inga schemaändringar  
+**Status:** Read-only Production-baseline med öppet rött säkerhetsfynd — inga schemaändringar  
 **Datum:** 2026-08-18  
 **Kodbaseline:** `d1bbf5f318405028113f12c5dd162662b7065464` (`main` efter Steg 2.6)  
+**Production-projekt:** Supabase `incheckad` (`ufioaijcmaujlvmveyra`)  
 **Arbetsprincip:** `behålla → reparera → ta bort → addera`
 
 ## 1. Syfte och avgränsning
 
-Steg 3.1 ska fastställa vad datamodellen faktiskt bär, vad applikationen faktiskt använder och var relationer eller källor är otydliga innan någon databasmigrering, normalisering eller borttagning övervägs.
+Steg 3.1 ska fastställa vad datamodellen faktiskt bär, vad applikationen faktiskt använder och var relationer, källor eller accessgränser är otydliga innan någon databasmigrering, normalisering eller borttagning övervägs.
+
+I detta steg har endast **read-only metadatafrågor** körts mot Production. Ingen DDL eller DML har körts och inga verksamhetsrader har ändrats.
 
 Detta dokument gör därför **inte** följande:
 
-- kör SQL mot Production,
-- ändrar tabeller, vyer, funktioner, constraints, index eller policies,
-- skapar migrationer,
+- ändrar tabeller, vyer, funktioner, constraints, index, grants eller policies,
+- skapar eller applicerar migrationer,
 - raderar legacy-/backupobjekt,
 - redesignar domänmodellen,
-- ändrar app-, API- eller affärslogik.
+- ändrar app-, API- eller affärslogik,
+- utför write probes mot Production.
 
 Ingen tabell eller kolumn är godkänd för borttagning genom detta dokument.
 
-## 2. Evidensnivåer och begränsning
+## 2. Evidensnivåer
 
-Inventeringen bygger på två separata evidenslager som inte ska blandas ihop:
+Inventeringen bygger på tre separata evidenslager.
 
 ### A. Aktuell kodevidens — 2026-08-18
 
@@ -30,52 +33,211 @@ Exakt `main` på commit `d1bbf5f318405028113f12c5dd162662b7065464` har granskats
 
 Detta är stark evidens för **vilka objekt den nuvarande applikationen refererar till**.
 
-### B. Produktionsschemaevidens — 2026-08-16
+### B. Historisk Production-schemaevidens — 2026-08-16
 
-Tidigare faktisk Production-schemaexport och Supabase-skärmbilder visar en större modell än repoets migrationsmapp: ungefär **50 tabeller/vyer, 802 kolumndefinitioner, 139 constraints, 59 index, 35 RLS-policies, 14 databasfunktioner och 6 foreign keys**.
+Tidigare schemaexport gav omfattningen cirka **50 tabeller/vyer, 802 kolumndefinitioner, 59 index, 35 RLS-policies, 14 databasfunktioner och 6 foreign keys**. Den äldre rapportens constraint-tal byggde på en annan räknemetod och jämförs därför inte direkt med `pg_constraint` nedan.
 
-Detta är stark historisk evidens för Production-modellens omfattning, men är **inte en färsk live-introspektion den 18 augusti**. Säkerhetsläget i äldre material ska inte användas för att återöppna Steg 2; server-API-säkerheten reparerades och verifierades därefter.
+### C. Färsk live-metadata — 2026-08-18
 
-### Begränsning
+Supabase Production har nu inventerats direkt med read-only metadatafrågor.
 
-Ingen direkt Supabase-databaskoppling finns i denna granskning. Exakta aktuella row counts, null-profiler, view-definitioner, triggerberoenden, funktionsberoenden, FK-definitioner och objekt som enbart används DB-side måste därför revalideras innan destruktiva beslut kan tas.
+Verifierat live:
 
-## 3. Första huvudslutsatsen
+| Mått | Production 2026-08-18 |
+|---|---:|
+| Vanliga/partitionerade tabeller i `public` | 44 |
+| Views/materialized views i `public` | 6 |
+| Relationsobjekt totalt | **50** |
+| Kolumner | **802** |
+| Index | **59** |
+| Funktioner | **14** |
+| Foreign keys | **9** |
+| RLS-policies | **35** |
+| Triggers | **3** |
 
-Databasen ska **inte** behandlas som ett tomt eller misslyckat schema som bör ersättas. Den bär verklig operativ data, historik, skadebevis, nybilsinventering, incheckningar, ankomster, statusändringar och ekonomiskt relevanta kvitton.
+Detta bekräftar att repoets migrationsmapp **inte** är ett komplett facit för Production.
 
-Det huvudsakliga strukturfyndet är i stället:
+## 3. Nytt rött fynd — direkt Supabase-access kringgår `/api`-gränsen
+
+Steg 2.1 reparerade den verifierade kedjan:
+
+`användare → klient → /api → verifierad serveridentitet → service role → Supabase`
+
+Live-databasen visar nu en **separat accessväg** som inte passerar `/api`:
+
+`extern klient → Supabase REST/RPC → RLS/grants → Production-data`
+
+Detta är ett nytt, separat säkerhetsfynd och innebär inte att Steg 2.1-reparationen var fel. API-gränsen fungerar som avsett; problemet är att vissa databaskontrakt fortfarande tillåter direkt access vid sidan av den.
+
+### 3.1 `checkins` — anonym läsning och skrivning är explicit tillåten
+
+Production har samtidigt table grants för `anon` och följande permissiva RLS-policies:
+
+- `SELECT` för `anon` med `USING (true)`,
+- `INSERT` för `anon` med `WITH CHECK (true)`,
+- `UPDATE` för `anon` med `USING (true)` och `WITH CHECK (true)`.
+
+`checkins` innehåller cirka **3 729 rader**.
+
+Detta betyder att server-API-autentiseringen inte är den enda gränsen runt incheckningsdata.
+
+**Klassning: RÖD — REPARERA före fortsatt datamodellstädning.**
+
+### 3.2 `checkin_damages` — anonym läsning och insert är explicit tillåten
+
+Production har cirka **1 289 rader** och permissiva `anon`-policies för:
+
+- `SELECT` med `USING (true)`,
+- `INSERT` med `WITH CHECK (true)`.
+
+**Klassning: RÖD — REPARERA.**
+
+### 3.3 Fler direktaccesskontrakt måste klassificeras
+
+Live-policyerna visar också bland annat:
+
+- `vehicles`: publik SELECT med `USING (true)`; cirka **1 261 rader**,
+- `nybil_inventering`: `authenticated` har `ALL` med `USING/WITH CHECK (true)`; cirka **26 rader**,
+- `arrivals`: autentiserade användare får SELECT/INSERT med `true`; cirka **18 rader**,
+- `checkin_damage_photos`: `anon` SELECT/INSERT med `true` (tabellen är tom nu),
+- `employees`: `anon` får läsa rader där `active` är true (tabellen är tom nu),
+- `checkin_drafts`: policies är kopplade till `user_email = auth.email()` och är därför inte samma typ av öppen `true`-policy.
+
+Att en tabell är tom idag gör inte en öppen policy säker för framtida data. Samtidigt ska inte alla publika reads automatiskt stängas utan att vi först verifierar vilka direkta klientflöden som fortfarande behöver dem.
+
+### 3.4 Anonyma `SECURITY DEFINER`-RPC:er
+
+Supabase Security Advisor flaggar att följande `SECURITY DEFINER`-funktioner kan exekveras av `anon` via `/rest/v1/rpc/...`:
+
+- `car_lookup_any`,
+- `damages_lookup_any`,
+- `get_all_allowed_plates`,
+- `get_damages_by_trimmed_regnr`,
+- `get_documented_legacy_texts`,
+- `get_vehicle_by_trimmed_regnr`,
+- `heartbeat_lock`,
+- `release_lock`,
+- `try_lock_checkin`,
+- `wheel_lookup_any`.
+
+Flera av dessa är gamla eller aktiva lookup-/lock-kontrakt. `get_vehicle_by_trimmed_regnr` och `get_damages_by_trimmed_regnr` är bekräftat använda av aktuell applikation.
+
+Detta måste repareras **kontraktsvis**, inte genom mass-revoke utan regressionstest.
+
+Supabase Advisor flaggar dessutom mutable `search_path` på flera funktioner och att aktuell Postgres-build har säkerhetspatchar tillgängliga. Dessa är separata säkerhetshärdningar och ska inte blandas ihop med den primära direkta anon-exponeringen.
+
+## 4. Huvudslutsats för datamodellen
+
+Databasen ska **inte** behandlas som ett tomt eller misslyckat schema som bör ersättas. Den bär verklig operativ data, historik, skadebevis, nybilsinventering, incheckningar, ankomster och ekonomiskt relevanta kvitton.
+
+Det huvudsakliga strukturfyndet är:
 
 > Applikationen rekonstruerar fordons- och skadebilden från flera källor med registreringsnummer, RPC-funktioner, fallbackkedjor, manuella overrides, text-/datum-matchning och applikationslogik. Datamodellen fungerar operativt, men en gemensam kanonisk relations- och precedensmodell är inte tydligt etablerad genom hela kedjan.
 
-Det är därför fel angreppssätt att börja med att "städa bort" tabeller. Först måste relationer, ägarskap och precedens göras verifierbara.
+**Men innan relationsstädning fortsätter måste den nyupptäckta direkta Supabase-accessgränsen repareras.**
 
-## 4. Bekräftat aktiva kärnobjekt i nuvarande applikation
+## 5. Live-inventering av aktiv kärna
 
-| Objekt | Aktuell användning | Primär koppling | Klassning |
-|---|---|---|---|
-| `checkins` | Check skriver; Status, Check/vehicle-info, damages och edits läser | `id`, `regnr` | **BEHÅLL** |
-| `checkin_damages` | Check skriver skadehändelser; Status/vehicle-info läser | `checkin_id`, `regnr` | **BEHÅLL / REPARERA relation till ursprungsskada** |
-| `damages` | Central skadehistorik från Check/Nybil/BUHS; läses av Status/Rapport/vehicle-info | `id`, `regnr`, legacy-fält | **BEHÅLL / REPARERA** |
-| `damages_external` | Indirekt källa bakom BUHS-RPC enligt nuvarande dokumentation/importkedja | normaliserat `regnr` via RPC | **BEHÅLL / REPARERA källgräns** |
-| `vehicles` | Bilkontroll/fordonsmaster; läses och uppdateras av flera flöden | `regnr` | **BEHÅLL** |
-| `nybil_inventering` | Nybil skriver direkt; Status/Check/vehicle-info/edits läser | `id`, `regnr` | **BEHÅLL / REPARERA** |
-| `arrivals` | Ankomst skriver; Status/vehicle-info läser | `regnr`, tid | **BEHÅLL** |
-| `vehicle_edits` | Append-only manuell override/historik som påverkar nuläge och historik | `regnr`, `field_name`, `edited_at`, `batch_id` | **BEHÅLL / FORMALISERA PRECEDENS** |
-| `employees` | Aktiv authz-källa tillsammans med central whitelist | `email`, `is_active` | **BEHÅLL** |
-| `vehicle_receipts` | Check skriver tankningskvitton/evidens | `checkin_id`, `regnr` | **BEHÅLL** |
-| `damage_comments` | Backend läser/skriver kommentarer kopplade till `damages.id` | `damage_id` | **BEHÅLL / REPARERA relation** |
-| `damage_media` | Rapport läser media per `damage_id` | `damage_id` | **BEHÅLL TILLS VERIFIERAD / REPARERA källfragmentering** |
-| `checkin_drafts` | Nuvarande repo innehåller en läsande drafts-sida; ingen writer hittad i aktuell kod | oklar | **VERIFIERA** |
+| Objekt | Live-rader | Aktuell användning | Klassning |
+|---|---:|---|---|
+| `checkins` | 3 729 | Check skriver; Status/vehicle-info läser | **BEHÅLL / RÖD ACCESSREPARATION** |
+| `checkin_damages` | 1 289 | Check skriver; Status/vehicle-info läser | **BEHÅLL / RÖD ACCESSREPARATION / REPARERA relation** |
+| `damages` | 1 369 | Central skadehistorik | **BEHÅLL / REPARERA** |
+| `vehicles` | 1 261 | Fordonsmaster | **BEHÅLL / VERIFIERA publik read-intention** |
+| `nybil_inventering` | 26 | Nybil skriver direkt; flera flöden läser | **BEHÅLL / REPARERA access + alias** |
+| `arrivals` | 18 | Ankomst skriver; Status/vehicle-info läser | **BEHÅLL / REPARERA access** |
+| `vehicle_receipts` | 125 | Kvittoevidens från Check | **BEHÅLL / REPARERA relation** |
+| `vehicle_edits` | 0 | Kod stödjer manuell override/historik | **BEHÅLL KONTRAKT / VERIFIERA live-användning** |
+| `damage_comments` | 0 | Kod stödjer kommentarer | **BEHÅLL KONTRAKT / REPARERA relation** |
+| `damage_media` | 0 | Rapport läser tabellen | **VERIFIERA / REPARERA mediamodell** |
+| `employees` | 0 | Authz-källa tillsammans med whitelist | **BEHÅLL KONTRAKT / REPARERA accessmodell** |
+| `checkin_drafts` | 0 | Drafts-läsare finns i repo | **VERIFIERA livscykel** |
+| `vehicle_status_log` | 0 | Ingen aktuell reporeferens hittad | **VERIFIERA** |
 
-### Aktiva RPC-kontrakt
+Row counts från Supabase-verktyget används här som aktuell metadata. Tomma tabeller är inte automatiskt borttagningskandidater.
 
-- `get_vehicle_by_trimmed_regnr` används av dagens fordons-/statuslogik.
-- `get_damages_by_trimmed_regnr` används av dagens BUHS-/skadelogik.
+## 6. Verifierade foreign keys — 9 totalt
 
-Dessa två funktioner är därför del av applikationens aktiva datakontrakt och får inte behandlas som "DB-internals" som kan ändras utan regressionstest.
+Production har följande FK-kontrakt:
 
-## 5. Hur Status faktiskt bygger fordonsbilden
+1. `checkin_damages.checkin_id → checkins.id`
+2. `checkins.completed_by → auth.users.id`
+3. `checkins.employee_id → employees.id`
+4. `checkins.locked_by → auth.users.id`
+5. `checkins.started_by → auth.users.id`
+6. `checkins.station_id → stations.id`
+7. `damage_media.damage_id → damages.id`
+8. `damage_positions.damage_id → damages.id`
+9. `damage_type_ref.parent_code → damage_type_ref.code`
+
+Tre viktiga relationer som appen behandlar som logiska kopplingar saknar däremot FK:
+
+- `damage_comments.damage_id` är UUID men har **ingen FK** till `damages.id`,
+- `vehicle_receipts.checkin_id` är UUID men har **ingen FK** till `checkins.id`,
+- `damages.nybil_inventering_id` är UUID men har **ingen FK** till `nybil_inventering.id`.
+
+Detta är nu live-verifierade **REPARERA-fynd**.
+
+## 7. Nybil-ID är nu live-verifierat
+
+Production har:
+
+- `nybil_inventering.id`: **UUID**, primary key, default `gen_random_uuid()`,
+- `damages.nybil_inventering_id`: **UUID**, nullable,
+- `duplicate_group_id`: UUID,
+- `original_registration_id`: fortfarande BIGINT och utan aktiv FK i live-schemat.
+
+Den tidigare osäkerheten är därmed stängd: aktuell runtime-kod ligger i linje med UUID-PK:n, medan äldre migrationer beskriver historisk modellutveckling.
+
+**Klassning: BEHÅLL UUID-kontraktet; REPARERA legacy/alias-relationer senare.**
+
+## 8. Views — samtliga sex använder `security_invoker=true`
+
+Live-verifierade views:
+
+- `mabi_damage_view`,
+- `simple_mabi_damage`,
+- `tire_storage_summary`,
+- `v_nybil_baseline`,
+- `v_wheel_storage_precedence`,
+- `vehicle_damage_summary`.
+
+Samtliga sex har `security_invoker=true`. Det är positivt och innebär att de inte ska återklassificeras som ett gammalt security-definer-view-fynd.
+
+## 9. Funktioner — 14 totalt
+
+Live-funktioner:
+
+- `_coalesce_expr`
+- `car_lookup_any`
+- `damages_lookup_any`
+- `get_all_allowed_plates`
+- `get_damages_by_trimmed_regnr`
+- `get_documented_legacy_texts`
+- `get_nybil_baseline`
+- `get_vehicle_by_trimmed_regnr`
+- `heartbeat_lock`
+- `release_lock`
+- `set_updated_at`
+- `try_lock_checkin`
+- `upsert_vehicles_from_staging`
+- `wheel_lookup_any`
+
+Tio är `SECURITY DEFINER`; dessa är listade i det röda accessfyndet ovan eftersom de också är anropbara av `anon` enligt Supabase Advisor.
+
+## 10. Triggers — 3 totalt
+
+Production har:
+
+- `checkins.trg_set_updated_at` → `set_updated_at()` före UPDATE,
+- `checkin_drafts.trg_drafts_updated_at` → `set_updated_at()` före UPDATE,
+- `checkin_drafts.trg_set_updated_at` → `set_updated_at()` före UPDATE.
+
+`checkin_drafts` har alltså **två BEFORE UPDATE-triggers som båda kör samma funktion**. Tabellen är tom idag, men dupliceringen bör verifieras innan drafts-funktionen används eller repareras.
+
+**Klassning: VERIFIERA / sannolik REPARERA.**
+
+## 11. Hur Status faktiskt bygger fordonsbilden
 
 `lib/vehicle-status.ts` hämtar i samma flöde data från:
 
@@ -89,18 +251,15 @@ Dessa två funktioner är därför del av applikationens aktiva datakontrakt och
 8. därefter `damage_comments`,
 9. och `checkin_damages` via det skyddade server-API:t.
 
-Detta är funktionellt värdefullt — Status kan rekonstruera mycket information — men visar också att "fordonets sanning" inte kommer från en enda relation eller ett enda livscykelobjekt.
+Detta är funktionellt värdefullt, men visar att "fordonets sanning" inte kommer från en enda relation eller ett enda livscykelobjekt.
 
-Två konkreta svagheter är synliga i den aktuella koden:
-
-- `damage_comments` kan inte joinas naturligt i den aktuella implementationen; koden hämtar damage-ID:n först och laddar kommentarer separat.
-- BUHS-RPC-resultaten saknar det UUID som används i `damages`. Status bygger därför en matchningsnyckel av `regnr + datum + damage_type_raw + note_customer + note_internal` för att hitta motsvarande `damages.id`.
+BUHS-RPC-resultaten saknar det UUID som används i `damages`. Status bygger därför en matchningsnyckel av `regnr + datum + damage_type_raw + note_customer + note_internal` för att hitta motsvarande `damages.id`.
 
 Det är ett **REPARERA-fynd**, inte ett skäl att ta bort historiken.
 
-## 6. Vehicle-info visar samma strukturella mönster
+## 12. Vehicle-info visar samma strukturella mönster
 
-Server-routen för vehicle-info använder service role bakom den verifierade API-authgränsen och kombinerar bland annat:
+Server-routen för vehicle-info kombinerar bland annat:
 
 - fordons-RPC,
 - BUHS-skade-RPC,
@@ -112,13 +271,11 @@ Server-routen för vehicle-info använder service role bakom den verifierade API
 - senaste `checkins`,
 - `checkin_damages`.
 
-För BUHS-hantering söker implementationen efter en "winning checkin": först bland de 10 senaste, sedan 30, baserat på om antalet hanterade skadeposter är tillräckligt stort i förhållande till antal BUHS-skador. Om ingen sådan hittas faller koden tillbaka till senaste incheckningen.
+För BUHS-hantering söker implementationen efter en "winning checkin" först bland 10 och sedan 30 senaste incheckningar. Det är stark evidens för att relationen mellan **ursprunglig BUHS-skada → dokumenterad skadehändelse → incheckning** behöver göras mer explicit.
 
-Detta är stark evidens för att relationen mellan **ursprunglig BUHS-skada → dokumenterad skadehändelse → incheckning** behöver göras mer explicit. Den fungerande fallbacken ska bevaras tills en säkrare relation är verifierad och migrerad.
+## 13. Nybil — verifierad semantisk dubblering
 
-## 7. Nybil — verifierad semantisk dubblering i samma tabell
-
-Nuvarande Nybil-kod dual-skriver flera semantiskt överlappande fält i `nybil_inventering` för kompatibilitet:
+Nuvarande kod dual-skriver flera semantiskt överlappande fält:
 
 - `modell` + `bilmodell`,
 - `registreringsdatum` + `ankomstdatum`,
@@ -127,160 +284,102 @@ Nuvarande Nybil-kod dual-skriver flera semantiskt överlappande fält i `nybil_i
 - `hjul_forvaring_ort` + `hjul_forvaring_station`,
 - `dackkompressor` + `kompressor`.
 
-Detta är inte en hypotes — aliasen skrivs uttryckligen av nuvarande applikationskod.
+Live-schemat bekräftar att båda varianterna fortfarande finns.
 
 **Klassning: REPARERA.**
 
-Ingen alias-kolumn får tas bort innan följande är verifierat:
+Ingen alias-kolumn får tas bort innan datafyllnad, läsare, views/RPC och backfillbehov är verifierade.
 
-- vilken kolumn som faktiskt läses av alla nuvarande konsumenter,
-- om äldre Production-data bara finns i den ena varianten,
-- om views/RPC/importer refererar till någon aliasvariant,
-- om backfill behövs,
-- om klient- och serverkontrakt kan ändras atomärt.
+## 14. Check — affärshändelsen är inte en atomisk persistence-transaktion
 
-## 8. Nybil-ID — migration och runtime beskriver olika verklighet
+Nuvarande Check-persistens gör separata writes till bland annat:
 
-Repoets äldre migrationer definierar `nybil_inventering.id` som `BIGSERIAL` och `original_registration_id` som `BIGINT`-FK.
+- `checkins`,
+- `vehicles`,
+- `damages`,
+- `checkin_damages`,
+- `vehicle_receipts`,
+- samt notifiering.
 
-Den nuvarande applikationen behandlar däremot Nybil-ID som UUID/string i dubblettkontrollen och använder `duplicate_group_id` som aktiv dubblettmekanism. Koden kommenterar uttryckligen att `original_registration_id` inte sätts.
+Flera databasfel loggas medan flödet kan fortsätta. Det skyddar operationen mot totalstopp men kan ge delvis persisterad affärshändelse.
 
-Detta betyder inte automatiskt att Production är fel. Det betyder att **migrationsmappen inte är ett tillräckligt facit för nuvarande Production-schema**.
+**Klassning: REPARERA data-integritet**, men inte i 3.1.
 
-**Klassning: VERIFIERA LIVE SCHEMA innan någon ID-/FK-migrering.**
+## 15. Ankomst har motsvarande integritetsgräns
 
-## 9. Check — en affärshändelse är inte en atomisk persistence-transaktion
+Ankomst skriver `arrivals`, kan uppdatera `vehicles.bransletyp` och skickar notifiering. DB-fel kan loggas som non-critical och mejl fortsätta.
 
-Nuvarande Check-persistens gör flera separata writes:
+**Klassning: REPARERA.**
 
-- skapar `checkins`,
-- uppdaterar/infogar `vehicles.bransletyp`,
-- skapar nya rader i `damages`,
-- skapar rader i `checkin_damages`,
-- kan skapa `vehicle_receipts`,
-- skickar därefter e-post.
-
-Felhanteringen är avsiktligt resilient: flera databasfel loggas men flödet kan fortsätta och mejl kan fortfarande skickas. Det skyddar användarflödet mot totalstopp, men innebär att en affärshändelse kan bli **delvis persisterad**.
-
-Exempel: misslyckad `checkins`-insert gör att skadeinserts hoppas över, medan notifieringen fortfarande kan fortsätta.
-
-**Klassning: REPARERA data-integritet**, men inte genom att ändra beteendet i Steg 3.1. En framtida lösning måste ta ställning till transaktion/idempotens/outbox eller motsvarande utan att förlora befintlig operativ robusthet.
-
-## 10. Ankomst har motsvarande integritetsgräns
-
-Ankomstflödet:
-
-- skriver `arrivals`,
-- uppdaterar `vehicles.bransletyp`,
-- skickar notifiering.
-
-DB-fel loggas som non-critical och mejl kan fortsätta skickas.
-
-Det är samma grundmönster: **operationell leverans och databasatomitet är separerade**.
-
-**Klassning: REPARERA**, inte ta bort.
-
-## 11. Skade- och mediakällor är fragmenterade
+## 16. Skade- och mediakällor är fragmenterade
 
 Aktuell kod använder flera representationer:
 
-- `damages.uploads` för media på skadepost,
+- `damages.uploads`,
 - `checkin_damages.photo_urls` / `video_urls`,
 - Storage-mappar,
-- `damage_media`, som fortfarande läses av Rapport.
+- `damage_media`,
+- Nybil `photo_urls` / `media_folder`,
+- `vehicle_receipts` för kvittofiler.
 
-Nuvarande Nybil skriver skadebilder i `damages.uploads`. Rapportens mediavy hämtar däremot från `damage_media`.
+Live-rader visar att `damage_media` och `damage_positions` är tomma, medan `damages` och `checkin_damages` bär aktiv data. Rapportkoden försöker ändå läsa `damage_media`.
 
-Detta bevisar inte att `damage_media` är oanvänd — tvärtom läses den — men det visar att mediamodellen inte har en enda kanonisk källa.
+**Klassning: REPARERA/VERIFIERA**, inte radera ännu.
 
-**Klassning: BEHÅLL + REPARERA/VERIFIERA.**
+## 17. Stationer — source-of-truth-fråga kvarstår
 
-## 12. Stationer — möjlig source-of-truth-dubblering
+`stations` finns live men har 0 rader. Samtidigt använder aktuell kod statiska stationslistor och datafiler. `checkins.station_id` har ändå en FK mot `stations.id`.
 
-Production-evidens visar ett `stations`-objekt, men aktuell kod använder också statiska stationslistor i repo, bland annat `lib/stations.ts` och formulärspecifika listor. Ingen direkt `.from('stations')`-referens hittades i nuvarande repo vid denna inventering.
+Detta är ett tydligt exempel på att ett schemaobjekt kan vara strukturellt närvarande men operationellt kringgånget.
 
-Detta räcker **inte** för att radera `stations`; tabellen kan användas av DB-logik, importer eller administration som inte syns i appkoden.
+**Klassning: REPARERA/VERIFIERA source of truth.**
 
-**Klassning: VERIFIERA source of truth.**
+## 18. Historik ska skyddas
 
-Målet bör vara att en station får ett tydligt kanoniskt ID/namn och att e-postrouting, formulär och rapportering inte driver egna divergerande listor.
+`vehicle_edits` och `vehicle_status_log` finns live men har 0 rader i aktuell metadata. Koden använder `vehicle_edits` som kontrakt för overrides/historik; `vehicle_status_log` saknar aktuell reporeferens.
 
-## 13. Historik är en tillgång som ska skyddas
-
-Produktionsschemaevidensen från 2026-08-16 visar bland annat:
-
-- `vehicle_status_log(regnr, event_type, data, changed_by, created_at)`,
-- `vehicle_edits(regnr, field_name, old_value, new_value, edited_by, edited_at, comment, batch_id)`.
-
-`vehicle_edits` är bekräftat aktivt i aktuell kod och används både för nulägesoverride och historik. Det ska inte flattenas bort under en cleanup.
-
-`vehicle_status_log` hade Production-evidens men gav ingen aktuell reporeferens i denna kodgranskning. Det kan vara trigger-/DB-side-drivet.
-
-**Klassning:**
-
-- `vehicle_edits`: **BEHÅLL / FORMALISERA PRECEDENS**.
+- `vehicle_edits`: **BEHÅLL KONTRAKT / VERIFIERA faktisk användning**.
 - `vehicle_status_log`: **VERIFIERA**, inte borttagningskandidat ännu.
 
-## 14. Bekräftad legacy-kolumnskuld i `checkins`
+Tomhet idag är inte i sig tillräckligt borttagningsbevis.
 
-Databasdokumentationen innehåller flera överlappande representationer. Kodsökning i nuvarande `main` ger följande preliminära bild:
+## 19. Legacy-kolumnskuld i `checkins`
 
-### Aktiv representation
+Nuvarande kod använder huvudsakligen bland annat:
 
-- `hjultyp`
-- `fuel_level`
-- `charge_cables_count`
+- `hjultyp`,
+- `fuel_level`,
+- `charge_cables_count`.
 
-### Ingen nuvarande runtime-referens hittad i repo
+Äldre överlappande representationer finns samtidigt kvar, exempelvis:
 
-- `wheel_type`
-- `tires_type`
-- `charging_cables`
-- `chargers_count`
-- `fuel_level_percent`
+- `wheel_type`,
+- `tires_type`,
+- `charging_cables`,
+- `chargers_count`,
+- `fuel_level_percent`.
 
-Dessa senare fält är **inte godkända att raderas**. De är endast **senare retirement-kandidater**, eftersom Production-data, views, RPC, importer och extern konsumtion först måste profileras.
+Dessa är **senare retirement-kandidater**, inte godkända att radera i 3.1.
 
-## 15. Objekt som måste verifieras innan klassning
+## 20. Tomma/staging/backupobjekt — endast kandidater
 
-Följande objekt finns i Production-evidens eller repo-dokumentation, men saknade tydlig aktuell runtime-referens i den granskade appkoden eller har en oklar livscykel:
+Live-inventeringen visar många tabeller med 0 rader, bland annat äldre backup-, staging- och importobjekt. Exempel:
 
-- `checkin_drafts` — läsare finns, writer hittades inte,
-- `vehicle_status_log`,
-- `tire_storage`,
-- `tire_storage_summary`,
-- `mabi_damage_data`,
-- `mabi_damage_data_raw`,
-- `mabi_damage_data_raw_new`,
-- `mabi_damage_view`,
-- `damages_current`,
-- `simple_mabi_damage`,
+- `damages_backup_*`,
+- `vehicles_backup_*`,
+- `damages_dedup_backup_*`,
+- `nybil_inventering_backup_20260425`,
+- `vehicles_staging`,
 - `skador_staging`,
-- `v_nybil_baseline`,
-- `v_wheel_storage_precedence`,
-- `vehicle_damage_summary`,
 - `duplicates_to_delete`,
-- historiskt synliga funktioner som `get_documented_legacy_texts`, `upsert_vehicles_from_staging`, `set_updated_at`, `try_lock_checkin`.
+- `mabi_damage_data*`,
+- `damages_external`,
+- `damages_current`,
+- `active_damages`.
 
-**Status för samtliga: VERIFIERA.**
+De är nu starkare kandidater för senare arkivering än tidigare, men **0 rader + ingen reporeferens är fortfarande inte samma sak som godkänt borttagande**. Views, RPC-definitioner, importprocesser, retention och rollbackbehov måste korsas innan drop.
 
-Frånvaro av reporeferens betyder endast "inte hittad som aktuell applikationskonsument". Det betyder inte att objektet är oanvänt i databasen.
-
-## 16. Senare arkiv-/borttagningskandidater — inte godkända
-
-Production-skärmbilden visar flera daterade backup-/dedupobjekt, exempelvis `damages_backup_*`, `damages_dedup_backup_*` och `nybil_inventering_backup_*`.
-
-Det är rimliga **kandidater** för arkivering eller borttagning senare, men först efter:
-
-1. verifierad row count och senast ändrad/använd,
-2. dependency-sökning i views/functions/triggers,
-3. bekräftelse att ingen rollback-/revisionskedja kräver dem,
-4. export/backup enligt beslutad retention,
-5. separat godkänt förändringsbeslut.
-
-Ingen sådan borttagning ingår i Steg 3.1.
-
-## 17. Klassning enligt revisionsordningen
+## 21. Klassning enligt revisionsordningen
 
 ### BEHÅLL
 
@@ -289,23 +388,27 @@ Operativ kärna och evidens:
 - `checkins`
 - `checkin_damages`
 - `damages`
-- `damages_external`
 - `vehicles`
 - `nybil_inventering`
 - `arrivals`
-- `vehicle_edits`
-- `employees`
 - `vehicle_receipts`
-- `damage_comments`
-- aktuella fordons-/BUHS-RPC-kontrakt
+- skade-/statushistorikens kontrakt
+- aktiva fordons-/BUHS-lookup-kontrakt tills säkert ersatta
 
-### REPARERA
+### REPARERA — PRIORITET RÖD
 
-- explicit relation mellan BUHS-ursprung och motsvarande `damages.id`,
-- relation mellan skadehändelse och ursprungsskada,
-- comment/damage-relation där FK saknas eller inte kan användas,
-- Nybil-alias/duplicerade semantiska fält,
-- Nybil-ID/migrationsdrift efter live-verifiering,
+1. **Direkt anonymous Supabase-access till `checkins` och `checkin_damages`.**
+2. **Anon-exekverbara `SECURITY DEFINER`-RPC:er**, särskilt aktiva fordons-/BUHS-lookups och lockfunktioner.
+3. Direkt `authenticated`-access måste harmoniseras med samma verkliga accessmodell som LoginGate/server-auth använder; UI-inloggning får inte vara enda behörighetskontrollen.
+
+### REPARERA — DATAMODELL EFTER SÄKERHETSGRÄNSEN
+
+- BUHS-ursprung ↔ `damages.id`,
+- skadehändelse ↔ ursprungsskada,
+- `damage_comments.damage_id` FK/kontrakt,
+- `vehicle_receipts.checkin_id` FK/kontrakt,
+- `damages.nybil_inventering_id` FK/kontrakt,
+- Nybil-alias,
 - canonical media source,
 - station source of truth,
 - explicit precedens mellan Nybil/vehicles/checkins/arrivals/vehicle_edits,
@@ -313,12 +416,11 @@ Operativ kärna och evidens:
 
 ### VERIFIERA
 
-- DB-side objekt utan nuvarande reporeferens,
+- tomma DB-side objekt utan nuvarande reporeferens,
 - views/staging/importtabeller,
 - `vehicle_status_log`,
-- `checkin_drafts`,
+- `checkin_drafts` och dess dubbla update-trigger,
 - backup-/dedupobjekt,
-- historiska funktioner som inte syns i aktuell appkod,
 - legacykolumner utan nuvarande runtime-referens.
 
 ### TA BORT — INGET BESLUT ÄN
@@ -327,39 +429,20 @@ Steg 3.1 godkänner **0** objekt för borttagning.
 
 ### ADDERA — INGET NYTT DOMÄNOBJEKT ÄN
 
-Nya tabeller/engines ska inte skapas innan relations- och precedenskartan är verifierad.
+Nya tabeller/engines ska inte skapas innan säkerhetsgräns, relationskarta och precedens är verifierade.
 
-## 18. Vad som behöver verifieras för att avsluta Steg 3.1
+## 22. Beslutspunkt efter live-inventeringen
 
-För att gå från preliminär inventering till låst databasbaseline behövs en färsk **read-only live schema snapshot** eller motsvarande metadataexport med minst:
+Den färska Production-metadata som tidigare saknades är nu hämtad. 3.1 har därmed kunnat verifiera schemaomfattning, centrala datatyper, PK/FK, views, funktioner, triggers, RLS-policies och aktuella row counts på metadata-nivå.
 
-- alla public tables/views/materialized views,
-- kolumner + datatyper + nullability + defaults,
-- PK/FK/unique/check constraints,
-- index,
-- functions/RPC + signaturer,
-- triggers,
-- view-definitioner och beroenden,
-- RLS enabled-status/policies för datamodellens accesskarta,
-- row counts eller säkra approximeringar,
-- identifiering av tomma/backup/stagingobjekt,
-- dependency-analys för kandidater,
-- särskild verifiering av `nybil_inventering.id` och damage/comment-ID-kontrakt.
+**3.1 ska ändå inte låsas som “klar och mergebar” innan det röda accessfyndet har ett separat reparationsbeslut.** Att fortsätta med cleanup medan anonym direktaccess är öppen skulle bryta revisionsordningen.
 
-Denna metadata ska hämtas read-only. Ingen DDL eller DML behöver köras för inventeringen.
+Nästa säkra arbetssteg är därför inte en drop, backfill eller redesign utan en fokuserad säkerhetsreparation av Supabase-gränsen med regression mot de klientflöden som fortfarande går direkt mot Supabase.
 
-## 19. Föreslagen ordning efter komplett 3.1
+Ingen reparation genomförs av denna inventerings-PR.
 
-När live-schemat är verifierat bör nästa del inte vara en generell "DB cleanup". Föreslagen ordning är:
+## 23. Låst princip för Steg 3
 
-1. **Kanonisk relations- och precedenskarta** för Vehicle/Nybil/Arrival/Checkin/Edit/Damage.
-2. **Integritetsreparationer** som kan införas kompatibelt och observerbart.
-3. **Alias-/legacykontrakt** med mätning, backfillplan och konsumentmigrering.
-4. **Arkivering/borttagning** först när objektens användning är bevisat noll eller ersatt.
-5. **Nya strukturer** först när nuvarande data inte kan bära det önskade kontraktet utan osäker workaround.
-
-## 20. Låst princip för Steg 3
-
-> Historik, evidens och fungerande kärnflöden är tillgångar. Databasstädning får inte börja med namn, ålder eller upplevd redundans. Varje förändring ska först visa vilken aktuell konsument, relation, datahistorik och fallback den ersätter.
+> Historik, evidens och fungerande kärnflöden är tillgångar. Databasstädning får inte börja med namn, ålder eller upplevd redundans. Varje förändring ska först visa vilken aktuell konsument, relation, accessgräns, datahistorik och fallback den ersätter.
 
 **Behålla → reparera → ta bort → addera.**

--- a/docs/DATA_MODEL_INVENTORY_2026-08-18.md
+++ b/docs/DATA_MODEL_INVENTORY_2026-08-18.md
@@ -1,0 +1,365 @@
+# Steg 3.1 — Datamodell- och databasberoendeinventering
+
+**Status:** Preliminär read-only baseline — inga schemaändringar  
+**Datum:** 2026-08-18  
+**Kodbaseline:** `d1bbf5f318405028113f12c5dd162662b7065464` (`main` efter Steg 2.6)  
+**Arbetsprincip:** `behålla → reparera → ta bort → addera`
+
+## 1. Syfte och avgränsning
+
+Steg 3.1 ska fastställa vad datamodellen faktiskt bär, vad applikationen faktiskt använder och var relationer eller källor är otydliga innan någon databasmigrering, normalisering eller borttagning övervägs.
+
+Detta dokument gör därför **inte** följande:
+
+- kör SQL mot Production,
+- ändrar tabeller, vyer, funktioner, constraints, index eller policies,
+- skapar migrationer,
+- raderar legacy-/backupobjekt,
+- redesignar domänmodellen,
+- ändrar app-, API- eller affärslogik.
+
+Ingen tabell eller kolumn är godkänd för borttagning genom detta dokument.
+
+## 2. Evidensnivåer och begränsning
+
+Inventeringen bygger på två separata evidenslager som inte ska blandas ihop:
+
+### A. Aktuell kodevidens — 2026-08-18
+
+Exakt `main` på commit `d1bbf5f318405028113f12c5dd162662b7065464` har granskats för direkta Supabase-anrop, RPC-anrop, server-side service-role-vägar, klientskrivningar och datakällor i de centrala flödena.
+
+Detta är stark evidens för **vilka objekt den nuvarande applikationen refererar till**.
+
+### B. Produktionsschemaevidens — 2026-08-16
+
+Tidigare faktisk Production-schemaexport och Supabase-skärmbilder visar en större modell än repoets migrationsmapp: ungefär **50 tabeller/vyer, 802 kolumndefinitioner, 139 constraints, 59 index, 35 RLS-policies, 14 databasfunktioner och 6 foreign keys**.
+
+Detta är stark historisk evidens för Production-modellens omfattning, men är **inte en färsk live-introspektion den 18 augusti**. Säkerhetsläget i äldre material ska inte användas för att återöppna Steg 2; server-API-säkerheten reparerades och verifierades därefter.
+
+### Begränsning
+
+Ingen direkt Supabase-databaskoppling finns i denna granskning. Exakta aktuella row counts, null-profiler, view-definitioner, triggerberoenden, funktionsberoenden, FK-definitioner och objekt som enbart används DB-side måste därför revalideras innan destruktiva beslut kan tas.
+
+## 3. Första huvudslutsatsen
+
+Databasen ska **inte** behandlas som ett tomt eller misslyckat schema som bör ersättas. Den bär verklig operativ data, historik, skadebevis, nybilsinventering, incheckningar, ankomster, statusändringar och ekonomiskt relevanta kvitton.
+
+Det huvudsakliga strukturfyndet är i stället:
+
+> Applikationen rekonstruerar fordons- och skadebilden från flera källor med registreringsnummer, RPC-funktioner, fallbackkedjor, manuella overrides, text-/datum-matchning och applikationslogik. Datamodellen fungerar operativt, men en gemensam kanonisk relations- och precedensmodell är inte tydligt etablerad genom hela kedjan.
+
+Det är därför fel angreppssätt att börja med att "städa bort" tabeller. Först måste relationer, ägarskap och precedens göras verifierbara.
+
+## 4. Bekräftat aktiva kärnobjekt i nuvarande applikation
+
+| Objekt | Aktuell användning | Primär koppling | Klassning |
+|---|---|---|---|
+| `checkins` | Check skriver; Status, Check/vehicle-info, damages och edits läser | `id`, `regnr` | **BEHÅLL** |
+| `checkin_damages` | Check skriver skadehändelser; Status/vehicle-info läser | `checkin_id`, `regnr` | **BEHÅLL / REPARERA relation till ursprungsskada** |
+| `damages` | Central skadehistorik från Check/Nybil/BUHS; läses av Status/Rapport/vehicle-info | `id`, `regnr`, legacy-fält | **BEHÅLL / REPARERA** |
+| `damages_external` | Indirekt källa bakom BUHS-RPC enligt nuvarande dokumentation/importkedja | normaliserat `regnr` via RPC | **BEHÅLL / REPARERA källgräns** |
+| `vehicles` | Bilkontroll/fordonsmaster; läses och uppdateras av flera flöden | `regnr` | **BEHÅLL** |
+| `nybil_inventering` | Nybil skriver direkt; Status/Check/vehicle-info/edits läser | `id`, `regnr` | **BEHÅLL / REPARERA** |
+| `arrivals` | Ankomst skriver; Status/vehicle-info läser | `regnr`, tid | **BEHÅLL** |
+| `vehicle_edits` | Append-only manuell override/historik som påverkar nuläge och historik | `regnr`, `field_name`, `edited_at`, `batch_id` | **BEHÅLL / FORMALISERA PRECEDENS** |
+| `employees` | Aktiv authz-källa tillsammans med central whitelist | `email`, `is_active` | **BEHÅLL** |
+| `vehicle_receipts` | Check skriver tankningskvitton/evidens | `checkin_id`, `regnr` | **BEHÅLL** |
+| `damage_comments` | Backend läser/skriver kommentarer kopplade till `damages.id` | `damage_id` | **BEHÅLL / REPARERA relation** |
+| `damage_media` | Rapport läser media per `damage_id` | `damage_id` | **BEHÅLL TILLS VERIFIERAD / REPARERA källfragmentering** |
+| `checkin_drafts` | Nuvarande repo innehåller en läsande drafts-sida; ingen writer hittad i aktuell kod | oklar | **VERIFIERA** |
+
+### Aktiva RPC-kontrakt
+
+- `get_vehicle_by_trimmed_regnr` används av dagens fordons-/statuslogik.
+- `get_damages_by_trimmed_regnr` används av dagens BUHS-/skadelogik.
+
+Dessa två funktioner är därför del av applikationens aktiva datakontrakt och får inte behandlas som "DB-internals" som kan ändras utan regressionstest.
+
+## 5. Hur Status faktiskt bygger fordonsbilden
+
+`lib/vehicle-status.ts` hämtar i samma flöde data från:
+
+1. `nybil_inventering`,
+2. `get_vehicle_by_trimmed_regnr`,
+3. `damages`,
+4. `get_damages_by_trimmed_regnr`,
+5. `checkins`,
+6. `arrivals`,
+7. `vehicle_edits`,
+8. därefter `damage_comments`,
+9. och `checkin_damages` via det skyddade server-API:t.
+
+Detta är funktionellt värdefullt — Status kan rekonstruera mycket information — men visar också att "fordonets sanning" inte kommer från en enda relation eller ett enda livscykelobjekt.
+
+Två konkreta svagheter är synliga i den aktuella koden:
+
+- `damage_comments` kan inte joinas naturligt i den aktuella implementationen; koden hämtar damage-ID:n först och laddar kommentarer separat.
+- BUHS-RPC-resultaten saknar det UUID som används i `damages`. Status bygger därför en matchningsnyckel av `regnr + datum + damage_type_raw + note_customer + note_internal` för att hitta motsvarande `damages.id`.
+
+Det är ett **REPARERA-fynd**, inte ett skäl att ta bort historiken.
+
+## 6. Vehicle-info visar samma strukturella mönster
+
+Server-routen för vehicle-info använder service role bakom den verifierade API-authgränsen och kombinerar bland annat:
+
+- fordons-RPC,
+- BUHS-skade-RPC,
+- `damages`,
+- `nybil_inventering`,
+- `vehicles`,
+- `vehicle_edits`,
+- `arrivals`,
+- senaste `checkins`,
+- `checkin_damages`.
+
+För BUHS-hantering söker implementationen efter en "winning checkin": först bland de 10 senaste, sedan 30, baserat på om antalet hanterade skadeposter är tillräckligt stort i förhållande till antal BUHS-skador. Om ingen sådan hittas faller koden tillbaka till senaste incheckningen.
+
+Detta är stark evidens för att relationen mellan **ursprunglig BUHS-skada → dokumenterad skadehändelse → incheckning** behöver göras mer explicit. Den fungerande fallbacken ska bevaras tills en säkrare relation är verifierad och migrerad.
+
+## 7. Nybil — verifierad semantisk dubblering i samma tabell
+
+Nuvarande Nybil-kod dual-skriver flera semantiskt överlappande fält i `nybil_inventering` för kompatibilitet:
+
+- `modell` + `bilmodell`,
+- `registreringsdatum` + `ankomstdatum`,
+- `hjultyp` + `monterade_dack`,
+- `hjul_ej_monterade` + `hjul_till_forvaring`,
+- `hjul_forvaring_ort` + `hjul_forvaring_station`,
+- `dackkompressor` + `kompressor`.
+
+Detta är inte en hypotes — aliasen skrivs uttryckligen av nuvarande applikationskod.
+
+**Klassning: REPARERA.**
+
+Ingen alias-kolumn får tas bort innan följande är verifierat:
+
+- vilken kolumn som faktiskt läses av alla nuvarande konsumenter,
+- om äldre Production-data bara finns i den ena varianten,
+- om views/RPC/importer refererar till någon aliasvariant,
+- om backfill behövs,
+- om klient- och serverkontrakt kan ändras atomärt.
+
+## 8. Nybil-ID — migration och runtime beskriver olika verklighet
+
+Repoets äldre migrationer definierar `nybil_inventering.id` som `BIGSERIAL` och `original_registration_id` som `BIGINT`-FK.
+
+Den nuvarande applikationen behandlar däremot Nybil-ID som UUID/string i dubblettkontrollen och använder `duplicate_group_id` som aktiv dubblettmekanism. Koden kommenterar uttryckligen att `original_registration_id` inte sätts.
+
+Detta betyder inte automatiskt att Production är fel. Det betyder att **migrationsmappen inte är ett tillräckligt facit för nuvarande Production-schema**.
+
+**Klassning: VERIFIERA LIVE SCHEMA innan någon ID-/FK-migrering.**
+
+## 9. Check — en affärshändelse är inte en atomisk persistence-transaktion
+
+Nuvarande Check-persistens gör flera separata writes:
+
+- skapar `checkins`,
+- uppdaterar/infogar `vehicles.bransletyp`,
+- skapar nya rader i `damages`,
+- skapar rader i `checkin_damages`,
+- kan skapa `vehicle_receipts`,
+- skickar därefter e-post.
+
+Felhanteringen är avsiktligt resilient: flera databasfel loggas men flödet kan fortsätta och mejl kan fortfarande skickas. Det skyddar användarflödet mot totalstopp, men innebär att en affärshändelse kan bli **delvis persisterad**.
+
+Exempel: misslyckad `checkins`-insert gör att skadeinserts hoppas över, medan notifieringen fortfarande kan fortsätta.
+
+**Klassning: REPARERA data-integritet**, men inte genom att ändra beteendet i Steg 3.1. En framtida lösning måste ta ställning till transaktion/idempotens/outbox eller motsvarande utan att förlora befintlig operativ robusthet.
+
+## 10. Ankomst har motsvarande integritetsgräns
+
+Ankomstflödet:
+
+- skriver `arrivals`,
+- uppdaterar `vehicles.bransletyp`,
+- skickar notifiering.
+
+DB-fel loggas som non-critical och mejl kan fortsätta skickas.
+
+Det är samma grundmönster: **operationell leverans och databasatomitet är separerade**.
+
+**Klassning: REPARERA**, inte ta bort.
+
+## 11. Skade- och mediakällor är fragmenterade
+
+Aktuell kod använder flera representationer:
+
+- `damages.uploads` för media på skadepost,
+- `checkin_damages.photo_urls` / `video_urls`,
+- Storage-mappar,
+- `damage_media`, som fortfarande läses av Rapport.
+
+Nuvarande Nybil skriver skadebilder i `damages.uploads`. Rapportens mediavy hämtar däremot från `damage_media`.
+
+Detta bevisar inte att `damage_media` är oanvänd — tvärtom läses den — men det visar att mediamodellen inte har en enda kanonisk källa.
+
+**Klassning: BEHÅLL + REPARERA/VERIFIERA.**
+
+## 12. Stationer — möjlig source-of-truth-dubblering
+
+Production-evidens visar ett `stations`-objekt, men aktuell kod använder också statiska stationslistor i repo, bland annat `lib/stations.ts` och formulärspecifika listor. Ingen direkt `.from('stations')`-referens hittades i nuvarande repo vid denna inventering.
+
+Detta räcker **inte** för att radera `stations`; tabellen kan användas av DB-logik, importer eller administration som inte syns i appkoden.
+
+**Klassning: VERIFIERA source of truth.**
+
+Målet bör vara att en station får ett tydligt kanoniskt ID/namn och att e-postrouting, formulär och rapportering inte driver egna divergerande listor.
+
+## 13. Historik är en tillgång som ska skyddas
+
+Produktionsschemaevidensen från 2026-08-16 visar bland annat:
+
+- `vehicle_status_log(regnr, event_type, data, changed_by, created_at)`,
+- `vehicle_edits(regnr, field_name, old_value, new_value, edited_by, edited_at, comment, batch_id)`.
+
+`vehicle_edits` är bekräftat aktivt i aktuell kod och används både för nulägesoverride och historik. Det ska inte flattenas bort under en cleanup.
+
+`vehicle_status_log` hade Production-evidens men gav ingen aktuell reporeferens i denna kodgranskning. Det kan vara trigger-/DB-side-drivet.
+
+**Klassning:**
+
+- `vehicle_edits`: **BEHÅLL / FORMALISERA PRECEDENS**.
+- `vehicle_status_log`: **VERIFIERA**, inte borttagningskandidat ännu.
+
+## 14. Bekräftad legacy-kolumnskuld i `checkins`
+
+Databasdokumentationen innehåller flera överlappande representationer. Kodsökning i nuvarande `main` ger följande preliminära bild:
+
+### Aktiv representation
+
+- `hjultyp`
+- `fuel_level`
+- `charge_cables_count`
+
+### Ingen nuvarande runtime-referens hittad i repo
+
+- `wheel_type`
+- `tires_type`
+- `charging_cables`
+- `chargers_count`
+- `fuel_level_percent`
+
+Dessa senare fält är **inte godkända att raderas**. De är endast **senare retirement-kandidater**, eftersom Production-data, views, RPC, importer och extern konsumtion först måste profileras.
+
+## 15. Objekt som måste verifieras innan klassning
+
+Följande objekt finns i Production-evidens eller repo-dokumentation, men saknade tydlig aktuell runtime-referens i den granskade appkoden eller har en oklar livscykel:
+
+- `checkin_drafts` — läsare finns, writer hittades inte,
+- `vehicle_status_log`,
+- `tire_storage`,
+- `tire_storage_summary`,
+- `mabi_damage_data`,
+- `mabi_damage_data_raw`,
+- `mabi_damage_data_raw_new`,
+- `mabi_damage_view`,
+- `damages_current`,
+- `simple_mabi_damage`,
+- `skador_staging`,
+- `v_nybil_baseline`,
+- `v_wheel_storage_precedence`,
+- `vehicle_damage_summary`,
+- `duplicates_to_delete`,
+- historiskt synliga funktioner som `get_documented_legacy_texts`, `upsert_vehicles_from_staging`, `set_updated_at`, `try_lock_checkin`.
+
+**Status för samtliga: VERIFIERA.**
+
+Frånvaro av reporeferens betyder endast "inte hittad som aktuell applikationskonsument". Det betyder inte att objektet är oanvänt i databasen.
+
+## 16. Senare arkiv-/borttagningskandidater — inte godkända
+
+Production-skärmbilden visar flera daterade backup-/dedupobjekt, exempelvis `damages_backup_*`, `damages_dedup_backup_*` och `nybil_inventering_backup_*`.
+
+Det är rimliga **kandidater** för arkivering eller borttagning senare, men först efter:
+
+1. verifierad row count och senast ändrad/använd,
+2. dependency-sökning i views/functions/triggers,
+3. bekräftelse att ingen rollback-/revisionskedja kräver dem,
+4. export/backup enligt beslutad retention,
+5. separat godkänt förändringsbeslut.
+
+Ingen sådan borttagning ingår i Steg 3.1.
+
+## 17. Klassning enligt revisionsordningen
+
+### BEHÅLL
+
+Operativ kärna och evidens:
+
+- `checkins`
+- `checkin_damages`
+- `damages`
+- `damages_external`
+- `vehicles`
+- `nybil_inventering`
+- `arrivals`
+- `vehicle_edits`
+- `employees`
+- `vehicle_receipts`
+- `damage_comments`
+- aktuella fordons-/BUHS-RPC-kontrakt
+
+### REPARERA
+
+- explicit relation mellan BUHS-ursprung och motsvarande `damages.id`,
+- relation mellan skadehändelse och ursprungsskada,
+- comment/damage-relation där FK saknas eller inte kan användas,
+- Nybil-alias/duplicerade semantiska fält,
+- Nybil-ID/migrationsdrift efter live-verifiering,
+- canonical media source,
+- station source of truth,
+- explicit precedens mellan Nybil/vehicles/checkins/arrivals/vehicle_edits,
+- atomitet/idempotens för Check och Ankomst.
+
+### VERIFIERA
+
+- DB-side objekt utan nuvarande reporeferens,
+- views/staging/importtabeller,
+- `vehicle_status_log`,
+- `checkin_drafts`,
+- backup-/dedupobjekt,
+- historiska funktioner som inte syns i aktuell appkod,
+- legacykolumner utan nuvarande runtime-referens.
+
+### TA BORT — INGET BESLUT ÄN
+
+Steg 3.1 godkänner **0** objekt för borttagning.
+
+### ADDERA — INGET NYTT DOMÄNOBJEKT ÄN
+
+Nya tabeller/engines ska inte skapas innan relations- och precedenskartan är verifierad.
+
+## 18. Vad som behöver verifieras för att avsluta Steg 3.1
+
+För att gå från preliminär inventering till låst databasbaseline behövs en färsk **read-only live schema snapshot** eller motsvarande metadataexport med minst:
+
+- alla public tables/views/materialized views,
+- kolumner + datatyper + nullability + defaults,
+- PK/FK/unique/check constraints,
+- index,
+- functions/RPC + signaturer,
+- triggers,
+- view-definitioner och beroenden,
+- RLS enabled-status/policies för datamodellens accesskarta,
+- row counts eller säkra approximeringar,
+- identifiering av tomma/backup/stagingobjekt,
+- dependency-analys för kandidater,
+- särskild verifiering av `nybil_inventering.id` och damage/comment-ID-kontrakt.
+
+Denna metadata ska hämtas read-only. Ingen DDL eller DML behöver köras för inventeringen.
+
+## 19. Föreslagen ordning efter komplett 3.1
+
+När live-schemat är verifierat bör nästa del inte vara en generell "DB cleanup". Föreslagen ordning är:
+
+1. **Kanonisk relations- och precedenskarta** för Vehicle/Nybil/Arrival/Checkin/Edit/Damage.
+2. **Integritetsreparationer** som kan införas kompatibelt och observerbart.
+3. **Alias-/legacykontrakt** med mätning, backfillplan och konsumentmigrering.
+4. **Arkivering/borttagning** först när objektens användning är bevisat noll eller ersatt.
+5. **Nya strukturer** först när nuvarande data inte kan bära det önskade kontraktet utan osäker workaround.
+
+## 20. Låst princip för Steg 3
+
+> Historik, evidens och fungerande kärnflöden är tillgångar. Databasstädning får inte börja med namn, ålder eller upplevd redundans. Varje förändring ska först visa vilken aktuell konsument, relation, datahistorik och fallback den ersätter.
+
+**Behålla → reparera → ta bort → addera.**


### PR DESCRIPTION
## Syfte
Låsa Steg 3.1 som read-only Production-inventering av datamodell, databeroenden, redundanser och source-of-truth innan någon cleanup eller redesign.

## Aktuell baseline
- Kod: `8b152db4d1dbfec202d0dc207ab3ff8fa499cc3f` (`main`).
- Supabase Production: `incheckad` (`ufioaijcmaujlvmveyra`).
- Inventeringen använder metadata/SELECT samt läsning av aktuell kod och drift-/importdokumentation.
- Ingen cleanup-DDL, DML eller write probe görs av denna PR.

## Diff
Exakt **1 dokumentationsfil**:
- `docs/DATA_MODEL_INVENTORY_2026-08-18.md`

Ingen appkod, dependency, API-logik eller schemaändring.

## Live-baseline efter Steg 3.1A
- 44 tabeller + 6 views = **50 relationsobjekt**
- **802** kolumner
- **59** index
- **14** funktioner, varav **7 SECURITY DEFINER**
- **9** foreign keys
- **25** RLS-policies
- **3** triggers
- **41 av 50** relationsobjekt har `regnr`-liknande kolumn

## Säkerhetsfyndet är stängt
Det röda fynd som först blockerade 3.1 reparerades separat i PR #318/#319 och verifierades i Production:
- inga `anon`-tabellgrants i `public`,
- browseråtkomst är explicit allowlistad för `authenticated`,
- de tre aktiva browser-RPC:erna är `SECURITY INVOKER`,
- kvarvarande `SECURITY DEFINER`-funktioner är service-only.

## Viktigaste nya datamodellfynd
- `checkins` har FK/scaffolding för station/användaridentitet men **0** populering i `station_id`, `employee_id`, `started_by`, `completed_by`, `locked_by`; verksamhetsdata ligger i textfält.
- tre logiska relationer saknar FK men har **0 orphans** idag: `vehicle_receipts.checkin_id`, `damages.nybil_inventering_id`, `damage_comments.damage_id`.
- sex Nybil-aliaspar är **100 % synkroniserade** i dagens 195 rader och är starka senare retirement-kandidater.
- äldre Check-alias är nästan helt tomma jämfört med nuvarande fält.
- `damages_external` är i dagens snapshot en **exakt 727-raders kopia** av BUHS-delen av `damages`; driftdokumentationen kräver manuell synkning.
- den dokumenterade importprocessen använder fortfarande staging och skapar backups; **14 backup-tabeller innehåller totalt 8 254 rader**.
- `allowed_plates` används inte av den aktiva allowlist-RPC:n och avviker kraftigt från den härledda aktuella mängden.
- `active_damages` är en projektion av `car_data` på gemensamma fält.
- dynamiska legacy-RPC:er skapar dolda beroenden mot tabeller genom `information_schema` och måste retireras innan legacytabeller kan tas bort säkert.
- två exakta indexdubletter finns: `damages(regnr)` och dubbel unik indexering av `vehicles(regnr)`.

## Klassning
- **BEHÅLL:** operativ kärna, historik och evidens.
- **REPARERA:** relationell integritet → BUHS source-of-truth → station/användaridentitet → alias → legacy DB-side → index → media/atomitet.
- **VERIFIERA/ARKIVERA:** backup-, staging-, import- och legacyobjekt utan aktuell appkonsument.
- **TA BORT:** 0 objekt godkända i 3.1.
- **ADDERA:** 0 nya domänobjekt behövs för att stänga 3.1.

## Nästa steg
**Steg 3.2 — relationer och source-of-truth**, i små reversibla delsteg. Första tekniska kandidater är de tre saknade FK-kontrakten med 0 orphans och därefter beteendebevarande eliminering av dubbel lagring i `damages_external`.

**Behålla → reparera → ta bort → addera.**