### PR TITLE
Steg 3.2B-1: gör damages till enda BUHS-källa

### DIFF
--- a/docs/wiki/CSV-import-skador - gör så här.md
+++ b/docs/wiki/CSV-import-skador - gör så här.md
@@ -1,6 +1,6 @@
 # CSV-import:  BUHS Skadedata
 
-**Senast uppdaterad:** 2026-01-16  
+**Senast uppdaterad:** 2026-08-18  
 **Författare:** System Documentation  
 **Relaterade filer:** `docs/wiki/Database.md`, `docs/wiki/database-constraints.md`
 
@@ -12,7 +12,7 @@ Denna guide beskriver hur du importerar BUHS skadedata från CSV-fil till produk
 
 **Källa:** MABI BUHS-system (manuell CSV-export)  
 **Frekvens:** Vid behov (när nya skador tillkommit i BUHS)  
-**Målformat:** `public.damages` + `public.damages_external`
+**Målformat:** `public.damages`
 
 ---
 
@@ -119,41 +119,28 @@ DO UPDATE SET
 
 ---
 
-### **STEG 4: Synkronisera damages_external**
+### **STEG 4: Verifiera RPC-läsningen**
 
-Kör denna SQL för att uppdatera externa skador:
+Efter Steg 3.2B-1 läser `get_damages_by_trimmed_regnr` BUHS-projektionen direkt från `damages WHERE source = 'BUHS'`.
+
+**Kör inte `TRUNCATE` eller `INSERT` mot `damages_external`.** Tabellen är endast en oförändrad rollback-snapshot under verifieringsperioden.
 
 ```sql
--- Töm och återskapa damages_external
-TRUNCATE public.damages_external;
-
-INSERT INTO public.damages_external (
-  regnr,
-  saludatum,
-  damage_date,
-  damage_type_raw,
-  note_customer,
-  note_internal,
-  vehiclenote
-)
-SELECT 
-  regnr,
-  saludatum,
-  damage_date,
-  damage_type_raw,
-  note_customer,
-  note_internal,
-  vehiclenote
-FROM public.damages
-WHERE source = 'BUHS';
-
--- Verifiera att antal matchar
-SELECT 
-  (SELECT COUNT(*) FROM public.damages_external) as damages_external_count,
-  (SELECT COUNT(*) FROM public.damages WHERE source = 'BUHS') as damages_buhs_count;
+-- Byt ut ABC123 mot ett registreringsnummer från importen.
+SELECT
+  (
+    SELECT COUNT(*)
+    FROM public.damages
+    WHERE source = 'BUHS'
+      AND TRIM(UPPER(regnr)) = TRIM(UPPER('ABC123'))
+  ) AS canonical_count,
+  (
+    SELECT COUNT(*)
+    FROM public.get_damages_by_trimmed_regnr('ABC123')
+  ) AS rpc_count;
 ```
 
-**Förväntat:** Båda kolumnerna visar samma antal
+**Förväntat:** `canonical_count = rpc_count`.
 
 ---
 
@@ -242,10 +229,10 @@ BUHS CSV-fil
 mabi_damage_data_raw_new (staging)
     ↓ (dedup + upsert)
 damages (legacy_damage_source_text = 'buhs_csv_import|.. .')
-    ↓ (filter WHERE source='BUHS')
-damages_external
+    ↓ (RPC filter WHERE source='BUHS')
+get_damages_by_trimmed_regnr
     ↓
-/check API (lib/damages. ts - loose matching)
+/check och /status
 ```
 
 ---
@@ -277,7 +264,7 @@ damages_external
 - [ ] CSV importerad till `mabi_damage_data_raw_new`
 - [ ] Deduplicering körd
 - [ ] Upsert till `damages` körd
-- [ ] `damages_external` synkroniserad
+- [ ] RPC-resultatet verifierat mot `damages WHERE source = 'BUHS'`
 - [ ] Verifieringsfrågor körda
 - [ ] Testning i `/check` genomförd
 - [ ] Antal skador dokumenterat i changelog

--- a/docs/wiki/CSV-import.md
+++ b/docs/wiki/CSV-import.md
@@ -202,44 +202,29 @@ ORDER BY damage_date DESC;
 
 ---
 
-### Steg 7: Uppdatera damages_external (RPC-källa)
+### Steg 7: Verifiera RPC-läsningen
 
-**OBS! `/check` läser BUHS-skador från `damages_external` via RPC `get_damages_by_trimmed_regnr`**
+Efter Steg 3.2B-1 läser `get_damages_by_trimmed_regnr` BUHS-projektionen direkt från `damages WHERE source = 'BUHS'`.
+
+**Skriv inte till `damages_external`.** Tabellen behålls oförändrad som rollback-snapshot under verifieringsperioden.
 
 ```sql
--- Töm damages_external
-TRUNCATE public.damages_external;
-
--- Kopiera alla BUHS-skador från damages
-INSERT INTO public.damages_external (
-  regnr,
-  saludatum,
-  damage_date,
-  damage_type_raw,
-  note_customer,
-  note_internal,
-  vehiclenote
-)
-SELECT 
-  regnr,
-  saludatum,
-  damage_date,
-  damage_type_raw,
-  note_customer,
-  note_internal,
-  vehiclenote
-FROM public.damages
-WHERE source = 'BUHS';
+-- Kontrollera ett registreringsnummer från importen.
+-- Byt ut SAM31A mot ett registreringsnummer som finns i CSV-filen.
+SELECT
+  (
+    SELECT COUNT(*)
+    FROM public.damages
+    WHERE source = 'BUHS'
+      AND TRIM(UPPER(regnr)) = TRIM(UPPER('SAM31A'))
+  ) AS canonical_count,
+  (
+    SELECT COUNT(*)
+    FROM public.get_damages_by_trimmed_regnr('SAM31A')
+  ) AS rpc_count;
 ```
 
-**Verifiera:**
-```sql
-SELECT COUNT(*) FROM public.damages_external;
--- Ska matcha antalet BUHS-skador i damages
-
-SELECT COUNT(*) FROM public.damages WHERE source = 'BUHS';
--- Dessa två COUNT ska vara samma! 
-```
+**Förväntat:** `canonical_count = rpc_count`.
 
 ---
 
@@ -414,7 +399,7 @@ SELECT source, COUNT(*) FROM public.damages GROUP BY source;
 - [ ] Dubbletter raderade i staging
 - [ ] UPSERT till huvudtabell klar (damages / vehicles)
 - [ ] Verifiering klar (rätt antal rader, rätt source för BUHS, legacy_damage_source_text ifylld)
-- [ ] `damages_external` uppdaterad (endast för Skadefil)
+- [ ] RPC-resultatet verifierat mot `damages WHERE source = 'BUHS'` (endast för Skadefil)
 - [ ] Testregistreringsnummer kontrollerat i `/check` och `/status`
 
 ---

--- a/docs/wiki/Database.md
+++ b/docs/wiki/Database.md
@@ -31,7 +31,7 @@ Systemet använder Supabase (PostgreSQL) med följande huvudtabeller:
 | `checkins` | Incheckningar av fordon | `/check`-formulär |
 | `checkin_damages` | Skador kopplade till specifik incheckning | `/check`-formulär |
 | `damages` | Konsoliderad skadehistorik per fordon | `/check`, `/nybil`, CSV-import |
-| `damages_external` | BUHS-skador (Skadefilen) - RPC-källa | CSV-import (manuell) |
+| `damages_external` | Rollback-snapshot från före Steg 3.2B-1; inte live-källa | Ingen löpande skrivning |
 | `nybil_inventering` | Nybilsregistreringar vid leverans | `/nybil`-formulär |
 | `vehicles` | Fordonsmaster från Bilkontroll | CSV-import (manuell) |
 
@@ -260,30 +260,21 @@ database-constraints.md - Unique constraint på detta fält
 
 ### damages_external
 
-**Skadefilen från BUHS** - importerad CSV med legacy-skador.  Denna tabell är källan för BUHS-skador som hämtas via RPC-funktionen `get_damages_by_trimmed_regnr`.
+Tabellen innehåller den BUHS-snapshot som fanns när Steg 3.2B-1 förbereddes. Den behålls oförändrad under verifieringsperioden eftersom RPC:ns returtyp fortfarande är `SETOF damages_external`.
+
+Live-data hämtas inte längre från tabellraderna. `get_damages_by_trimmed_regnr` projicerar samma sju kolumner från `damages WHERE source = 'BUHS'`.
 
 | Kolumn | Typ | Nullable | Beskrivning |
 |--------|-----|----------|-------------|
-| `regnr` | text | NO | Registreringsnummer (primärnyckel, UPPERCASE) |
+| `regnr` | text | NO | Registreringsnummer |
 | `saludatum` | date | YES | Saludatum |
 | `damage_date` | date | YES | Skadedatum |
-| `damage_type_raw` | text | YES | Skadetyp (t.ex. "Repa", "Spricka") |
+| `damage_type_raw` | text | YES | Skadetyp |
 | `note_customer` | text | YES | Kundnotering |
 | `note_internal` | text | YES | Intern notering |
 | `vehiclenote` | text | YES | Fordonsnotering |
 
-**Viktigt:** 
-- Denna tabell uppdateras genom manuell CSV-import.   
-- Den innehåller ~566 rader (januari 2026).
-- **MÅSTE** synkroniseras med `damages`-tabellen efter varje BUHS-import!  
-
-**Synkronisering:**
-```sql
-TRUNCATE damages_external;
-INSERT INTO damages_external SELECT ...  FROM damages WHERE source = 'BUHS';
-```
-
-**Se:** [CSV-import. md § 2 Steg 7](./CSV-import.md#steg-7-uppdatera-damages_external-rpc-källa)
+**Driftregel:** skriv inte, töm inte och synkronisera inte `damages_external`. BUHS-importen skriver endast till `damages`.
 
 ---
 
@@ -472,16 +463,15 @@ get_vehicle_by_trimmed_regnr(p_regnr text)
 
 ### get_damages_by_trimmed_regnr
 
-Hämtar BUHS-skador från `damages_external`-tabellen för ett fordon.
+Hämtar BUHS-skador från den kanoniska `damages`-tabellen.
 
 ```sql
 get_damages_by_trimmed_regnr(p_regnr text)
 ```
 
-**Returnerar:** Alla rader från `damages_external` där `TRIM(UPPER(regnr)) = TRIM(UPPER(p_regnr))`
+**Returnerar:** De sju befintliga RPC-fälten för rader där `source = 'BUHS'` och `TRIM(UPPER(regnr)) = TRIM(UPPER(p_regnr))`.
 
-**Viktigt:** Denna RPC hämtar endast från `damages_external`, INTE från `damages`!   
-→ `damages_external` måste uppdateras efter varje BUHS-import! 
+RPC-signaturen är fortsatt `SETOF damages_external` för att bevara browserkontraktet, men tabellraderna i `damages_external` används inte som live-källa.
 
 ---
 
@@ -500,14 +490,14 @@ get_damages_by_trimmed_regnr(p_regnr text)
 
 ### Vid /status-sökning
 
-1. Hämtar data från:  `nybil_inventering`, `vehicles`, `damages`, `checkins`, `checkin_damages`, `damages_external` (via RPC)
+1. Hämtar data från: `nybil_inventering`, `vehicles`, `damages`, `checkins`, `checkin_damages` samt BUHS-projektionen via RPC
 2. Prioritetsordning för fordonsinfo: `checkins` (senaste) → `nybil_inventering` → `vehicles`
-3. Skador hämtas från både `damages` och `damages_external` (BUHS via RPC)
+3. Alla skador hämtas från `damages`; BUHS-delen filtreras via RPC
 
 ### Vid /check-sökning (faktarutan)
 
 1. Hämtar fordonsinfo via `get_vehicle_by_trimmed_regnr` (från `vehicles`)
-2. Hämtar BUHS-skador via `get_damages_by_trimmed_regnr` (från `damages_external`)
+2. Hämtar BUHS-skador via `get_damages_by_trimmed_regnr` (från `damages WHERE source = 'BUHS'`)
 3. Hämtar dokumenterade skador från `damages` (för att avgöra `is_inventoried`)
 4. Hämtar senaste `checkin_damages` för att visa hanteringsstatus
 
@@ -728,18 +718,19 @@ ORDER BY cd.created_at DESC;
 
 ### Kontrollera om BUHS-skador skulle hanteras av datum-logik
 ```sql
-SELECT 
-  de.regnr,
-  de.damage_date as buhs_datum,
-  c.completed_at as senaste_incheckning,
-  CASE 
-    WHEN c.completed_at > de.damage_date THEN 'Datum-backup aktiveras ✅'
+SELECT
+  d.regnr,
+  d.damage_date AS buhs_datum,
+  c.completed_at AS senaste_incheckning,
+  CASE
+    WHEN c.completed_at > d.damage_date THEN 'Datum-backup aktiveras ✅'
     ELSE 'Förlitar sig på textmatchning'
-  END as status
-FROM damages_external de
-JOIN checkins c ON UPPER(TRIM(de.regnr)) = UPPER(TRIM(c.regnr))
-WHERE de.regnr = 'ABC123'
-ORDER BY de.damage_date;
+  END AS status
+FROM damages d
+JOIN checkins c ON UPPER(TRIM(d.regnr)) = UPPER(TRIM(c.regnr))
+WHERE d.source = 'BUHS'
+  AND d.regnr = 'ABC123'
+ORDER BY d.damage_date;
 ```
 
 ### Kontrollera source-distribution i damages
@@ -753,7 +744,7 @@ GROUP BY source;
 ```
 CHECK | ~X antal
 NYBIL | ~Y antal
-BUHS  | ~566 antal (ska matcha damages_external)
+BUHS  | aktuellt antal i den kanoniska källan
 ```
 
 ### Hitta dubbletter (samma skada från flera källor)

--- a/docs/wiki/OVERVIEW.md
+++ b/docs/wiki/OVERVIEW.md
@@ -99,11 +99,11 @@ MABI Syd Incheckningssystem är ett internt verktyg för att hantera:
 **Användare:** Per (endast)
 
 **Funktioner:**
-- 📂 **Skadefilen (BUHS):** Import av skador från Excel → `damages` + `damages_external`
+- 📂 **Skadefilen (BUHS):** Import av skador från Excel → `damages`
 - 📂 **Bilkontrollfilen:** Import av bilinfo från Excel → `vehicles`
 
 **Output:**
-- Rader i: `damages`, `damages_external`, `vehicles`
+- Rader i: `damages`, `vehicles`
 
 **Dokumentation:** [CSV-import. md](./docs/wiki/CSV-import.md)
 
@@ -186,7 +186,7 @@ graph TD
 │                                                              │
 │  📧 BUHS Skadefil (Excel)                                    │
 │  └─> Mejlas till per. andersson@mabi.se varje vardag kl 8    │
-│  └─> Manuell import → damages + damages_external            │
+│  └─> Manuell import → damages                               │
 │                                                              │
 │  📊 Bilkontrollfilen (Excel)                                 │
 │  └─> MABISYD Bilkontroll 2024-2025. xlsx (OneDrive)          │
@@ -194,7 +194,7 @@ graph TD
 │                                                              │
 │  🔌 BUHS API (automatisk vid /check)                         │
 │  └─> Hämtar skador via RPC get_damages_by_trimmed_regnr     │
-│  └─> Källa: damages_external                                │
+│  └─> Källa: damages WHERE source='BUHS'                    │
 │                                                              │
 │  🚗 Vehicle API (planerad, ej implementerad)                 │
 │  └─> Hämta bilinfo från Transportstyrelsen                  │
@@ -210,7 +210,7 @@ graph TD
 │  📦 checkins              (incheckningar)                    │
 │  📦 checkin_damages       (skador vid incheckning)           │
 │  📦 damages               (konsoliderad skadehistorik)       │
-│  📦 damages_external      (BUHS-skador, RPC-källa)           │
+│  📦 damages_external      (rollback-snapshot, ej live-källa)│
 │  📦 nybil_inventering     (nybilsregistreringar)             │
 │  📦 vehicles              (fordonsmaster från Bilkontroll)   │
 │                                                              │
@@ -459,7 +459,7 @@ Innehåller fullständig historik av utvecklingskonversationer med AI-assistent.
 1. Öppna `Skador Albarone[dagens datum].xlsx`
 2. Följ [CSV-import.md § 1-2](./docs/wiki/CSV-import.md)
 3. Verifiera antal rader
-4. Uppdatera `damages_external`
+4. Verifiera BUHS-RPC mot `damages WHERE source='BUHS'`
 
 **Tidsåtgång:** ~10 minuter
 

--- a/docs/wiki/Operations.md
+++ b/docs/wiki/Operations.md
@@ -37,7 +37,7 @@
 1. **Importera CSV** → Supabase Table Editor → `mabi_damage_data_raw_new`
 2. **Kör dedup-SQL** - Ta bort exakta dubbletter
 3. **Kör upsert-SQL** - Importera till `damages` med unik `legacy_damage_source_text`
-4. **Synka `damages_external`** - TRUNCATE + INSERT från `damages WHERE source='BUHS'`
+4. **Verifiera BUHS-RPC** - jämför RPC-resultatet med `damages WHERE source='BUHS'`; skriv inte till `damages_external`
 5. **Verifiera** - Kör verifieringsfrågor (antal, senaste import, inga dubbletter)
 6. **Testa** - Öppna `/check` med ett regnr från CSV: en
 

--- a/docs/wiki/troubleshooting.md
+++ b/docs/wiki/troubleshooting.md
@@ -230,30 +230,29 @@ SELECT source, COUNT(*) FROM damages GROUP BY source;
 
 ---
 
-### ❌ Antal rader i `damages` ≠ antal rader i `damages_external`
+### ❌ RPC-resultatet saknar BUHS-skador efter import
 
-**Orsak:** Glömt uppdatera `damages_external` efter BUHS-import.
+**Orsak:** BUHS-raderna har inte skrivits korrekt till `damages`, eller så saknar de `source = 'BUHS'`.
 
-**Lösning:**
+Efter Steg 3.2B-1 är `damages` den enda aktiva BUHS-källan. **Kör inte `TRUNCATE` eller `INSERT` mot `damages_external`.**
+
+**Verifiering:**
 ```sql
--- Töm och återskapa damages_external
-TRUNCATE damages_external;
-
-INSERT INTO damages_external (
-  regnr, saludatum, damage_date, damage_type_raw,
-  note_customer, note_internal, vehiclenote
-)
-SELECT 
-  regnr, saludatum, damage_date, damage_type_raw,
-  note_customer, note_internal, vehiclenote
-FROM damages
-WHERE source = 'BUHS';
-
--- Verifiera
-SELECT COUNT(*) FROM damages WHERE source = 'BUHS';
-SELECT COUNT(*) FROM damages_external;
--- Båda ska vara samma! 
+-- Byt ut ABC123 mot ett registreringsnummer från importen.
+SELECT
+  (
+    SELECT COUNT(*)
+    FROM public.damages
+    WHERE source = 'BUHS'
+      AND TRIM(UPPER(regnr)) = TRIM(UPPER('ABC123'))
+  ) AS canonical_count,
+  (
+    SELECT COUNT(*)
+    FROM public.get_damages_by_trimmed_regnr('ABC123')
+  ) AS rpc_count;
 ```
+
+**Förväntat:** `canonical_count = rpc_count`. Om båda är 0 ligger felet i importen till `damages`.
 
 ---
 

--- a/migrations/20260818_step_3_2b_reroute_buhs_lookup.sql
+++ b/migrations/20260818_step_3_2b_reroute_buhs_lookup.sql
@@ -1,0 +1,104 @@
+-- Step 3.2B-1: make public.damages the only live BUHS source.
+--
+-- This preserves the existing browser RPC name, argument, return composite
+-- type, column order, SECURITY INVOKER mode, and execute grants.
+-- public.damages_external remains untouched as a rollback snapshot.
+
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Abort instead of switching source if the rollback snapshot has drifted from
+-- the canonical BUHS projection at migration time.
+do $$
+begin
+  if exists (
+    select 1
+    from (
+      (
+        select
+          regnr,
+          saludatum,
+          damage_date,
+          damage_type_raw,
+          note_customer,
+          note_internal,
+          vehiclenote
+        from public.damages_external
+
+        except all
+
+        select
+          regnr,
+          saludatum,
+          damage_date,
+          damage_type_raw,
+          note_customer,
+          note_internal,
+          vehiclenote
+        from public.damages
+        where source = 'BUHS'
+      )
+
+      union all
+
+      (
+        select
+          regnr,
+          saludatum,
+          damage_date,
+          damage_type_raw,
+          note_customer,
+          note_internal,
+          vehiclenote
+        from public.damages
+        where source = 'BUHS'
+
+        except all
+
+        select
+          regnr,
+          saludatum,
+          damage_date,
+          damage_type_raw,
+          note_customer,
+          note_internal,
+          vehiclenote
+        from public.damages_external
+      )
+    ) as drift
+  ) then
+    raise exception
+      'Step 3.2B-1 aborted: damages_external differs from damages source=BUHS';
+  end if;
+end
+$$;
+
+create or replace function public.get_damages_by_trimmed_regnr(p_regnr text)
+returns setof public.damages_external
+language sql
+security invoker
+set search_path = public
+as $function$
+  select
+    d.regnr,
+    d.saludatum,
+    d.damage_date,
+    d.damage_type_raw,
+    d.note_customer,
+    d.note_internal,
+    d.vehiclenote
+  from public.damages as d
+  where d.source = 'BUHS'
+    and trim(upper(d.regnr)) = trim(upper(p_regnr));
+$function$;
+
+grant execute
+on function public.get_damages_by_trimmed_regnr(text)
+to authenticated, service_role;
+
+comment on function public.get_damages_by_trimmed_regnr(text) is
+  'Returns the BUHS projection from canonical public.damages; Step 3.2B-1.';
+
+commit;


### PR DESCRIPTION
## Syfte

Steg 3.2B-1 gör `public.damages` till enda aktiva BUHS-källa utan att ändra browserkontraktet eller röra rollback-datan i `public.damages_external`.

## Rotorsak

BUHS-importen skriver först till `damages` och kräver därefter en manuell `TRUNCATE + INSERT` till `damages_external`. Det skapar två samtidiga källor som kan glida isär.

## Diff

- en migration: `migrations/20260818_step_3_2b_reroute_buhs_lookup.sql`
- sex uppdaterade drift-/databastexter
- ingen appkod eller dependency ändras

Migrationen:

1. avbryter om de sju BUHS-fälten skiljer sig mellan tabellerna,
2. behåller exakt samma RPC-namn, parameter, returtyp och kolumnordning,
3. behåller `SECURITY INVOKER` och befintliga execute-grants,
4. ändrar endast RPC-kroppen till `damages WHERE source = 'BUHS'`.

## Färsk Production-preflight

- `damages WHERE source='BUHS'`: **727** rader
- `damages_external`: **727** rader
- symmetrisk `EXCEPT ALL`: **0** avvikande rader
- samtliga **292** BUHS-fordon har samma resultat
- aktuell RPC är `SECURITY INVOKER`
- `authenticated` har fortsatt endast det redan verifierade RPC-/RLS-kontraktet
- senaste API-loggarna visar RPC-anrop men inga direkta REST-anrop till `damages_external`

## Säkerhet och reversibilitet

- ingen `DROP`
- ingen `TRUNCATE`
- ingen `INSERT`, `UPDATE` eller `DELETE`
- inga tabellgrants eller RLS-policies ändras
- `damages_external` lämnas med sina 727 rader som oförändrad rollback-snapshot
- migrationen använder korta timeouts och stoppar vid datadrift

Rollback är en ren `CREATE OR REPLACE FUNCTION` tillbaka till den tidigare tabelläsningen.

## Verifierat i PR-steget

- exakt dataekvivalens i Production via read-only SQL
- RPC-signatur, returtyp, kolumnordning, säkerhetsläge och grants
- repokonsumenterna använder RPC:n; ingen direkt runtime-läsning av tabellen hittades
- samtliga kända driftinstruktioner för manuell dubbelskrivning är borttagna
- diffen innehåller ingen destruktiv SQL

## Efter separat Production-godkännande

Applicera migrationen och verifiera först `/status` och `/check` med befintliga fordon. Ingen radering av rollback-snapshot ingår i detta steg.
