### PR TITLE
3.2D-4A: stoppa tre Nybil legacy-writes

### DIFF
--- a/lib/nybil-aliases.ts
+++ b/lib/nybil-aliases.ts
@@ -8,20 +8,14 @@ export type NybilCanonicalAliasFields = {
 };
 
 /**
- * Preserve Nybil's legacy database aliases from one canonical mapping point.
- *
- * The canonical fields remain the source values. This helper only mirrors them
- * to the legacy columns that are still written today; it does not add business
- * logic or choose between conflicting values.
+ * Preserve the Nybil legacy database aliases that still have live compatibility
+ * dependencies. Canonical fields remain the source values.
  */
 export function withNybilLegacyAliases<T extends NybilCanonicalAliasFields>(data: T) {
   return {
     ...data,
     bilmodell: data.modell,
-    ankomstdatum: data.registreringsdatum,
-    monterade_dack: data.hjultyp,
     hjul_till_forvaring: data.hjul_ej_monterade,
     hjul_forvaring_station: data.hjul_forvaring_ort,
-    kompressor: data.dackkompressor,
   };
 }

--- a/tests/nybil-aliases.test.ts
+++ b/tests/nybil-aliases.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { withNybilLegacyAliases } from '../lib/nybil-aliases';
 
-test('Nybil legacy aliases mirror canonical fields without changing other data', () => {
+test('Nybil retained legacy aliases mirror canonical fields without changing other data', () => {
   const canonical = {
     regnr: 'ABC123',
     modell: 'T-Cross',
@@ -20,18 +20,15 @@ test('Nybil legacy aliases mirror canonical fields without changing other data',
   assert.deepEqual(result, {
     ...canonical,
     bilmodell: canonical.modell,
-    ankomstdatum: canonical.registreringsdatum,
-    monterade_dack: canonical.hjultyp,
     hjul_till_forvaring: canonical.hjul_ej_monterade,
     hjul_forvaring_station: canonical.hjul_forvaring_ort,
-    kompressor: canonical.dackkompressor,
   });
 
   assert.equal('bilmodell' in canonical, false);
-  assert.equal('ankomstdatum' in canonical, false);
+  assert.equal('hjul_till_forvaring' in canonical, false);
 });
 
-test('canonical Nybil fields always win over stale legacy aliases', () => {
+test('canonical Nybil fields win over stale retained legacy aliases', () => {
   const result = withNybilLegacyAliases({
     modell: 'Kanonisk modell',
     registreringsdatum: '2026-08-18',
@@ -40,17 +37,11 @@ test('canonical Nybil fields always win over stale legacy aliases', () => {
     hjul_forvaring_ort: null,
     dackkompressor: false,
     bilmodell: 'Gammal modell',
-    ankomstdatum: '2020-01-01',
-    monterade_dack: 'Gammalt värde',
     hjul_till_forvaring: 'Gammalt värde',
     hjul_forvaring_station: 'Gammal ort',
-    kompressor: true,
   });
 
   assert.equal(result.bilmodell, 'Kanonisk modell');
-  assert.equal(result.ankomstdatum, '2026-08-18');
-  assert.equal(result.monterade_dack, null);
   assert.equal(result.hjul_till_forvaring, null);
   assert.equal(result.hjul_forvaring_station, null);
-  assert.equal(result.kompressor, false);
 });


### PR DESCRIPTION
## Scope
Steg 3.2D-4A slutar generera exakt tre Nybil legacy-DB-alias som inventeringen inte hittade några kvarvarande runtime-/DB-läsare för:
- `ankomstdatum`
- `monterade_dack`
- `kompressor`

## Ändring
- `lib/nybil-aliases.ts`: helpern fortsätter endast spegla de tre alias som fortfarande har separata kompatibilitetsberoenden: `bilmodell`, `hjul_till_forvaring`, `hjul_forvaring_station`.
- `tests/nybil-aliases.test.ts`: regressionstesterna uppdateras till samma kvarvarande kontrakt.

## Utanför scope
- Ingen DB-migration eller kolumndrop.
- Ingen historisk backfill.
- Ingen Production-write eller write-probe.
- Ingen ändring av notifieringskontraktet `hjul_till_forvaring`.
- Ingen ändring av `bilmodell`-beroendet i `car_lookup_any`.
- Ingen ändring av vyberoendena för `hjul_forvaring_station`.
- Ingen station-/identity-mappning.

## Lokal verifiering
- `npm run test:regression`: success
- `npm run typecheck`: success
- `npm run lint`: 0 errors, 64 kända baseline-warnings
- `git diff --check`: success
- diff: 2 filer, 5 additions, 20 deletions

GitHub CI och Vercel får nu verifiera PR-head innan eventuell merge.