### PR TITLE
3.2C-2: spara verifierad användar-UUID i completed_by

### DIFF
--- a/app/api/notify/legacy-handler.ts
+++ b/app/api/notify/legacy-handler.ts
@@ -3,6 +3,7 @@ import { Resend } from 'resend';
 import { createClient } from '@supabase/supabase-js';
 import { normalizeDamageType } from './normalizeDamageType';
 import { getHuvudstationRecipients } from '@/lib/constants';
+import { getServerVerifiedCompletedBy } from '@/lib/notify-identity';
 
 // =================================================================
 // 1. INITIALIZATION & CONFIGURATION
@@ -784,6 +785,7 @@ export async function POST(request: Request) {
           current_location_note: payload.bilen_star_nu?.kommentar || null,
           checker_name: payload.fullName || payload.full_name || payload.incheckare || null,
           checker_email: payload.user_email || payload.email || null,
+          completed_by: getServerVerifiedCompletedBy(payload),
           completed_at: now.toISOString(),
           status: 'COMPLETED',
           

--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { verifyApiUser } from '@/lib/server-auth';
+import { withVerifiedNotifyIdentity } from '@/lib/notify-identity';
 import { POST as legacyPOST } from './legacy-handler';
 
 export async function POST(request: Request) {
@@ -18,15 +19,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
   }
 
-  const meta = body?.meta && typeof body.meta === 'object' ? { ...body.meta } : {};
-  meta.user_email = verification.user.email;
-  meta.email = verification.user.email;
-  if (meta.tankning_receipt && typeof meta.tankning_receipt === 'object') {
-    meta.tankning_receipt = {
-      ...meta.tankning_receipt,
-      uploaded_by_email: verification.user.email,
-    };
-  }
+  const meta = withVerifiedNotifyIdentity(body?.meta, verification.user);
 
   const headers = new Headers(request.headers);
   headers.delete('content-length');

--- a/lib/notify-identity.ts
+++ b/lib/notify-identity.ts
@@ -1,0 +1,41 @@
+import type { VerifiedApiUser } from './server-auth';
+
+type NotifyMeta = Record<string, unknown>;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function withVerifiedNotifyIdentity(
+  rawMeta: unknown,
+  user: VerifiedApiUser
+): NotifyMeta {
+  const meta: NotifyMeta =
+    rawMeta && typeof rawMeta === 'object' && !Array.isArray(rawMeta)
+      ? { ...(rawMeta as NotifyMeta) }
+      : {};
+
+  meta.verified_user_id = user.id;
+  meta.user_email = user.email;
+  meta.email = user.email;
+
+  const receipt = meta.tankning_receipt;
+  if (receipt && typeof receipt === 'object' && !Array.isArray(receipt)) {
+    meta.tankning_receipt = {
+      ...(receipt as NotifyMeta),
+      uploaded_by_email: user.email,
+    };
+  }
+
+  return meta;
+}
+
+export function getServerVerifiedCompletedBy(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+
+  const verifiedUserId = (payload as NotifyMeta).verified_user_id;
+  return typeof verifiedUserId === 'string' && UUID_PATTERN.test(verifiedUserId)
+    ? verifiedUserId
+    : null;
+}

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -4,6 +4,10 @@ import { NextRequest } from 'next/server'
 
 import { EMAIL_WHITELIST, isWhitelistedEmail } from '../lib/access-control'
 import { verifyApiUser } from '../lib/server-auth'
+import {
+  getServerVerifiedCompletedBy,
+  withVerifiedNotifyIdentity,
+} from '../lib/notify-identity'
 import { proxy } from '../proxy'
 
 const protectedApiPaths = [
@@ -69,4 +73,44 @@ test('whitelist entries remain normalized to lowercase', () => {
   for (const email of EMAIL_WHITELIST) {
     assert.equal(email, email.toLowerCase())
   }
+})
+
+
+test('notify canonicalizes completed_by from the server-verified Supabase user', () => {
+  const verifiedUser = {
+    id: '4a3b4c2d-1e0f-4a5b-8c6d-7e8f9012a345',
+    email: 'verified@example.com',
+  }
+  const clientMeta = {
+    verified_user_id: '11111111-1111-4111-8111-111111111111',
+    user_email: 'forged@example.com',
+    email: 'forged@example.com',
+    tankning_receipt: {
+      uploaded_by_email: 'forged@example.com',
+      file_url: 'https://example.com/receipt.pdf',
+    },
+  }
+
+  const canonicalMeta = withVerifiedNotifyIdentity(clientMeta, verifiedUser)
+
+  assert.equal(canonicalMeta.verified_user_id, verifiedUser.id)
+  assert.equal(canonicalMeta.user_email, verifiedUser.email)
+  assert.equal(canonicalMeta.email, verifiedUser.email)
+  assert.deepEqual(canonicalMeta.tankning_receipt, {
+    uploaded_by_email: verifiedUser.email,
+    file_url: 'https://example.com/receipt.pdf',
+  })
+  assert.equal(getServerVerifiedCompletedBy(canonicalMeta), verifiedUser.id)
+
+  assert.equal(
+    clientMeta.verified_user_id,
+    '11111111-1111-4111-8111-111111111111',
+    'canonicalization must not mutate the incoming client payload',
+  )
+})
+
+test('completed_by rejects missing or malformed server identity', () => {
+  assert.equal(getServerVerifiedCompletedBy({}), null)
+  assert.equal(getServerVerifiedCompletedBy({ verified_user_id: 'not-a-uuid' }), null)
+  assert.equal(getServerVerifiedCompletedBy(null), null)
 })


### PR DESCRIPTION
## Steg 3.2C-2

Sparar den serververifierade Supabase-användarens UUID i `checkins.completed_by` för **nya** incheckningar.

### Säkerhetsgräns

- UUID hämtas från `verifyApiUser()`, som validerar bearer-token med Supabase `auth.getUser(accessToken)`.
- `/api/notify` skriver över eventuellt klientskickat identitetsvärde innan legacy-handlern anropas.
- Endast ett giltigt UUID förs vidare till `completed_by`.
- Befintliga `checker_name` och `checker_email` behålls som snapshots.

### Databasomfattning

- Ingen schemaändring eller migration.
- Ingen historisk backfill.
- Ingen Production-data har ändrats.
- Read-only verifiering: `completed_by` är nullable `uuid` med FK till `auth.users(id)`; 3 751 historiska rader är fortsatt `NULL`.

### Regression

- Klientförfalskad användar-UUID skrivs över av serververifierad UUID.
- Serververifierad UUID blir värdet för `completed_by`.
- Saknat eller ogiltigt UUID ger `NULL`.
- Befintlig kanonisering av e-post och tankkvitto verifieras samtidigt.

### Verifiering

- [x] TypeScript
- [x] ESLint
- [x] Security regression
- [x] Production build
- [x] Built Next security smoke
