### PR TITLE
4.1B-3: add SALU trigger evaluation engine

### DIFF
--- a/lib/salu-trigger-engine.ts
+++ b/lib/salu-trigger-engine.ts
@@ -1,0 +1,101 @@
+import { saluFlagDate } from './salu-core';
+import type { SaluEscalationStatus } from './salu-core';
+
+export type SaluTriggerEvent =
+  | 'SALU_FLAG_CREATED'
+  | 'SALU_T10_ESCALATED'
+  | 'SALU_T0_PASSED';
+
+export type SaluTriggerAction = {
+  type: SaluTriggerEvent;
+  eventKey: string;
+  saludatum: string;
+};
+
+export type SaluTriggerEvaluation = {
+  actions: SaluTriggerAction[];
+  requiresCatchUpPolicy: boolean;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseIsoDate(value: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) throw new Error(`Invalid ISO date: ${value}`);
+  const result = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+  if (
+    result.getUTCFullYear() !== Number(match[1]) ||
+    result.getUTCMonth() !== Number(match[2]) - 1 ||
+    result.getUTCDate() !== Number(match[3])
+  ) {
+    throw new Error(`Invalid calendar date: ${value}`);
+  }
+  return result;
+}
+
+function formatIsoDate(value: Date): string {
+  return `${value.getUTCFullYear()}-${String(value.getUTCMonth() + 1).padStart(2, '0')}-${String(value.getUTCDate()).padStart(2, '0')}`;
+}
+
+function addDays(isoDate: string, days: number): string {
+  const value = parseIsoDate(isoDate);
+  value.setUTCDate(value.getUTCDate() + days);
+  return formatIsoDate(value);
+}
+
+function compareDates(left: string, right: string): number {
+  return Math.sign(parseIsoDate(left).getTime() - parseIsoDate(right).getTime());
+}
+
+function eventKey(type: SaluTriggerEvent, saludatum: string): string {
+  return `${type}:${saludatum}`;
+}
+
+export function evaluateSaluTriggers(input: {
+  today: string;
+  saludatum: string;
+  hasActiveFlag: boolean;
+  activeFlagEscalation?: SaluEscalationStatus;
+  emittedEventKeys?: Iterable<string>;
+}): SaluTriggerEvaluation {
+  const emitted = new Set(input.emittedEventKeys ?? []);
+  const actions: SaluTriggerAction[] = [];
+  const t30 = saluFlagDate(input.saludatum);
+  const t10 = addDays(input.saludatum, -10);
+
+  if (!input.hasActiveFlag) {
+    if (input.today === t30) {
+      const key = eventKey('SALU_FLAG_CREATED', input.saludatum);
+      if (!emitted.has(key)) {
+        actions.push({ type: 'SALU_FLAG_CREATED', eventKey: key, saludatum: input.saludatum });
+      }
+      return { actions, requiresCatchUpPolicy: false };
+    }
+
+    return {
+      actions,
+      requiresCatchUpPolicy: compareDates(input.today, t30) > 0,
+    };
+  }
+
+  if (compareDates(input.today, input.saludatum) >= 0) {
+    const key = eventKey('SALU_T0_PASSED', input.saludatum);
+    if (!emitted.has(key)) {
+      actions.push({ type: 'SALU_T0_PASSED', eventKey: key, saludatum: input.saludatum });
+    }
+    return { actions, requiresCatchUpPolicy: false };
+  }
+
+  if (compareDates(input.today, t10) >= 0) {
+    const key = eventKey('SALU_T10_ESCALATED', input.saludatum);
+    if (!emitted.has(key)) {
+      actions.push({ type: 'SALU_T10_ESCALATED', eventKey: key, saludatum: input.saludatum });
+    }
+  }
+
+  return { actions, requiresCatchUpPolicy: false };
+}
+
+export function daysBetween(left: string, right: string): number {
+  return Math.round((parseIsoDate(right).getTime() - parseIsoDate(left).getTime()) / DAY_MS);
+}

--- a/tests/salu-trigger-engine.test.ts
+++ b/tests/salu-trigger-engine.test.ts
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evaluateSaluTriggers } from '../lib/salu-trigger-engine';
+
+test('T-30 creates a flag action exactly on trigger date when no active flag exists', () => {
+  const result = evaluateSaluTriggers({
+    today: '2026-08-01',
+    saludatum: '2026-08-31',
+    hasActiveFlag: false,
+  });
+
+  assert.deepEqual(result, {
+    actions: [
+      {
+        type: 'SALU_FLAG_CREATED',
+        eventKey: 'SALU_FLAG_CREATED:2026-08-31',
+        saludatum: '2026-08-31',
+      },
+    ],
+    requiresCatchUpPolicy: false,
+  });
+});
+
+test('no active flag after T-30 is surfaced as unresolved catch-up policy instead of guessed automation', () => {
+  const result = evaluateSaluTriggers({
+    today: '2026-08-20',
+    saludatum: '2026-08-31',
+    hasActiveFlag: false,
+  });
+
+  assert.deepEqual(result, { actions: [], requiresCatchUpPolicy: true });
+});
+
+test('before T-30 no flag action is due', () => {
+  const result = evaluateSaluTriggers({
+    today: '2026-07-31',
+    saludatum: '2026-08-31',
+    hasActiveFlag: false,
+  });
+
+  assert.deepEqual(result, { actions: [], requiresCatchUpPolicy: false });
+});
+
+test('active flag emits T10 once for the current saludatum', () => {
+  const first = evaluateSaluTriggers({
+    today: '2026-08-21',
+    saludatum: '2026-08-31',
+    hasActiveFlag: true,
+  });
+
+  assert.equal(first.actions[0]?.type, 'SALU_T10_ESCALATED');
+
+  const second = evaluateSaluTriggers({
+    today: '2026-08-22',
+    saludatum: '2026-08-31',
+    hasActiveFlag: true,
+    emittedEventKeys: [first.actions[0]!.eventKey],
+  });
+
+  assert.deepEqual(second.actions, []);
+});
+
+test('active flag emits T0/PASSERAD on saludatum and suppresses retrospective T10', () => {
+  const result = evaluateSaluTriggers({
+    today: '2026-08-31',
+    saludatum: '2026-08-31',
+    hasActiveFlag: true,
+  });
+
+  assert.deepEqual(result.actions.map((action) => action.type), ['SALU_T0_PASSED']);
+});
+
+test('a changed saludatum gets its own idempotency key so a later T10 can be emitted again', () => {
+  const result = evaluateSaluTriggers({
+    today: '2026-10-21',
+    saludatum: '2026-10-31',
+    hasActiveFlag: true,
+    emittedEventKeys: ['SALU_T10_ESCALATED:2026-08-31'],
+  });
+
+  assert.deepEqual(result.actions, [
+    {
+      type: 'SALU_T10_ESCALATED',
+      eventKey: 'SALU_T10_ESCALATED:2026-10-31',
+      saludatum: '2026-10-31',
+    },
+  ]);
+});
+
+test('T0 catch-up for an active flag is idempotent for the current saludatum', () => {
+  const result = evaluateSaluTriggers({
+    today: '2026-09-02',
+    saludatum: '2026-08-31',
+    hasActiveFlag: true,
+    emittedEventKeys: ['SALU_T0_PASSED:2026-08-31'],
+  });
+
+  assert.deepEqual(result.actions, []);
+});


### PR DESCRIPTION
## Syfte
Tredje kontrollerade implementationen efter 4.1B teknisk gap-analys med GO.

## Ingår
- ren T-30/T-10/T-0-utvärdering utan sidoeffekter
- idempotensnycklar per eventtyp + aktuellt saludatum
- ny saludatumplan kan skapa nytt T10/T0-event utan att historik raderas
- T0/PASSERAD prioriteras över retrospektiv T10
- aktiv flagga kan få T0 catch-up idempotent
- olåst catch-up för saknad flagga efter T-30 gissas inte utan markeras explicit som policybehov
- fokuserade regressionstester

## Ingår inte
- ingen schemaläggare/cron
- ingen databas-DDL eller Production-migration
- ingen faktisk flaggskapning eller event-write
- ingen backfill
- ingen UI-förändring
- ingen Kistan/Planner

## Kontraktsregler som täcks
T-30, B7, 9AB, 9AM samt append-only/idempotensprincipen.

## Säkerhet
Ingen Production-write eller syntetisk verksamhetsdata. Modulen returnerar endast föreslagna actions; exekvering kopplas först i separat steg när lagring och catch-up-policy är verifierade.