### PR TITLE
Steg 3.1A: lås slutliga browser-grants

### DIFF
--- a/migrations/20260818_restore_verified_browser_grants.sql
+++ b/migrations/20260818_restore_verified_browser_grants.sql
@@ -1,0 +1,28 @@
+-- Step 3.1A ordering correction.
+--
+-- The default-hardening migration intentionally revokes broad browser grants.
+-- This final migration restores only the verified current browser contracts,
+-- with RLS from the preceding migrations remaining authoritative.
+
+begin;
+
+grant usage on schema private to authenticated, service_role;
+grant execute on function private.is_app_user() to authenticated, service_role;
+
+grant select on table public.employees to authenticated;
+grant select on table public.vehicles to authenticated;
+grant select, insert, update on table public.nybil_inventering to authenticated;
+grant select, insert on table public.damages to authenticated;
+grant select on table public.damage_media to authenticated;
+grant select on table public.vehicle_edits to authenticated;
+grant select on table public.checkin_drafts to authenticated;
+grant select on table public.checkins to authenticated;
+grant select on table public.arrivals to authenticated;
+grant select on table public.damage_comments to authenticated;
+grant select on table public.damages_external to authenticated;
+
+grant execute on function public.get_all_allowed_plates() to authenticated, service_role;
+grant execute on function public.get_vehicle_by_trimmed_regnr(text) to authenticated, service_role;
+grant execute on function public.get_damages_by_trimmed_regnr(text) to authenticated, service_role;
+
+commit;


### PR DESCRIPTION
## Syfte
Registrera den grant-only ordningskorrigering som redan verifierats i Production efter Steg 3.1A.

## Bakgrund
`20260818_lock_down_supabase_data_api_defaults.sql` återkallar breda Data API-grants efter core-migrationen. Denna sista migration ligger alfabetiskt efter övriga Steg 3.1A-filer och återger därför endast de verifierade browser-kontrakten efter hardening.

## Diff
Exakt **1 migrationsfil**:
- `migrations/20260818_restore_verified_browser_grants.sql`

Ingen appkod, RLS-logik, data, dependency eller UI ändras.

## Säkerhetsmodell
- `anon`: inga grants återges.
- `authenticated`: endast verifierade browserkontrakt återges.
- RLS `private.is_app_user()` från föregående migrationer förblir den faktiska radbehörighetsgränsen.
- känsliga `SECURITY DEFINER`-RPC:er återöppnas inte.
- endast de tre verifierade `SECURITY INVOKER`-RPC:erna får authenticated EXECUTE.

Production har redan fått motsvarande grant-only korrigering efter att read-only verifiering fångade ordningsfelet. Denna PR gör repoets migrationshistorik deterministisk med samma slutläge.

**Behålla → reparera → ta bort → addera.**