### PR TITLE
Steg 3.1A: stäng Supabase Data API-accessgränsen

### DIFF
--- a/migrations/20260818_lock_down_supabase_data_api.sql
+++ b/migrations/20260818_lock_down_supabase_data_api.sql
@@ -1,0 +1,279 @@
+-- Step 3.1A: close direct Supabase Data API paths without changing business logic.
+--
+-- Goals:
+-- 1. No anonymous database-table/RPC access through the public Data API.
+-- 2. Signed-in users only receive browser-level database access when they are
+--    an existing application user (current whitelist OR active employee).
+-- 3. The browser receives only the object privileges used by current main.
+-- 4. Server-side service_role behavior is preserved.
+-- 5. SECURITY DEFINER RPCs are no longer executable by anon/authenticated;
+--    get_all_allowed_plates remains browser-accessible as SECURITY INVOKER.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Internal authorization helper. `private` is not an exposed Data API schema.
+-- Keep this list synchronized with lib/access-control.ts until authorization
+-- governance is consolidated in a later, separately reviewed change.
+-- ---------------------------------------------------------------------------
+create schema if not exists private;
+
+revoke all on schema private from public, anon, authenticated;
+grant usage on schema private to authenticated, service_role;
+
+create or replace function private.is_app_user()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    coalesce(
+      lower(auth.jwt() ->> 'email') = any (array[
+        'per.andersson@mabi.se',
+        'per.enskede@gmail.com',
+        'ingemar.carqueija@mabi.se',
+        'latif.mutlu@mabi.se',
+        'hugo.carqueija@gmail.com',
+        'benjamin.mutlu@outlook.com',
+        'oliwer.fredriksson@mabi.se',
+        'louise.espe@mabi.se',
+        'lucas.nemeth@mabi.se',
+        'isak.brandeby@mabi.se',
+        'noorullah.mohammad.zarif@mabi.se',
+        'maciej.krupa@mabi.se',
+        'nimet.mecaj@mabi.se',
+        'lukas.svensson@mabi.se',
+        'leo.hedenberg@mabi.se',
+        'anders.larsson@mabi.se',
+        'haris.poricanin@mabi.se',
+        'mikael.gronqvist@mabi.se',
+        'ludvig.johansson@mabi.se',
+        'joachim.mellden@mabi.se',
+        'felicia.sarlov@mabi.se',
+        'mohamed.ismael@mabi.se',
+        'linus.croon@mabi.se',
+        'wanda.andersson@mabi.se',
+        'dan.hermodsson@mabi.se',
+        'elvir.poricanin@mabi.se',
+        'asa.andersson@mabi.se',
+        'dilot_85@hotmail.com',
+        'alicia.carqueija@mabi.se',
+        'isak.andersson@mabi.se',
+        'isakeandersson@gmail.com',
+        'lucianoinzunza71@gmail.com',
+        'helsingborg@mabi.se'
+      ]::text[]),
+      false
+    )
+    or exists (
+      select 1
+      from public.employees e
+      where lower(e.email) = lower(auth.jwt() ->> 'email')
+        and e.is_active is true
+    );
+$$;
+
+revoke all on function private.is_app_user() from public, anon;
+grant execute on function private.is_app_user() to authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- Close the broad default Data API surface first, then explicitly re-grant
+-- only the browser contracts used by current main. service_role is untouched.
+-- ---------------------------------------------------------------------------
+revoke all privileges on all tables in schema public from anon, authenticated;
+revoke execute on all functions in schema public from public, anon, authenticated;
+
+-- Preserve current server-side RPC behavior after removing PUBLIC execute.
+grant execute on all functions in schema public to service_role;
+
+-- Prevent new public-schema objects from silently reopening the same boundary.
+alter default privileges for role postgres in schema public
+  revoke all on tables from anon, authenticated;
+alter default privileges for role postgres in schema public
+  revoke execute on functions from public, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- employees: remove self-provisioning / self-activation paths.
+-- Browser only needs to read its own row for LoginGate when not whitelisted.
+-- ---------------------------------------------------------------------------
+alter table public.employees enable row level security;
+
+drop policy if exists "Public read employees" on public.employees;
+drop policy if exists employees_insert_admin_like on public.employees;
+drop policy if exists employees_select_self on public.employees;
+drop policy if exists employees_update_self on public.employees;
+
+create policy employees_select_self_app
+on public.employees
+for select
+to authenticated
+using (
+  (select private.is_app_user())
+  and lower(email) = lower(auth.jwt() ->> 'email')
+);
+
+grant select on table public.employees to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- vehicles: browser SELECT is required by Nybil duplicate detection and Rapport.
+-- ---------------------------------------------------------------------------
+alter table public.vehicles enable row level security;
+drop policy if exists "Enable read access for all users" on public.vehicles;
+
+create policy vehicles_select_app_users
+on public.vehicles
+for select
+to authenticated
+using ((select private.is_app_user()));
+
+grant select on table public.vehicles to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- nybil_inventering: current Nybil browser flow reads/inserts/updates directly.
+-- DELETE is intentionally not granted.
+-- ---------------------------------------------------------------------------
+alter table public.nybil_inventering enable row level security;
+drop policy if exists "Allow all for authenticated users" on public.nybil_inventering;
+
+create policy nybil_select_app_users
+on public.nybil_inventering
+for select
+to authenticated
+using ((select private.is_app_user()));
+
+create policy nybil_insert_app_users
+on public.nybil_inventering
+for insert
+to authenticated
+with check ((select private.is_app_user()));
+
+create policy nybil_update_app_users
+on public.nybil_inventering
+for update
+to authenticated
+using ((select private.is_app_user()))
+with check ((select private.is_app_user()));
+
+grant select, insert, update on table public.nybil_inventering to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- damages: Nybil inserts damage evidence directly; Rapport reads it directly.
+-- ---------------------------------------------------------------------------
+alter table public.damages enable row level security;
+
+drop policy if exists damages_select_app_users on public.damages;
+drop policy if exists damages_insert_app_users on public.damages;
+
+create policy damages_select_app_users
+on public.damages
+for select
+to authenticated
+using ((select private.is_app_user()));
+
+create policy damages_insert_app_users
+on public.damages
+for insert
+to authenticated
+with check ((select private.is_app_user()));
+
+grant select, insert on table public.damages to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- damage_media: Rapport reads media metadata directly.
+-- ---------------------------------------------------------------------------
+alter table public.damage_media enable row level security;
+drop policy if exists damage_media_select_app_users on public.damage_media;
+
+create policy damage_media_select_app_users
+on public.damage_media
+for select
+to authenticated
+using ((select private.is_app_user()));
+
+grant select on table public.damage_media to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- vehicle_edits: Check/Ankomst/Status browser code reads latest sale overrides.
+-- Writes remain server-side.
+-- ---------------------------------------------------------------------------
+alter table public.vehicle_edits enable row level security;
+drop policy if exists vehicle_edits_select_app_users on public.vehicle_edits;
+
+create policy vehicle_edits_select_app_users
+on public.vehicle_edits
+for select
+to authenticated
+using ((select private.is_app_user()));
+
+grant select on table public.vehicle_edits to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- checkin_drafts: current repo has a browser reader but no current writer.
+-- Keep only read access to the signed-in user's own drafts.
+-- ---------------------------------------------------------------------------
+alter table public.checkin_drafts enable row level security;
+
+drop policy if exists p_drafts_delete on public.checkin_drafts;
+drop policy if exists p_drafts_insert on public.checkin_drafts;
+drop policy if exists p_drafts_select on public.checkin_drafts;
+drop policy if exists p_drafts_update on public.checkin_drafts;
+
+create policy checkin_drafts_select_self_app
+on public.checkin_drafts
+for select
+to authenticated
+using (
+  (select private.is_app_user())
+  and lower(user_email) = lower(auth.jwt() ->> 'email')
+);
+
+grant select on table public.checkin_drafts to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- checkins: remove public/anon write access. Browser SELECT is retained only
+-- because get_all_allowed_plates is converted to SECURITY INVOKER below.
+-- All normal Check persistence continues through service_role on the server.
+-- ---------------------------------------------------------------------------
+alter table public.checkins enable row level security;
+
+drop policy if exists "Public insert checkins" on public.checkins;
+drop policy if exists "Public select checkins" on public.checkins;
+drop policy if exists "Public select checkins limited" on public.checkins;
+drop policy if exists "Public update checkins" on public.checkins;
+drop policy if exists checkins_delete on public.checkins;
+drop policy if exists checkins_insert on public.checkins;
+drop policy if exists checkins_select on public.checkins;
+drop policy if exists checkins_update on public.checkins;
+
+create policy checkins_select_app_users
+on public.checkins
+for select
+to authenticated
+using ((select private.is_app_user()));
+
+grant select on table public.checkins to authenticated;
+
+-- checkin_damages is server-side in current main. Remove legacy browser grants.
+alter table public.checkin_damages enable row level security;
+drop policy if exists "Public insert checkin_damages" on public.checkin_damages;
+drop policy if exists "Public read checkin_damages" on public.checkin_damages;
+drop policy if exists insert_checkin_damages_authenticated on public.checkin_damages;
+
+-- Legacy photo-table anon policies are dead once table grants are revoked; drop
+-- them explicitly so future grant changes cannot silently reactivate them.
+alter table public.checkin_damage_photos enable row level security;
+drop policy if exists "Public insert checkin_damage_photos" on public.checkin_damage_photos;
+drop policy if exists "Public select checkin_damage_photos" on public.checkin_damage_photos;
+
+-- ---------------------------------------------------------------------------
+-- Browser RPC allowlist.
+-- get_all_allowed_plates is the only RPC referenced by current client code.
+-- Run it as the caller so RLS on vehicles/nybil/checkins remains authoritative.
+-- ---------------------------------------------------------------------------
+alter function public.get_all_allowed_plates() security invoker;
+alter function public.get_all_allowed_plates() set search_path = public;
+grant execute on function public.get_all_allowed_plates() to authenticated, service_role;
+
+commit;

--- a/migrations/20260818_lock_down_supabase_data_api_defaults.sql
+++ b/migrations/20260818_lock_down_supabase_data_api_defaults.sql
@@ -1,0 +1,30 @@
+-- Step 3.1A follow-up hardening for the same Data API boundary.
+--
+-- This deliberately targets existing PUBLIC/anon/authenticated grants and
+-- postgres-owned future objects. Supabase platform-owned default privileges
+-- under supabase_admin are not modified here because the application migration
+-- role (postgres) is not a member of supabase_admin.
+
+begin;
+
+-- PUBLIC privileges are inherited by every role. Current Production has no
+-- explicit PUBLIC table grants, but revoke them defensively so a later policy
+-- change cannot reactivate access through an inherited table privilege.
+revoke all privileges on all tables in schema public from public, anon, authenticated;
+
+-- Existing projects also carry broad legacy sequence grants. Current browser
+-- inserts use UUID defaults and do not require sequence access.
+revoke all privileges on all sequences in schema public from public, anon, authenticated;
+
+-- Harden defaults for app/database objects created by the postgres migration
+-- role. service_role defaults are intentionally preserved for server-side work.
+alter default privileges for role postgres in schema public
+  revoke all on tables from public, anon, authenticated;
+
+alter default privileges for role postgres in schema public
+  revoke all on sequences from public, anon, authenticated;
+
+alter default privileges for role postgres in schema public
+  revoke execute on functions from public, anon, authenticated;
+
+commit;

--- a/migrations/20260818_preserve_status_read_contracts.sql
+++ b/migrations/20260818_preserve_status_read_contracts.sql
@@ -1,0 +1,57 @@
+-- Step 3.1A compatibility hardening for the current Status client.
+--
+-- Status executes lib/vehicle-status.ts in the browser. Preserve only its
+-- verified read contracts, gated by private.is_app_user(), while converting
+-- the two required lookup RPCs from SECURITY DEFINER to SECURITY INVOKER.
+
+begin;
+
+-- arrivals: Status reads arrival history directly. Replace the broad
+-- authenticated=true read policy with application-user authorization.
+alter table public.arrivals enable row level security;
+drop policy if exists "Authenticated users can read arrivals" on public.arrivals;
+
+create policy arrivals_select_app_users
+on public.arrivals
+for select
+to authenticated
+using ((select private.is_app_user()));
+
+grant select on table public.arrivals to authenticated;
+
+-- damage_comments: Status reads comments for known damages directly.
+alter table public.damage_comments enable row level security;
+drop policy if exists damage_comments_select_app_users on public.damage_comments;
+
+create policy damage_comments_select_app_users
+on public.damage_comments
+for select
+to authenticated
+using ((select private.is_app_user()));
+
+grant select on table public.damage_comments to authenticated;
+
+-- damages_external is the source behind the BUHS lookup RPC. It remains
+-- read-only for authorized app users so the RPC can run as SECURITY INVOKER.
+alter table public.damages_external enable row level security;
+drop policy if exists damages_external_select_app_users on public.damages_external;
+
+create policy damages_external_select_app_users
+on public.damages_external
+for select
+to authenticated
+using ((select private.is_app_user()));
+
+grant select on table public.damages_external to authenticated;
+
+-- Vehicle lookup: caller privileges + RLS on public.vehicles.
+alter function public.get_vehicle_by_trimmed_regnr(text) security invoker;
+alter function public.get_vehicle_by_trimmed_regnr(text) set search_path = public;
+grant execute on function public.get_vehicle_by_trimmed_regnr(text) to authenticated, service_role;
+
+-- BUHS damage lookup: caller privileges + RLS on public.damages_external.
+alter function public.get_damages_by_trimmed_regnr(text) security invoker;
+alter function public.get_damages_by_trimmed_regnr(text) set search_path = public;
+grant execute on function public.get_damages_by_trimmed_regnr(text) to authenticated, service_role;
+
+commit;


### PR DESCRIPTION
## Syfte
Reparera det röda fyndet från Steg 3.1: direkt Supabase Data API-access som ligger vid sidan av det redan säkrade `/api`-lagret.

## Baseline
- `main`: `d1bbf5f318405028113f12c5dd162662b7065464`
- Production-schema live-verifierat 2026-08-18
- Ingen Production-DDL eller DML har körts i denna PR

## Diff
Exakt **3 migrationsfiler**:
- `migrations/20260818_lock_down_supabase_data_api.sql`
- `migrations/20260818_lock_down_supabase_data_api_defaults.sql`
- `migrations/20260818_preserve_status_read_contracts.sql`

Ingen appkod, affärslogik, dependency eller UI-förändring.

## Reparation
- återkallar browser/Data API-tabellrättigheter generellt från `PUBLIC`, `anon` och `authenticated`
- återkallar legacy-sekvensrättigheter från samma roller
- återger endast verifierade browser-kontrakt till `authenticated`
- kräver intern DB-side `whitelist OR employees.is_active` för RLS
- stänger själv-eskalering via `employees` INSERT/UPDATE
- återkallar `EXECUTE` på public-schemafunktioner från `PUBLIC`, `anon` och `authenticated`
- bevarar service-role RPC-behörighet explicit
- konverterar de tre verifierade browser-RPC:erna till `SECURITY INVOKER`: `get_all_allowed_plates`, `get_vehicle_by_trimmed_regnr`, `get_damages_by_trimmed_regnr`
- stänger legacy anon-policyer på `checkins`, `checkin_damages` och `checkin_damage_photos`
- hårdnar `postgres` default privileges för tabeller, funktioner och sekvenser

## Verifierade browser-kontrakt som bevaras
- `employees`: SELECT egen rad
- `vehicles`: SELECT
- `nybil_inventering`: SELECT/INSERT/UPDATE
- `damages`: SELECT/INSERT
- `damage_media`: SELECT
- `vehicle_edits`: SELECT
- `arrivals`: SELECT för Status
- `damage_comments`: SELECT för Status
- `damages_external`: SELECT endast som underliggande RLS-källa för BUHS-RPC
- `checkin_drafts`: SELECT egen användares drafts
- `checkins`: SELECT för Status och `get_all_allowed_plates`
- tre ovan nämnda RPC:er: EXECUTE för authenticated, nu som invoker

`checkin_damages` fortsätter via skyddat server-API i Status och får ingen browsergrant.

## Plattformsspecifik residual
Live-default ACL visar även Supabase-ägda defaults under rollen `supabase_admin`. Migrationsrollen `postgres` är inte medlem i `supabase_admin`, så PR:n försöker inte ändra dessa plattformsägda defaults och riskerar därmed inte en transaktionsrollback. Alla **befintliga** public-objekt stängs explicit. Efter Production-migration körs Security Advisor igen.

## Viktigt
Migrationerna är ännu **inte körda mot Production**. De ska först gå igenom repo-CI och därefter appliceras kontrollerat med negativa accesskontroller och read-only funktionella smoke checks. Inga write probes ska göras i Production.

**Behålla → reparera → ta bort → addera.**