### PR TITLE
4.1B-2: add SALU process state contract

### DIFF
--- a/lib/salu-process.ts
+++ b/lib/salu-process.ts
@@ -44,7 +44,9 @@ export const SALU_EVENTS = [
 
 export type SaluEventType = (typeof SALU_EVENTS)[number];
 
-export function isTerminalChildStatus(status: SaluChildStatus): boolean {
+export function isTerminalChildStatus(
+  status: SaluChildStatus,
+): status is Extract<SaluChildStatus, 'VERIFIED' | 'CANCELLED'> {
   return status === 'VERIFIED' || status === 'CANCELLED';
 }
 

--- a/lib/salu-process.ts
+++ b/lib/salu-process.ts
@@ -2,7 +2,13 @@ import { saluEscalationStatus, type SaluEscalationStatus } from './salu-core';
 
 export type SaluFlagStatus = 'NY' | 'HANDLÄGGS' | 'VÄNTAR' | 'SLUTBEDÖMNING' | 'STÄNGD';
 export type SaluCheckpointStatus = 'GODKÄND' | 'AVVIKELSE' | 'EJ RELEVANT' | 'VÄNTAR';
-export type SaluChildStatus = 'CREATED' | 'ACCEPTED' | 'IN_PROGRESS' | 'READY_FOR_VERIFICATION' | 'VERIFIED' | 'CANCELLED';
+export type SaluChildStatus =
+  | 'CREATED'
+  | 'ACCEPTED'
+  | 'IN_PROGRESS'
+  | 'READY_FOR_VERIFICATION'
+  | 'VERIFIED'
+  | 'CANCELLED';
 
 export type SaluFlagSnapshot = {
   flagId: string;
@@ -42,6 +48,36 @@ export function isTerminalChildStatus(status: SaluChildStatus): boolean {
   return status === 'VERIFIED' || status === 'CANCELLED';
 }
 
+export function transitionSaluChildStatus(
+  current: SaluChildStatus,
+  next: SaluChildStatus,
+): SaluChildStatus {
+  if (current === next) {
+    return current;
+  }
+
+  if (isTerminalChildStatus(current)) {
+    throw new Error(`Terminal SALU child status ${current} cannot transition`);
+  }
+
+  if (next === 'CANCELLED') {
+    return next;
+  }
+
+  const allowed: Record<Exclude<SaluChildStatus, 'VERIFIED' | 'CANCELLED'>, SaluChildStatus[]> = {
+    CREATED: ['ACCEPTED'],
+    ACCEPTED: ['IN_PROGRESS'],
+    IN_PROGRESS: ['READY_FOR_VERIFICATION'],
+    READY_FOR_VERIFICATION: ['VERIFIED', 'IN_PROGRESS'],
+  };
+
+  if (!allowed[current].includes(next)) {
+    throw new Error(`Invalid SALU child transition ${current} -> ${next}`);
+  }
+
+  return next;
+}
+
 export function assessSaluCloseReadiness(input: {
   checkpointStatuses: SaluCheckpointStatus[];
   childStatuses: SaluChildStatus[];
@@ -75,8 +111,8 @@ export function moveSaluFlagToFinalAssessment(
     throw new Error('SALU flag is not ready for final assessment');
   }
 
-  if (snapshot.status === 'STÄNGD') {
-    throw new Error('A closed SALU flag cannot move to final assessment');
+  if (snapshot.status !== 'HANDLÄGGS' && snapshot.status !== 'VÄNTAR') {
+    throw new Error('Final assessment requires HANDLÄGGS or VÄNTAR');
   }
 
   return { ...snapshot, status: 'SLUTBEDÖMNING' };

--- a/lib/salu-process.ts
+++ b/lib/salu-process.ts
@@ -1,0 +1,134 @@
+import { saluEscalationStatus, type SaluEscalationStatus } from './salu-core';
+
+export type SaluFlagStatus = 'NY' | 'HANDLÄGGS' | 'VÄNTAR' | 'SLUTBEDÖMNING' | 'STÄNGD';
+export type SaluCheckpointStatus = 'GODKÄND' | 'AVVIKELSE' | 'EJ RELEVANT' | 'VÄNTAR';
+export type SaluChildStatus = 'CREATED' | 'ACCEPTED' | 'IN_PROGRESS' | 'READY_FOR_VERIFICATION' | 'VERIFIED' | 'CANCELLED';
+
+export type SaluFlagSnapshot = {
+  flagId: string;
+  regnr: string;
+  previousFlagId?: string | null;
+  cycleSaludatum: string;
+  currentSaludatum: string;
+  status: SaluFlagStatus;
+  escalationStatus: SaluEscalationStatus;
+};
+
+export type SaluCloseReadiness = {
+  ready: boolean;
+  reasons: string[];
+};
+
+export const SALU_EVENTS = [
+  'SALU_FLAG_CREATED',
+  'SALU_FLAG_ACKNOWLEDGED',
+  'SALU_ASSESSMENT_RECORDED',
+  'SALU_CHECKPOINT_CHANGED',
+  'SALU_INLINE_ACTION_CREATED',
+  'SALU_CHILD_PROCESS_CREATED',
+  'SALU_CHILD_STATUS_REPORTED',
+  'SALU_SALUDATUM_CHANGED',
+  'SALU_SOLD_RECORDED',
+  'SALU_HANDOVER_RECORDED',
+  'SALU_T10_ESCALATED',
+  'SALU_T0_PASSED',
+  'SALU_FLAG_READY_FOR_OWNER_DECISION',
+  'SALU_FLAG_CLOSED_MANUALLY',
+] as const;
+
+export type SaluEventType = (typeof SALU_EVENTS)[number];
+
+export function isTerminalChildStatus(status: SaluChildStatus): boolean {
+  return status === 'VERIFIED' || status === 'CANCELLED';
+}
+
+export function assessSaluCloseReadiness(input: {
+  checkpointStatuses: SaluCheckpointStatus[];
+  childStatuses: SaluChildStatus[];
+}): SaluCloseReadiness {
+  const reasons: string[] = [];
+
+  if (input.checkpointStatuses.some((status) => status === 'VÄNTAR')) {
+    reasons.push('CHECKPOINT_VÄNTAR');
+  }
+
+  if (input.childStatuses.some((status) => !isTerminalChildStatus(status))) {
+    reasons.push('CHILD_PROCESS_NOT_TERMINAL');
+  }
+
+  return { ready: reasons.length === 0, reasons };
+}
+
+export function acknowledgeSaluFlag(snapshot: SaluFlagSnapshot): SaluFlagSnapshot {
+  if (snapshot.status !== 'NY') {
+    throw new Error('Only a NY SALU flag can be acknowledged');
+  }
+
+  return { ...snapshot, status: 'HANDLÄGGS' };
+}
+
+export function moveSaluFlagToFinalAssessment(
+  snapshot: SaluFlagSnapshot,
+  readiness: SaluCloseReadiness,
+): SaluFlagSnapshot {
+  if (!readiness.ready) {
+    throw new Error('SALU flag is not ready for final assessment');
+  }
+
+  if (snapshot.status === 'STÄNGD') {
+    throw new Error('A closed SALU flag cannot move to final assessment');
+  }
+
+  return { ...snapshot, status: 'SLUTBEDÖMNING' };
+}
+
+export function closeSaluFlagManually(
+  snapshot: SaluFlagSnapshot,
+  readiness: SaluCloseReadiness,
+): SaluFlagSnapshot {
+  if (snapshot.status !== 'SLUTBEDÖMNING') {
+    throw new Error('Manual closure requires SLUTBEDÖMNING');
+  }
+
+  if (!readiness.ready) {
+    throw new Error('SALU flag cannot close while blocking conditions remain');
+  }
+
+  return { ...snapshot, status: 'STÄNGD' };
+}
+
+export function applyActiveSaludatumChange(input: {
+  snapshot: SaluFlagSnapshot;
+  newSaludatum: string;
+  today: string;
+}): SaluFlagSnapshot {
+  if (input.snapshot.status === 'STÄNGD') {
+    throw new Error('A closed SALU flag must not be mutated by an active-plan date change');
+  }
+
+  return {
+    ...input.snapshot,
+    currentSaludatum: input.newSaludatum,
+    escalationStatus: saluEscalationStatus(input.today, input.newSaludatum),
+  };
+}
+
+export function createReopenedSaluFlag(input: {
+  previous: SaluFlagSnapshot;
+  newFlagId: string;
+  today: string;
+}): SaluFlagSnapshot {
+  if (input.previous.status !== 'STÄNGD') {
+    throw new Error('SALU can only be reopened from a closed flag');
+  }
+
+  return {
+    flagId: input.newFlagId,
+    regnr: input.previous.regnr,
+    previousFlagId: input.previous.flagId,
+    cycleSaludatum: input.previous.currentSaludatum,
+    currentSaludatum: input.previous.currentSaludatum,
+    status: 'NY',
+    escalationStatus: saluEscalationStatus(input.today, input.previous.currentSaludatum),
+  };
+}

--- a/tests/salu-process.test.ts
+++ b/tests/salu-process.test.ts
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  acknowledgeSaluFlag,
+  applyActiveSaludatumChange,
+  assessSaluCloseReadiness,
+  closeSaluFlagManually,
+  createReopenedSaluFlag,
+  moveSaluFlagToFinalAssessment,
+  type SaluFlagSnapshot,
+} from '../lib/salu-process';
+
+const activeFlag: SaluFlagSnapshot = {
+  flagId: 'flag-1',
+  regnr: 'ABC123',
+  cycleSaludatum: '2026-08-31',
+  currentSaludatum: '2026-08-31',
+  status: 'NY',
+  escalationStatus: 'T10',
+};
+
+test('NY flag is acknowledged into HANDLÄGGS without changing ownership identity fields', () => {
+  const next = acknowledgeSaluFlag(activeFlag);
+  assert.equal(next.status, 'HANDLÄGGS');
+  assert.equal(next.flagId, activeFlag.flagId);
+  assert.equal(next.regnr, activeFlag.regnr);
+});
+
+test('close readiness blocks on VÄNTAR checkpoint and non-terminal child process', () => {
+  const readiness = assessSaluCloseReadiness({
+    checkpointStatuses: ['GODKÄND', 'VÄNTAR', 'AVVIKELSE'],
+    childStatuses: ['VERIFIED', 'IN_PROGRESS'],
+  });
+
+  assert.equal(readiness.ready, false);
+  assert.deepEqual(readiness.reasons, ['CHECKPOINT_VÄNTAR', 'CHILD_PROCESS_NOT_TERMINAL']);
+});
+
+test('VERIFIED and CANCELLED are terminal child statuses for close readiness', () => {
+  const readiness = assessSaluCloseReadiness({
+    checkpointStatuses: ['GODKÄND', 'AVVIKELSE', 'EJ RELEVANT'],
+    childStatuses: ['VERIFIED', 'CANCELLED'],
+  });
+
+  assert.deepEqual(readiness, { ready: true, reasons: [] });
+});
+
+test('manual close requires SLUTBEDÖMNING and ready conditions', () => {
+  const acknowledged = acknowledgeSaluFlag(activeFlag);
+  const readiness = assessSaluCloseReadiness({ checkpointStatuses: ['GODKÄND'], childStatuses: ['VERIFIED'] });
+  const finalAssessment = moveSaluFlagToFinalAssessment(acknowledged, readiness);
+  const closed = closeSaluFlagManually(finalAssessment, readiness);
+
+  assert.equal(finalAssessment.status, 'SLUTBEDÖMNING');
+  assert.equal(closed.status, 'STÄNGD');
+});
+
+test('active saludatum change keeps the same flag and recalculates escalation snapshot', () => {
+  const acknowledged = acknowledgeSaluFlag(activeFlag);
+  const changed = applyActiveSaludatumChange({
+    snapshot: acknowledged,
+    newSaludatum: '2026-10-31',
+    today: '2026-08-20',
+  });
+
+  assert.equal(changed.flagId, acknowledged.flagId);
+  assert.equal(changed.cycleSaludatum, acknowledged.cycleSaludatum);
+  assert.equal(changed.currentSaludatum, '2026-10-31');
+  assert.equal(changed.escalationStatus, 'NORMAL');
+});
+
+test('closed flag cannot be mutated by active-plan date change', () => {
+  const closed: SaluFlagSnapshot = { ...activeFlag, status: 'STÄNGD' };
+
+  assert.throws(
+    () => applyActiveSaludatumChange({ snapshot: closed, newSaludatum: '2026-10-31', today: '2026-08-20' }),
+    /closed SALU flag/i,
+  );
+});
+
+test('reopening creates a new NY flag and keeps previous flag identity historical', () => {
+  const previous: SaluFlagSnapshot = {
+    ...activeFlag,
+    status: 'STÄNGD',
+    currentSaludatum: '2026-08-19',
+    escalationStatus: 'PASSERAD',
+  };
+
+  const reopened = createReopenedSaluFlag({ previous, newFlagId: 'flag-2', today: '2026-08-20' });
+
+  assert.equal(reopened.flagId, 'flag-2');
+  assert.equal(reopened.previousFlagId, 'flag-1');
+  assert.equal(reopened.status, 'NY');
+  assert.equal(reopened.currentSaludatum, '2026-08-19');
+  assert.equal(reopened.cycleSaludatum, '2026-08-19');
+  assert.equal(reopened.escalationStatus, 'PASSERAD');
+  assert.equal(previous.status, 'STÄNGD');
+});

--- a/tests/salu-process.test.ts
+++ b/tests/salu-process.test.ts
@@ -8,6 +8,7 @@ import {
   closeSaluFlagManually,
   createReopenedSaluFlag,
   moveSaluFlagToFinalAssessment,
+  transitionSaluChildStatus,
   type SaluFlagSnapshot,
 } from '../lib/salu-process';
 
@@ -25,6 +26,32 @@ test('NY flag is acknowledged into HANDLÄGGS without changing ownership identit
   assert.equal(next.status, 'HANDLÄGGS');
   assert.equal(next.flagId, activeFlag.flagId);
   assert.equal(next.regnr, activeFlag.regnr);
+});
+
+test('child process follows CREATED -> ACCEPTED -> IN_PROGRESS -> READY_FOR_VERIFICATION -> VERIFIED', () => {
+  let status = transitionSaluChildStatus('CREATED', 'ACCEPTED');
+  status = transitionSaluChildStatus(status, 'IN_PROGRESS');
+  status = transitionSaluChildStatus(status, 'READY_FOR_VERIFICATION');
+  status = transitionSaluChildStatus(status, 'VERIFIED');
+  assert.equal(status, 'VERIFIED');
+});
+
+test('verification rejection returns the same child process to IN_PROGRESS', () => {
+  assert.equal(
+    transitionSaluChildStatus('READY_FOR_VERIFICATION', 'IN_PROGRESS'),
+    'IN_PROGRESS',
+  );
+});
+
+test('child process cannot skip ACCEPTED and terminal states cannot reopen', () => {
+  assert.throws(
+    () => transitionSaluChildStatus('CREATED', 'IN_PROGRESS'),
+    /Invalid SALU child transition/,
+  );
+  assert.throws(
+    () => transitionSaluChildStatus('VERIFIED', 'IN_PROGRESS'),
+    /Terminal SALU child status/,
+  );
 });
 
 test('close readiness blocks on VÄNTAR checkpoint and non-terminal child process', () => {
@@ -54,6 +81,14 @@ test('manual close requires SLUTBEDÖMNING and ready conditions', () => {
 
   assert.equal(finalAssessment.status, 'SLUTBEDÖMNING');
   assert.equal(closed.status, 'STÄNGD');
+});
+
+test('final assessment cannot be entered directly from NY', () => {
+  const readiness = assessSaluCloseReadiness({ checkpointStatuses: ['GODKÄND'], childStatuses: [] });
+  assert.throws(
+    () => moveSaluFlagToFinalAssessment(activeFlag, readiness),
+    /HANDLÄGGS or VÄNTAR/,
+  );
 });
 
 test('active saludatum change keeps the same flag and recalculates escalation snapshot', () => {


### PR DESCRIPTION
## Syfte
Andra kontrollerade implementationen efter 4.1B teknisk gap-analys med GO.

## Ingår
- kanoniska SALU-flaggstatusar och checkpointstatusar
- barnprocessstatus med terminalregel VERIFIED/CANCELLED
- stängningsberedskap utan auto-stängning
- explicit övergång NY -> HANDLÄGGS -> SLUTBEDÖMNING -> STÄNGD
- aktiv saludatumändring behåller samma flagga och räknar om eskalering
- återöppning efter STÄNGD skapar ny flagga med previousFlagId
- fokuserade regressionstester

## Ingår inte
- ingen databas-DDL eller Production-migration
- ingen backfill
- ingen UI-förändring
- ingen faktisk schemaläggning eller automatisk flaggskapning
- ingen RBAC
- ingen Kistan/Planner

## Kontraktsregler som täcks
B1, B2, B6, B8, B9 samt 9AB, 9AC-9AI.

## Säkerhet
Ingen Production-write eller syntetisk verksamhetsdata. Ändringen är en sidoeffektsfri domänmodul och tester.