### PR TITLE
4.1B-1: add SALU core calculation contract

### DIFF
--- a/lib/salu-core.ts
+++ b/lib/salu-core.ts
@@ -1,0 +1,192 @@
+export type SaluControlMode = 'AUTO' | 'MANUELL';
+export type SaluEscalationStatus = 'NORMAL' | 'T10' | 'PASSERAD';
+
+export type SaluAutoRule = {
+  id: string;
+  version: number;
+  make: string;
+  months: number;
+  modelTokens?: string[];
+  priority?: number;
+  active?: boolean;
+};
+
+export type SaluAutoMatch = {
+  ruleId: string;
+  ruleVersion: number;
+  matchedMake: string;
+  matchedModelTokens: string[];
+  monthsApplied: number;
+  saludatum: string;
+};
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseIsoDate(value: string): Date {
+  if (!ISO_DATE_RE.test(value)) {
+    throw new Error(`Invalid ISO date: ${value}`);
+  }
+
+  const [year, month, day] = value.split('-').map(Number);
+  const result = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    result.getUTCFullYear() !== year ||
+    result.getUTCMonth() !== month - 1 ||
+    result.getUTCDate() !== day
+  ) {
+    throw new Error(`Invalid calendar date: ${value}`);
+  }
+
+  return result;
+}
+
+function formatIsoDate(value: Date): string {
+  const year = value.getUTCFullYear();
+  const month = String(value.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(value.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function daysInMonth(year: number, zeroBasedMonth: number): number {
+  return new Date(Date.UTC(year, zeroBasedMonth + 1, 0)).getUTCDate();
+}
+
+export function addCalendarMonths(isoDate: string, months: number): string {
+  if (!Number.isInteger(months)) {
+    throw new Error('Calendar months must be an integer');
+  }
+
+  const source = parseIsoDate(isoDate);
+  const sourceDay = source.getUTCDate();
+  const targetMonthIndex = source.getUTCMonth() + months;
+  const targetYear = source.getUTCFullYear() + Math.floor(targetMonthIndex / 12);
+  const targetMonth = ((targetMonthIndex % 12) + 12) % 12;
+  const targetDay = Math.min(sourceDay, daysInMonth(targetYear, targetMonth));
+
+  return formatIsoDate(new Date(Date.UTC(targetYear, targetMonth, targetDay)));
+}
+
+export function lifecycleDay(nyDate: string, date: string): number {
+  const start = parseIsoDate(nyDate).getTime();
+  const current = parseIsoDate(date).getTime();
+  const difference = Math.round((current - start) / DAY_MS);
+
+  if (difference < 0) {
+    throw new Error('Lifecycle date cannot be before NY date');
+  }
+
+  return difference + 1;
+}
+
+export function stillestandSaluDays(slutbedomningDate: string, closedDate: string): number {
+  const start = parseIsoDate(slutbedomningDate).getTime();
+  const end = parseIsoDate(closedDate).getTime();
+  const difference = Math.round((end - start) / DAY_MS);
+
+  if (difference < 0) {
+    throw new Error('STÄNGD cannot be before SLUTBEDÖMNING');
+  }
+
+  return difference;
+}
+
+export function normalizeSaluTokenText(value: string): string[] {
+  return value
+    .normalize('NFKC')
+    .toLocaleUpperCase('sv-SE')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function normalizedText(value: string): string {
+  return normalizeSaluTokenText(value).join(' ');
+}
+
+function ruleMatches(rule: SaluAutoRule, make: string, modelTokens: Set<string>): boolean {
+  if (rule.active === false || normalizedText(rule.make) !== normalizedText(make)) {
+    return false;
+  }
+
+  const requiredTokens = (rule.modelTokens ?? []).flatMap(normalizeSaluTokenText);
+  return requiredTokens.every((token) => modelTokens.has(token));
+}
+
+export function selectSaluAutoRule(
+  make: string,
+  model: string,
+  rules: SaluAutoRule[],
+): SaluAutoRule | null {
+  const modelTokens = new Set(normalizeSaluTokenText(model));
+  const matches = rules.filter((rule) => ruleMatches(rule, make, modelTokens));
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  return [...matches].sort((left, right) => {
+    const leftSpecificity = (left.modelTokens ?? []).flatMap(normalizeSaluTokenText).length;
+    const rightSpecificity = (right.modelTokens ?? []).flatMap(normalizeSaluTokenText).length;
+
+    if (leftSpecificity !== rightSpecificity) {
+      return rightSpecificity - leftSpecificity;
+    }
+
+    const priorityDifference = (right.priority ?? 0) - (left.priority ?? 0);
+    if (priorityDifference !== 0) {
+      return priorityDifference;
+    }
+
+    return left.id.localeCompare(right.id);
+  })[0];
+}
+
+export function calculateAutoSaludatum(input: {
+  nyDate: string;
+  make: string;
+  model: string;
+  rules: SaluAutoRule[];
+}): SaluAutoMatch | null {
+  const rule = selectSaluAutoRule(input.make, input.model, input.rules);
+  if (!rule) {
+    return null;
+  }
+
+  if (!Number.isInteger(rule.months) || rule.months <= 0) {
+    throw new Error(`Invalid month count for SALU rule ${rule.id}`);
+  }
+
+  return {
+    ruleId: rule.id,
+    ruleVersion: rule.version,
+    matchedMake: rule.make,
+    matchedModelTokens: rule.modelTokens ?? [],
+    monthsApplied: rule.months,
+    saludatum: addCalendarMonths(input.nyDate, rule.months),
+  };
+}
+
+export function saluFlagDate(saludatum: string): string {
+  const date = parseIsoDate(saludatum);
+  date.setUTCDate(date.getUTCDate() - 30);
+  return formatIsoDate(date);
+}
+
+export function saluEscalationStatus(today: string, saludatum: string): SaluEscalationStatus {
+  const current = parseIsoDate(today).getTime();
+  const target = parseIsoDate(saludatum).getTime();
+  const daysUntil = Math.round((target - current) / DAY_MS);
+
+  if (daysUntil < 0) {
+    return 'PASSERAD';
+  }
+
+  if (daysUntil <= 10) {
+    return 'T10';
+  }
+
+  return 'NORMAL';
+}

--- a/lib/salu-core.ts
+++ b/lib/salu-core.ts
@@ -180,7 +180,7 @@ export function saluEscalationStatus(today: string, saludatum: string): SaluEsca
   const target = parseIsoDate(saludatum).getTime();
   const daysUntil = Math.round((target - current) / DAY_MS);
 
-  if (daysUntil < 0) {
+  if (daysUntil <= 0) {
     return 'PASSERAD';
   }
 

--- a/tests/salu-core.test.ts
+++ b/tests/salu-core.test.ts
@@ -1,0 +1,106 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  addCalendarMonths,
+  calculateAutoSaludatum,
+  lifecycleDay,
+  saluEscalationStatus,
+  saluFlagDate,
+  selectSaluAutoRule,
+  stillestandSaluDays,
+  type SaluAutoRule,
+} from '../lib/salu-core';
+
+const rules: SaluAutoRule[] = [
+  { id: 'mb-default', version: 1, make: 'Mercedes-Benz', months: 6 },
+  { id: 'mb-sprinter', version: 1, make: 'Mercedes-Benz', modelTokens: ['Sprinter'], months: 24, priority: 10 },
+  { id: 'mb-citan', version: 1, make: 'Mercedes-Benz', modelTokens: ['Citan'], months: 24, priority: 10 },
+  { id: 'mb-vito', version: 1, make: 'Mercedes-Benz', modelTokens: ['Vito'], months: 24, priority: 10 },
+  { id: 'mb-v', version: 1, make: 'Mercedes-Benz', modelTokens: ['V'], months: 24, priority: 10 },
+  { id: 'bmw-default', version: 1, make: 'BMW', months: 6 },
+  { id: 'vw-default', version: 1, make: 'VW', months: 12 },
+  { id: 'kia-default', version: 1, make: 'KIA', months: 12 },
+  { id: 'ford-default', version: 1, make: 'FORD', months: 12 },
+  { id: 'ford-transit', version: 1, make: 'FORD', modelTokens: ['Transit'], months: 24, priority: 10 },
+  { id: 'ford-connect', version: 1, make: 'FORD', modelTokens: ['Connect'], months: 24, priority: 10 },
+  { id: 'ford-tourneo', version: 1, make: 'FORD', modelTokens: ['Tourneo'], months: 24, priority: 10 },
+];
+
+test('calendar month rule preserves day when valid and clamps month-end otherwise', () => {
+  assert.equal(addCalendarMonths('2026-01-31', 1), '2026-02-28');
+  assert.equal(addCalendarMonths('2028-01-31', 1), '2028-02-29');
+  assert.equal(addCalendarMonths('2026-01-31', 2), '2026-03-31');
+  assert.equal(addCalendarMonths('2026-07-15', 2), '2026-09-15');
+});
+
+test('repeated extensions are calculated from the then-current saludatum', () => {
+  const first = addCalendarMonths('2026-07-15', 2);
+  const second = addCalendarMonths(first, 1);
+
+  assert.equal(first, '2026-09-15');
+  assert.equal(second, '2026-10-15');
+});
+
+test('lifecycle is inclusive from NY = day 1', () => {
+  assert.equal(lifecycleDay('2026-01-01', '2026-01-01'), 1);
+  assert.equal(lifecycleDay('2026-01-01', '2027-01-01'), 366);
+});
+
+test('Stillestånd SALU is elapsed calendar days from final assessment to close', () => {
+  assert.equal(stillestandSaluDays('2026-01-01', '2026-01-19'), 18);
+});
+
+test('AUTO uses model exception before make default', () => {
+  const match = calculateAutoSaludatum({
+    nyDate: '2026-01-15',
+    make: 'Mercedes-Benz',
+    model: 'Sprinter 316 CDI',
+    rules,
+  });
+
+  assert.deepEqual(match, {
+    ruleId: 'mb-sprinter',
+    ruleVersion: 1,
+    matchedMake: 'Mercedes-Benz',
+    matchedModelTokens: ['Sprinter'],
+    monthsApplied: 24,
+    saludatum: '2028-01-15',
+  });
+});
+
+test('AUTO model matching is token-safe, including Mercedes V', () => {
+  assert.equal(selectSaluAutoRule('Mercedes-Benz', 'V 300 d', rules)?.id, 'mb-v');
+  assert.equal(selectSaluAutoRule('Mercedes-Benz', 'Vito 119 CDI', rules)?.id, 'mb-vito');
+  assert.equal(selectSaluAutoRule('Mercedes-Benz', 'EQA 250 Advanced', rules)?.id, 'mb-default');
+});
+
+test('AUTO normalization ignores case, whitespace, hyphens and punctuation', () => {
+  assert.equal(selectSaluAutoRule('ford', '  Transit-Custom  ', rules)?.id, 'ford-transit');
+  assert.equal(selectSaluAutoRule('MERCEDES BENZ', 'SPRINTER-316 CDI', rules)?.id, 'mb-sprinter');
+});
+
+test('AUTO never guesses when the make has no rule', () => {
+  assert.equal(calculateAutoSaludatum({ nyDate: '2026-01-15', make: 'Volvo', model: 'XC40', rules }), null);
+});
+
+test('most specific matching AUTO rule wins before priority', () => {
+  const localRules: SaluAutoRule[] = [
+    { id: 'ford-default', version: 1, make: 'Ford', months: 12, priority: 100 },
+    { id: 'transit', version: 1, make: 'Ford', modelTokens: ['Transit'], months: 24 },
+    { id: 'transit-custom', version: 1, make: 'Ford', modelTokens: ['Transit', 'Custom'], months: 30 },
+  ];
+
+  assert.equal(selectSaluAutoRule('Ford', 'Transit Custom', localRules)?.id, 'transit-custom');
+});
+
+test('T-30 flag date is exactly 30 calendar days before saludatum', () => {
+  assert.equal(saluFlagDate('2027-01-31'), '2027-01-01');
+  assert.equal(saluFlagDate('2026-03-01'), '2026-01-30');
+});
+
+test('escalation is a current snapshot and can move back after a new plan', () => {
+  assert.equal(saluEscalationStatus('2026-08-20', '2026-08-19'), 'PASSERAD');
+  assert.equal(saluEscalationStatus('2026-08-20', '2026-08-30'), 'T10');
+  assert.equal(saluEscalationStatus('2026-08-20', '2026-10-19'), 'NORMAL');
+});

--- a/tests/salu-core.test.ts
+++ b/tests/salu-core.test.ts
@@ -101,6 +101,7 @@ test('T-30 flag date is exactly 30 calendar days before saludatum', () => {
 
 test('escalation is a current snapshot and can move back after a new plan', () => {
   assert.equal(saluEscalationStatus('2026-08-20', '2026-08-19'), 'PASSERAD');
+  assert.equal(saluEscalationStatus('2026-08-20', '2026-08-20'), 'PASSERAD');
   assert.equal(saluEscalationStatus('2026-08-20', '2026-08-30'), 'T10');
   assert.equal(saluEscalationStatus('2026-08-20', '2026-10-19'), 'NORMAL');
 });


### PR DESCRIPTION
## Syfte
Första kontrollerade implementationen efter 4.1B teknisk gap-analys med GO.

## Ingår
- ren, sidoeffektsfri SALU-kärna för kalenderdatum och livscykel
- AUTO-regelmatchning som tar konfigurerbara regler som input
- modellundantag före märkesdefault
- token-säker normalisering
- explicit spårning av regel-id/version i beräkningsresultat
- T-30-datum och separat aktuell eskaleringssnapshot
- Stillestånd SALU som datumdifferens
- fokuserade regressionstester

## Ingår inte
- ingen databas-DDL eller Production-migration
- ingen backfill
- ingen UI-förändring
- ingen automatisk flaggskapning
- ingen Kistan/Planner

## Kontraktsregler som täcks
9A, 9D, 9L, 9M, 9O-9Z, 9AA, 9AJ-9AM.

## Säkerhet
Ingen Production-write eller syntetisk verksamhetsdata. Ändringen är isolerad till ny kärnmodul och tester.