### PR TITLE
Steg 3.2C-1: centralisera stationskontraktet

### DIFF
--- a/app/ankomst/form-client.tsx
+++ b/app/ankomst/form-client.tsx
@@ -11,6 +11,10 @@ import { supabase } from '@/lib/supabase';
 const MABI_LOGO_URL = "https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/MABI%20Syd%20logga/MABI%20Syd%20logga%202.png";
 const BACKGROUND_IMAGE_URL = "https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/Svart%20bakgrund%20MB%20grill/MB%20front%20grill%20logo.jpg";
 
+const capitalizeFirstLetter = (str: string): string => {
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+};
+
 const getFirstNameFromEmail = (email: string): string => {
   const namePart = email.split('@')[0];
   const firstName = namePart.split('.')[0];

--- a/app/ankomst/form-client.tsx
+++ b/app/ankomst/form-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState, useCallback, useRef, Fragment } from 'react';
+import { ORTER, STATIONER } from '@/lib/constants';
 import { supabase } from '@/lib/supabase';
 
 // =================================================================
@@ -9,23 +10,6 @@ import { supabase } from '@/lib/supabase';
 
 const MABI_LOGO_URL = "https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/MABI%20Syd%20logga/MABI%20Syd%20logga%202.png";
 const BACKGROUND_IMAGE_URL = "https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/Svart%20bakgrund%20MB%20grill/MB%20front%20grill%20logo.jpg";
-
-const ORTER = ['Malmö', 'Helsingborg', 'Ängelholm', 'Halmstad', 'Falkenberg', 'Trelleborg', 'Varberg', 'Lund'].sort();
-
-const STATIONER: Record<string, string[]> = {
-  'Falkenberg': ['Falkenberg'],
-  'Halmstad': ['BVH (Hedin multi)', 'Flyget Halmstad', 'FORD Halmstad', 'KIA Halmstad', 'MB Halmstad'],
-  'Helsingborg': ['B/S Klippan', 'BMW Helsingborg', 'Euromaster Helsingborg', 'FORD Helsingborg', 'HBSC Helsingborg', 'KIA Helsingborg', 'MB Helsingborg', 'S. Jönsson', 'Transport Helsingborg'],
-  'Lund': ['B/S Lund', 'FORD Lund', 'Hedin Lund', 'P7 Revinge'],
-  'Malmö': ['FORD Malmö', 'Hedbergs Malmö', 'Hedin Automotive Burlöv', 'Malmö Automera', 'MB Malmö', 'Mechanum', 'Sturup', 'Werksta Malmö Hamn', 'Werksta St Bernstorp'],
-  'Trelleborg': ['Trelleborg'],
-  'Varberg': ['Autoklinik (Sällstorp)', 'Finnveden plåt', 'FORD Varberg', 'MB Varberg', 'Varberg multi (Hedin)'],
-  'Ängelholm': ['Flyget Ängelholm', 'FORD Ängelholm', 'Mekonomen Ängelholm']
-};
-
-const capitalizeFirstLetter = (str: string): string => {
-  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
-};
 
 const getFirstNameFromEmail = (email: string): string => {
   const namePart = email.split('@')[0];

--- a/app/api/notify-arrival/legacy-handler.ts
+++ b/app/api/notify-arrival/legacy-handler.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { createClient } from '@supabase/supabase-js';
+import { getHuvudstationRecipients } from '@/lib/constants';
 
 // =================================================================
 // 1. INITIALIZATION & CONFIGURATION
@@ -11,20 +12,6 @@ const resend = new Resend(process.env.RESEND_API_KEY || 'placeholder');
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co';
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || 'placeholder';
 const supabaseAdmin = createClient(supabaseUrl, supabaseServiceRoleKey);
-
-// --- E-postmottagare ---
-const defaultHuvudstationAddress = 'per@incheckad.se';
-
-const stationEmailMapping: { [ort: string]: string } = {
-  Helsingborg: 'helsingborg@incheckad.se',
-  Ängelholm: 'helsingborg@incheckad.se',
-  Varberg: 'varberg@incheckad.se',
-  Malmö: 'malmo@incheckad.se',
-  Trelleborg: 'trelleborg@incheckad.se',
-  Lund: 'lund@incheckad.se',
-  Halmstad: 'halmstad@incheckad.se',
-  Falkenberg: 'falkenberg@incheckad.se',
-};
 
 const LOGO_URL =
   'https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/MABI%20Syd%20logga/MABI%20Syd%20logga%202.png';
@@ -262,11 +249,7 @@ export async function POST(request: Request) {
 
     // --- 3. Build email recipients ---
     const finalOrt = payload.current_city || '';
-    const huvudstationTo = [defaultHuvudstationAddress];
-    const stationSpecificEmail = stationEmailMapping[finalOrt];
-    if (stationSpecificEmail && !huvudstationTo.includes(stationSpecificEmail)) {
-      huvudstationTo.push(stationSpecificEmail);
-    }
+    const huvudstationTo = getHuvudstationRecipients(finalOrt);
 
     // --- 4. Build subject ---
     const cleanStation = payload.current_station || finalOrt || '---';

--- a/app/api/notify/legacy-handler.ts
+++ b/app/api/notify/legacy-handler.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { createClient } from '@supabase/supabase-js';
 import { normalizeDamageType } from './normalizeDamageType';
+import { getHuvudstationRecipients } from '@/lib/constants';
 
 // =================================================================
 // 1. INITIALIZATION & CONFIGURATION
@@ -11,20 +12,6 @@ const resend = new Resend(process.env.RESEND_API_KEY || 'placeholder');
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co';
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || 'placeholder';
 const supabaseAdmin = createClient(supabaseUrl, supabaseServiceRoleKey);
-
-// --- E-postmottagare ---
-const defaultHuvudstationAddress = 'per@incheckad.se';
-
-const stationEmailMapping: { [ort: string]: string } = {
-  Helsingborg: 'helsingborg@incheckad.se',
-  Ängelholm: 'helsingborg@incheckad.se',
-  Varberg: 'varberg@incheckad.se',
-  Malmö: 'malmo@incheckad.se',
-  Trelleborg: 'trelleborg@incheckad.se',
-  Lund: 'lund@incheckad.se',
-  Halmstad: 'halmstad@incheckad.se',
-  Falkenberg: 'falkenberg@incheckad.se',
-};
 
 const getSiteUrl = (request: Request): string => {
   if (process.env.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL;
@@ -713,11 +700,7 @@ export async function POST(request: Request) {
 
    // Mottagare/ämnen
     const finalOrt = payload.bilen_star_nu?.ort || payload.ort;
-    const huvudstationTo = [defaultHuvudstationAddress];
-    const stationSpecificEmail = stationEmailMapping[finalOrt];
-    if (stationSpecificEmail && !huvudstationTo.includes(stationSpecificEmail)) {
-      huvudstationTo.push(stationSpecificEmail);
-    }
+    const huvudstationTo = getHuvudstationRecipients(finalOrt);
 
     // Bilkontroll recipients: Per always, Latif always (alla orter)
     const bilkontrollTo = ['per@incheckad.se', 'latif@incheckad.se'];

--- a/app/check/form-client.tsx
+++ b/app/check/form-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState, useCallback, useRef, Fragment } from 'react';
+import { ORTER, STATIONER } from '@/lib/constants';
 import { supabase } from '@/lib/supabase';
 import { VehicleInfo, ConsolidatedDamage } from '@/lib/damages';
 import { notifyCheckin } from '@/lib/notify';
@@ -16,19 +17,6 @@ import { formatDamageTypeSwedish } from '@/lib/damage-type-mapping';
 const MABI_LOGO_URL = "https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/MABI%20Syd%20logga/MABI%20Syd%20logga%202.png";
 // keep background image reference but don't change UI behavior
 const BACKGROUND_IMAGE_URL = "https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/Svart%20bakgrund%20MB%20grill/MB%20front%20grill%20logo.jpg";
-
-const ORTER = ['Malmö', 'Helsingborg', 'Ängelholm', 'Halmstad', 'Falkenberg', 'Trelleborg', 'Varberg', 'Lund'].sort();
-
-const STATIONER: Record<string, string[]> = {
-  'Falkenberg': ['Falkenberg'],
-  'Halmstad': ['BVH (Hedin multi)', 'Flyget Halmstad', 'FORD Halmstad', 'KIA Halmstad', 'MB Halmstad'],
-  'Helsingborg': ['B/S Klippan', 'BMW Helsingborg', 'Euromaster Helsingborg', 'FORD Helsingborg', 'HBSC Helsingborg', 'KIA Helsingborg', 'MB Helsingborg', 'S. Jönsson', 'Transport Helsingborg'],
-  'Lund': ['B/S Lund', 'FORD Lund', 'Hedin Lund', 'P7 Revinge'],
-  'Malmö': ['FORD Malmö', 'Hedbergs Malmö', 'Hedin Automotive Burlöv', 'Malmö Automera', 'MB Malmö', 'Mechanum', 'Sturup', 'Werksta Malmö Hamn', 'Werksta St Bernstorp'],
-  'Trelleborg': ['Trelleborg'],
-  'Varberg': ['Autoklinik (Sällstorp)', 'Finnveden plåt', 'FORD Varberg', 'MB Varberg', 'Varberg multi (Hedin)'],
-  'Ängelholm': ['Flyget Ängelholm', 'FORD Ängelholm', 'Mekonomen Ängelholm']
-};
 
 const DAMAGE_TYPES = Object.keys(DAMAGE_OPTIONS).sort((a, b) => a.localeCompare(b, 'sv'));
 

--- a/app/nybil/form-client.tsx
+++ b/app/nybil/form-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useMemo } from 'react';
-import { BILMARKEN, FUEL_TYPES, ORTER } from '@/lib/constants';
+import { BILMARKEN, FUEL_TYPES, HUVUDSTATIONER, ORTER, STATIONER } from '@/lib/constants';
 import { supabase } from '@/lib/supabase';
 import { DAMAGE_OPTIONS, DAMAGE_TYPES } from '@/data/damage-options';
 import ImageAnnotator from '@/components/ImageAnnotator';
@@ -10,31 +10,6 @@ import { compressImage } from '@/lib/image-utils';
 // Constants
 const MABI_LOGO_URL = "https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/MABI%20Syd%20logga/MABI%20Syd%20logga%202.png";
 const BACKGROUND_IMAGE_URL = "https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/Silver%20logo%20white%20bkgrd/MB-logo-white-logo.jpg";
-
-// ORTER importeras nu från lib/constants.ts (delas med /status-editering).
-
-// Huvudstationer for Planerad Station and Saluinfo
-const HUVUDSTATIONER = [
-  { name: 'Falkenberg', id: 282 },
-  { name: 'Halmstad', id: 274 },
-  { name: 'Helsingborg', id: 170 },
-  { name: 'Lund', id: 406 },
-  { name: 'Malmö', id: 166 },
-  { name: 'Trelleborg', id: 283 },
-  { name: 'Varberg', id: 290 },
-  { name: 'Ängelholm', id: 171 }
-];
-
-const STATIONER: Record<string, string[]> = {
-  'Falkenberg': ['Falkenberg'],
-  'Halmstad': ['BVH (Hedin multi)', 'Flyget Halmstad', 'FORD Halmstad', 'KIA Halmstad', 'MB Halmstad'],
-  'Helsingborg': ['B/S Klippan', 'BMW Helsingborg', 'Euromaster Helsingborg', 'FORD Helsingborg', 'HBSC Helsingborg', 'KIA Helsingborg', 'MB Helsingborg', 'S. Jönsson', 'Transport Helsingborg'],
-  'Lund': ['B/S Lund', 'FORD Lund', 'Hedin Lund', 'P7 Revinge'],
-  'Malmö': ['FORD Malmö', 'Hedbergs Malmö', 'Hedin Automotive Burlöv', 'Malmö Automera', 'MB Malmö', 'Mechanum', 'Sturup', 'Werksta Malmö Hamn', 'Werksta St Bernstorp'],
-  'Trelleborg': ['Trelleborg'],
-  'Varberg': ['Autoklinik (Sällstorp)', 'Finnveden plåt', 'FORD Varberg', 'MB Varberg', 'Varberg multi (Hedin)'],
-  'Ängelholm': ['Flyget Ängelholm', 'FORD Ängelholm', 'Mekonomen Ängelholm']
-};
 
 const capitalizeFirstLetter = (str: string): string => {
   return str.charAt(0).toUpperCase() + str.slice(1);

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -34,3 +34,56 @@ export const HJULTYP_OPTIONS = ['Sommardäck', 'Vinterdäck'];
 // Laddkablar, Instruktionsbok och COC. För Instruktionsbok och COC kan även 'I bilen' väljas;
 // det hanteras lokalt i respektive UI-komponent (är inte en ort i geografisk mening).
 export const ORTER = ['Falkenberg', 'Halmstad', 'Helsingborg', 'Lund', 'Malmö', 'Trelleborg', 'Varberg', 'Ängelholm'];
+
+//
+// Operativt platskontrakt
+//
+// ORTER är huvudorter. STATIONER är de detaljstationer som användaren väljer i
+// Check, Ankomst och Nybil. HUVUDSTATIONER innehåller befintliga externa ID:n
+// för planerad station/salustation. Värdena är beteendebevarande från de tre
+// tidigare lokala listorna.
+export const STATIONER: Readonly<Record<string, readonly string[]>> = {
+  Falkenberg: ['Falkenberg'],
+  Halmstad: ['BVH (Hedin multi)', 'Flyget Halmstad', 'FORD Halmstad', 'KIA Halmstad', 'MB Halmstad'],
+  Helsingborg: ['B/S Klippan', 'BMW Helsingborg', 'Euromaster Helsingborg', 'FORD Helsingborg', 'HBSC Helsingborg', 'KIA Helsingborg', 'MB Helsingborg', 'S. Jönsson', 'Transport Helsingborg'],
+  Lund: ['B/S Lund', 'FORD Lund', 'Hedin Lund', 'P7 Revinge'],
+  Malmö: ['FORD Malmö', 'Hedbergs Malmö', 'Hedin Automotive Burlöv', 'Malmö Automera', 'MB Malmö', 'Mechanum', 'Sturup', 'Werksta Malmö Hamn', 'Werksta St Bernstorp'],
+  Trelleborg: ['Trelleborg'],
+  Varberg: ['Autoklinik (Sällstorp)', 'Finnveden plåt', 'FORD Varberg', 'MB Varberg', 'Varberg multi (Hedin)'],
+  Ängelholm: ['Flyget Ängelholm', 'FORD Ängelholm', 'Mekonomen Ängelholm'],
+};
+
+export const HUVUDSTATIONER = [
+  { name: 'Falkenberg', id: 282 },
+  { name: 'Halmstad', id: 274 },
+  { name: 'Helsingborg', id: 170 },
+  { name: 'Lund', id: 406 },
+  { name: 'Malmö', id: 166 },
+  { name: 'Trelleborg', id: 283 },
+  { name: 'Varberg', id: 290 },
+  { name: 'Ängelholm', id: 171 },
+] as const;
+
+export const DEFAULT_HUVUDSTATION_ADDRESS = 'per@incheckad.se';
+
+export const HUVUDSTATION_EMAIL_BY_ORT: Readonly<Record<string, string>> = {
+  Helsingborg: 'helsingborg@incheckad.se',
+  Ängelholm: 'helsingborg@incheckad.se',
+  Varberg: 'varberg@incheckad.se',
+  Malmö: 'malmo@incheckad.se',
+  Trelleborg: 'trelleborg@incheckad.se',
+  Lund: 'lund@incheckad.se',
+  Halmstad: 'halmstad@incheckad.se',
+  Falkenberg: 'falkenberg@incheckad.se',
+};
+
+export function getHuvudstationRecipients(ort: string | null | undefined): string[] {
+  const recipients = [DEFAULT_HUVUDSTATION_ADDRESS];
+  const stationSpecificEmail = ort ? HUVUDSTATION_EMAIL_BY_ORT[ort] : undefined;
+
+  if (stationSpecificEmail && !recipients.includes(stationSpecificEmail)) {
+    recipients.push(stationSpecificEmail);
+  }
+
+  return recipients;
+}

--- a/tests/station-contract.test.ts
+++ b/tests/station-contract.test.ts
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_HUVUDSTATION_ADDRESS,
+  getHuvudstationRecipients,
+  HUVUDSTATION_EMAIL_BY_ORT,
+  HUVUDSTATIONER,
+  ORTER,
+  STATIONER,
+} from '../lib/constants';
+
+const expectedStations = {
+  Falkenberg: ['Falkenberg'],
+  Halmstad: ['BVH (Hedin multi)', 'Flyget Halmstad', 'FORD Halmstad', 'KIA Halmstad', 'MB Halmstad'],
+  Helsingborg: ['B/S Klippan', 'BMW Helsingborg', 'Euromaster Helsingborg', 'FORD Helsingborg', 'HBSC Helsingborg', 'KIA Helsingborg', 'MB Helsingborg', 'S. Jönsson', 'Transport Helsingborg'],
+  Lund: ['B/S Lund', 'FORD Lund', 'Hedin Lund', 'P7 Revinge'],
+  Malmö: ['FORD Malmö', 'Hedbergs Malmö', 'Hedin Automotive Burlöv', 'Malmö Automera', 'MB Malmö', 'Mechanum', 'Sturup', 'Werksta Malmö Hamn', 'Werksta St Bernstorp'],
+  Trelleborg: ['Trelleborg'],
+  Varberg: ['Autoklinik (Sällstorp)', 'Finnveden plåt', 'FORD Varberg', 'MB Varberg', 'Varberg multi (Hedin)'],
+  Ängelholm: ['Flyget Ängelholm', 'FORD Ängelholm', 'Mekonomen Ängelholm'],
+};
+
+test('preserves the shared city and detailed-station choices', () => {
+  assert.deepEqual(ORTER, [
+    'Falkenberg',
+    'Halmstad',
+    'Helsingborg',
+    'Lund',
+    'Malmö',
+    'Trelleborg',
+    'Varberg',
+    'Ängelholm',
+  ]);
+  assert.deepEqual(STATIONER, expectedStations);
+  assert.equal(Object.values(STATIONER).flat().length, 37);
+});
+
+test('preserves external main-station ids', () => {
+  assert.deepEqual(HUVUDSTATIONER, [
+    { name: 'Falkenberg', id: 282 },
+    { name: 'Halmstad', id: 274 },
+    { name: 'Helsingborg', id: 170 },
+    { name: 'Lund', id: 406 },
+    { name: 'Malmö', id: 166 },
+    { name: 'Trelleborg', id: 283 },
+    { name: 'Varberg', id: 290 },
+    { name: 'Ängelholm', id: 171 },
+  ]);
+});
+
+test('preserves huvudstation email routing and fallback', () => {
+  assert.deepEqual(HUVUDSTATION_EMAIL_BY_ORT, {
+    Helsingborg: 'helsingborg@incheckad.se',
+    Ängelholm: 'helsingborg@incheckad.se',
+    Varberg: 'varberg@incheckad.se',
+    Malmö: 'malmo@incheckad.se',
+    Trelleborg: 'trelleborg@incheckad.se',
+    Lund: 'lund@incheckad.se',
+    Halmstad: 'halmstad@incheckad.se',
+    Falkenberg: 'falkenberg@incheckad.se',
+  });
+  assert.deepEqual(getHuvudstationRecipients('Malmö'), [
+    DEFAULT_HUVUDSTATION_ADDRESS,
+    'malmo@incheckad.se',
+  ]);
+  assert.deepEqual(getHuvudstationRecipients('Okänd'), [
+    DEFAULT_HUVUDSTATION_ADDRESS,
+  ]);
+});


### PR DESCRIPTION
## Syfte

Genomför Steg 3.2C-1 som en beteendebevarande centralisering av appens stationskontrakt innan någon databasmodell eller historik ändras.

## Ändring

- flyttar de 8 huvudorterna och 37 detaljstationerna till `lib/constants.ts`,
- flyttar de 8 befintliga externa huvudstations-ID:na till samma kontrakt,
- centraliserar huvudstationernas befintliga mejlrouting och fallback,
- låter Check, Ankomst och Nybil läsa samma stationslista,
- låter Check- och Ankomst-notifiering använda samma routingfunktion,
- lägger regressionstest som låser dagens värden, ID:n, mottagare och fallback.

## Beteende

Ingen etikett, stationsordning, extern ID-koppling eller mejladress ändras. Formulärens val och notifieringarnas mottagare ska vara identiska med `main`.

## Avgränsning

- ingen Supabase-migration,
- ingen DDL eller DML,
- ingen Production-dataändring,
- ingen fyllning av `station_id`, `employee_id`, `started_by`, `completed_by` eller `locked_by`,
- ingen historisk backfill,
- ingen ändring av accesskontroll.

## Verifiering

- samtliga sju branchfiler återlästa från GitHub och byte-för-byte-verifierade mot den granskade diffen,
- regressionstest låser 8 orter, 37 detaljstationer, 8 externa huvudstations-ID:n och befintlig mejlrouting,
- GitHub TypeScript gate: **grön** (typecheck, lint, säkerhetsregression och produktionsbuild),
- Vercel preview: **grön**.
