### PR TITLE
3.2D-4C: stoppa sista Nybil DB-aliaswrites

### DIFF
--- a/lib/nybil-aliases.ts
+++ b/lib/nybil-aliases.ts
@@ -8,14 +8,12 @@ export type NybilCanonicalAliasFields = {
 };
 
 /**
- * Preserve the Nybil legacy database aliases that still have live compatibility
- * dependencies. Canonical fields remain the source values.
+ * Preserve the separate Nybil notifier compatibility field that still shares a
+ * legacy database name. Canonical fields remain the source values.
  */
 export function withNybilLegacyAliases<T extends NybilCanonicalAliasFields>(data: T) {
   return {
     ...data,
-    bilmodell: data.modell,
     hjul_till_forvaring: data.hjul_ej_monterade,
-    hjul_forvaring_station: data.hjul_forvaring_ort,
   };
 }

--- a/tests/nybil-aliases.test.ts
+++ b/tests/nybil-aliases.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { withNybilLegacyAliases } from '../lib/nybil-aliases';
 
-test('Nybil retained legacy aliases mirror canonical fields without changing other data', () => {
+test('Nybil retains only the separate notifier compatibility field', () => {
   const canonical = {
     regnr: 'ABC123',
     modell: 'T-Cross',
@@ -19,16 +19,14 @@ test('Nybil retained legacy aliases mirror canonical fields without changing oth
 
   assert.deepEqual(result, {
     ...canonical,
-    bilmodell: canonical.modell,
     hjul_till_forvaring: canonical.hjul_ej_monterade,
-    hjul_forvaring_station: canonical.hjul_forvaring_ort,
   });
 
-  assert.equal('bilmodell' in canonical, false);
-  assert.equal('hjul_till_forvaring' in canonical, false);
+  assert.equal('bilmodell' in result, false);
+  assert.equal('hjul_forvaring_station' in result, false);
 });
 
-test('canonical Nybil fields win over stale retained legacy aliases', () => {
+test('canonical Nybil value wins over stale notifier compatibility input', () => {
   const result = withNybilLegacyAliases({
     modell: 'Kanonisk modell',
     registreringsdatum: '2026-08-18',
@@ -36,12 +34,10 @@ test('canonical Nybil fields win over stale retained legacy aliases', () => {
     hjul_ej_monterade: null,
     hjul_forvaring_ort: null,
     dackkompressor: false,
-    bilmodell: 'Gammal modell',
     hjul_till_forvaring: 'Gammalt värde',
-    hjul_forvaring_station: 'Gammal ort',
   });
 
-  assert.equal(result.bilmodell, 'Kanonisk modell');
   assert.equal(result.hjul_till_forvaring, null);
-  assert.equal(result.hjul_forvaring_station, null);
+  assert.equal('bilmodell' in result, false);
+  assert.equal('hjul_forvaring_station' in result, false);
 });


### PR DESCRIPTION
## Scope
Slutar generera de två kvarvarande Nybil legacy-DB-aliasen efter att 3.2D-4B flyttat deras DB-läsare till kanoniska fält.

## Ändring
- `lib/nybil-aliases.ts`: slutar skriva `bilmodell` och `hjul_forvaring_station`.
- Behåller endast `hjul_till_forvaring`, eftersom det fortfarande är ett separat notifierings-/kompatibilitetskontrakt.
- `tests/nybil-aliases.test.ts`: verifierar att endast notifieringsfältet speglas och att de två DB-aliasen inte längre genereras.

## Verifierad grund
- Production-preflight: 195 Nybil-rader, 0 mismatch för `modell`/`bilmodell`.
- Production-preflight: 195 Nybil-rader, 0 mismatch för `hjul_forvaring_ort`/`hjul_forvaring_station`.
- Efter 3.2D-4B finns inget funktionsberoende kvar på `bilmodell`.
- DB-vyerna läser nu kanoniskt `hjul_forvaring_ort`; kvarvarande `hjul_forvaring_station` i view-definitionen är endast ett bevarat output-alias, inte en läsning av legacy-kolumnen.

## Utanför scope
- Ingen DROP av legacy-kolumner.
- Ingen historisk backfill eller DML.
- Ingen ändring av `hjul_till_forvaring` notifieringskontrakt.
- Ingen BUHS-ändring.
- Ingen station-/identity-mappning.

## Validation
Diffen är exakt 2 filer: helper + regressionstest. GitHub CI och Vercel verifierar PR-head innan merge.