### PR TITLE
Steg 3.2A: lägg till saknade relationskontrakt

### DIFF
--- a/migrations/20260818_step_3_2a_add_missing_relation_contracts.sql
+++ b/migrations/20260818_step_3_2a_add_missing_relation_contracts.sql
@@ -1,0 +1,80 @@
+-- Step 3.2A: add the three verified missing relation contracts.
+--
+-- Production preflight 2026-08-18:
+-- - vehicle_receipts.checkin_id -> checkins.id: 126 populated, 0 orphans
+-- - damages.nybil_inventering_id -> nybil_inventering.id: 5 populated, 0 orphans
+-- - damage_comments.damage_id -> damages.id: 0 rows, 0 orphans
+-- - all six participating columns are UUID
+--
+-- The constraints are added NOT VALID first so the catalog change is short.
+-- New writes are still enforced immediately. Historical rows are validated by
+-- the separate follow-up migration after this transaction has committed.
+--
+-- RESTRICT is deliberate: check-ins, Nybil records, damages, receipts and
+-- comments are operational history/evidence and must not be cascade-deleted.
+
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- PostgreSQL does not automatically index the referencing side of a foreign
+-- key. The other two child columns already have verified indexes.
+create index if not exists idx_damages_nybil_inventering_id
+  on public.damages (nybil_inventering_id);
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.vehicle_receipts'::regclass
+      and conname = 'vehicle_receipts_checkin_id_fkey'
+  ) then
+    alter table public.vehicle_receipts
+      add constraint vehicle_receipts_checkin_id_fkey
+      foreign key (checkin_id)
+      references public.checkins (id)
+      on delete restrict
+      not valid;
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.damages'::regclass
+      and conname = 'damages_nybil_inventering_id_fkey'
+  ) then
+    alter table public.damages
+      add constraint damages_nybil_inventering_id_fkey
+      foreign key (nybil_inventering_id)
+      references public.nybil_inventering (id)
+      on delete restrict
+      not valid;
+  end if;
+end
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.damage_comments'::regclass
+      and conname = 'damage_comments_damage_id_fkey'
+  ) then
+    alter table public.damage_comments
+      add constraint damage_comments_damage_id_fkey
+      foreign key (damage_id)
+      references public.damages (id)
+      on delete restrict
+      not valid;
+  end if;
+end
+$$;
+
+commit;

--- a/migrations/20260818_step_3_2a_validate_missing_relation_contracts.sql
+++ b/migrations/20260818_step_3_2a_validate_missing_relation_contracts.sql
@@ -1,0 +1,25 @@
+-- Step 3.2A: validate the relation contracts added by the preceding migration.
+--
+-- Each validation runs in its own short transaction. The lock timeout makes
+-- the migration fail safely instead of waiting behind live Production traffic.
+
+begin;
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+alter table public.vehicle_receipts
+  validate constraint vehicle_receipts_checkin_id_fkey;
+commit;
+
+begin;
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+alter table public.damages
+  validate constraint damages_nybil_inventering_id_fkey;
+commit;
+
+begin;
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+alter table public.damage_comments
+  validate constraint damage_comments_damage_id_fkey;
+commit;


### PR DESCRIPTION
## Syfte

Steg 3.2A reparerar de tre relationer som Steg 3.1 identifierade som logiska men inte databastvingade, utan att ändra appens beteende eller Production-data.

## Production-preflight 2026-08-18

| Relation | Populerade referenser | Orphans | Typ |
|---|---:|---:|---|
| `vehicle_receipts.checkin_id → checkins.id` | 126 | 0 | UUID → UUID |
| `damages.nybil_inventering_id → nybil_inventering.id` | 5 | 0 | UUID → UUID |
| `damage_comments.damage_id → damages.id` | 0 | 0 | UUID → UUID |

Exakta radantal verifierades separat: 3 748 `checkins`, 126 `vehicle_receipts`, 1 372 `damages`, 195 `nybil_inventering` och 0 `damage_comments`.

## Ändring

Exakt två SQL-filer:

1. lägger till det saknade indexet på `damages.nybil_inventering_id` och tre FK-kontrakt som `NOT VALID`,
2. validerar varje FK i en separat kort transaktion.

`vehicle_receipts.checkin_id` och `damage_comments.damage_id` har redan index.

Alla tre relationer använder `ON DELETE RESTRICT`. Det är avsiktligt: check-ins, Nybil-rader, skador, kvitton och kommentarer är verksamhetshistorik/evidens och ska inte kunna cascade-raderas.

## Driftsäkerhet

- `lock_timeout = 5s`: migrationen avbryts i stället för att vänta bakom live-trafik.
- `statement_timeout = 30s`: ingen DDL får hänga.
- `NOT VALID` gör katalogändringen kort; nya writes omfattas direkt.
- Historiken valideras först efter att constraint-migrationen har committat.
- Migrationerna är additiva och kräver ingen apprelease för kompatibilitet.
- Ingen DML, DROP, dataradering eller write probe har gjorts.

## Regression

- Check: incheckningens serverflöde kan fortsatt skapa `vehicle_receipts` med giltigt `checkin_id`.
- Nybil: `nybil_inventering` kan skapas och efterföljande `damages` kan referera till dess UUID.
- Status: befintliga skador och historik laddar; skadekommentar-API accepterar endast ett verkligt `damages.id`.
- Ankomst: läs-/skrivflödet är opåverkat.

## Production-resultat 2026-08-18

- PR #321 mergad: `8f7dbc4b0a00ee03fe3e8021b8e4816c9562af34`.
- Migration `20260818131815 step_3_2a_add_missing_relation_contracts` applicerad.
- Mellanverifiering: tre constraints fanns som `NOT VALID`, indexet var giltigt, 0 orphans och oförändrade radantal.
- Migration `20260818131844 step_3_2a_validate_missing_relation_contracts` applicerad.
- Slutverifiering: samtliga tre constraints är `convalidated=true` med `ON DELETE RESTRICT`.
- `idx_damages_nybil_inventering_id` är `indisready=true` och `indisvalid=true`.
- Radantal efter migration: 3 748 checkins, 126 vehicle_receipts, 1 372 damages, 195 nybil_inventering, 0 damage_comments.
- 0 orphans i alla tre relationer.
- Accessgränsen är oförändrad: anon har inga public-tabellgrants; authenticated har fortsatt 11 SELECT-, 2 INSERT- och 1 UPDATE-grants.
- Security/Performance Advisor visar inga nya varningar för de tre relationerna.
- Ingen DML, DROP, dataradering eller write probe gjordes.
