### PR TITLE
3.2D-4E: stoppa hjul_till_forvaring DB-write

### DIFF
--- a/lib/nybil-aliases.ts
+++ b/lib/nybil-aliases.ts
@@ -8,12 +8,9 @@ export type NybilCanonicalAliasFields = {
 };
 
 /**
- * Preserve the separate Nybil notifier compatibility field that still shares a
- * legacy database name. Canonical fields remain the source values.
+ * Compatibility shim retained to keep the Nybil form diff narrow while the
+ * legacy database aliases are retired. It must not generate DB alias fields.
  */
 export function withNybilLegacyAliases<T extends NybilCanonicalAliasFields>(data: T) {
-  return {
-    ...data,
-    hjul_till_forvaring: data.hjul_ej_monterade,
-  };
+  return data;
 }

--- a/tests/nybil-aliases.test.ts
+++ b/tests/nybil-aliases.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 
 import { withNybilLegacyAliases } from '../lib/nybil-aliases';
 
-test('Nybil retains only the separate notifier compatibility field', () => {
+test('Nybil compatibility shim leaves canonical data unchanged', () => {
   const canonical = {
     regnr: 'ABC123',
     modell: 'T-Cross',
@@ -17,27 +17,12 @@ test('Nybil retains only the separate notifier compatibility field', () => {
 
   const result = withNybilLegacyAliases(canonical);
 
-  assert.deepEqual(result, {
-    ...canonical,
-    hjul_till_forvaring: canonical.hjul_ej_monterade,
-  });
-
+  assert.equal(result, canonical);
+  assert.deepEqual(result, canonical);
   assert.equal('bilmodell' in result, false);
+  assert.equal('ankomstdatum' in result, false);
+  assert.equal('monterade_dack' in result, false);
+  assert.equal('hjul_till_forvaring' in result, false);
   assert.equal('hjul_forvaring_station' in result, false);
-});
-
-test('canonical Nybil value wins over stale notifier compatibility input', () => {
-  const result = withNybilLegacyAliases({
-    modell: 'Kanonisk modell',
-    registreringsdatum: '2026-08-18',
-    hjultyp: null,
-    hjul_ej_monterade: null,
-    hjul_forvaring_ort: null,
-    dackkompressor: false,
-    hjul_till_forvaring: 'Gammalt värde',
-  });
-
-  assert.equal(result.hjul_till_forvaring, null);
-  assert.equal('bilmodell' in result, false);
-  assert.equal('hjul_forvaring_station' in result, false);
+  assert.equal('kompressor' in result, false);
 });


### PR DESCRIPTION
## Scope
Stoppar den sista Nybil legacy-DB-writen `hjul_till_forvaring` utan att ändra notifieringskontraktet `/api/notify-nybil`.

## Ändring
- `withNybilLegacyAliases(...)` blir en ren passthrough och genererar inga legacy DB-alias.
- Regressionstestet verifierar uttryckligen att inget av de sex legacy DB-aliasen läggs till.
- Nybil-formens notifieringspayload fortsätter separat att sätta `hjul_till_forvaring: hjulTillForvaring` till `/api/notify-nybil`, så e-postkontraktet bevaras.

## Grund
- 3.2D-4D read-only retirement-preflight visar 0 direkta view-/function-dependencies för legacy-kolumnerna och 0 mismatch på befintliga 195 Nybil-rader.
- Repo-inspektion visar att notifieringsfältet byggs separat i `emailPayload`; DB-helpern behöver därför inte längre skapa samma namn.

## Utanför scope
- Ingen DROP.
- Ingen DML, backfill eller syntetisk Production-write.
- Ingen ändring av notifierings-API:ts externa payload eller e-postrendering.
- Ingen BUHS-/station-/identity-ändring.

## Validation
GitHub CI och Vercel ska vara gröna innan merge. Post-merge verifiering av riktig Nybil-write förblir read-only och event-gated.