### PR TITLE
4.1B-5: add gated atomic SALU plan endpoint

### DIFF
--- a/app/api/salu/plan/route.ts
+++ b/app/api/salu/plan/route.ts
@@ -20,6 +20,16 @@ type PlanRequest = {
   manualMonths?: number;
 };
 
+type SaluAutoRuleRow = {
+  rule_id: string;
+  rule_version: number;
+  make: string;
+  model_tokens: string[] | null;
+  months: number;
+  priority: number;
+  active: boolean;
+};
+
 type PersistedPlanRow = {
   original_saludatum: string;
   previous_saludatum: string | null;
@@ -29,6 +39,18 @@ type PersistedPlanRow = {
 
 function cleanRegnr(value: string): string {
   return value.toUpperCase().replace(/\s+/g, '');
+}
+
+function isValidIsoDate(value: string): boolean {
+  if (!ISO_DATE_RE.test(value)) {
+    return false;
+  }
+
+  try {
+    return addCalendarMonths(value, 0) === value;
+  } catch {
+    return false;
+  }
 }
 
 function createAdminClient() {
@@ -72,7 +94,7 @@ export async function POST(request: Request) {
   if (!REGNR_RE.test(regnr)) {
     return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
   }
-  if (!ISO_DATE_RE.test(nyDate)) {
+  if (!isValidIsoDate(nyDate)) {
     return NextResponse.json({ error: 'Invalid nyDate' }, { status: 400 });
   }
   if (!make || !model || (mode !== 'AUTO' && mode !== 'MANUELL')) {
@@ -103,7 +125,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Failed to load SALU rules' }, { status: 500 });
     }
 
-    const rules: SaluAutoRule[] = (ruleRows ?? []).map((row: any) => ({
+    const rules: SaluAutoRule[] = ((ruleRows ?? []) as SaluAutoRuleRow[]).map((row) => ({
       id: row.rule_id,
       version: row.rule_version,
       make: row.make,

--- a/app/api/salu/plan/route.ts
+++ b/app/api/salu/plan/route.ts
@@ -1,0 +1,190 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+import {
+  addCalendarMonths,
+  calculateAutoSaludatum,
+  type SaluAutoRule,
+  type SaluControlMode,
+} from '@/lib/salu-core';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+type PlanRequest = {
+  regnr?: string;
+  nyDate?: string;
+  make?: string;
+  model?: string;
+  mode?: SaluControlMode;
+  manualMonths?: number;
+};
+
+function cleanRegnr(value: string): string {
+  return value.toUpperCase().replace(/\s+/g, '');
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing Supabase server configuration');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  if (process.env.SALU_WRITES_ENABLED !== 'true') {
+    return NextResponse.json(
+      { error: 'SALU writes are not enabled' },
+      { status: 503 },
+    );
+  }
+
+  let body: PlanRequest;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const regnr = cleanRegnr(body.regnr ?? '');
+  const nyDate = body.nyDate ?? '';
+  const make = (body.make ?? '').trim();
+  const model = (body.model ?? '').trim();
+  const mode = body.mode;
+
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+  if (!ISO_DATE_RE.test(nyDate)) {
+    return NextResponse.json({ error: 'Invalid nyDate' }, { status: 400 });
+  }
+  if (!make || !model || (mode !== 'AUTO' && mode !== 'MANUELL')) {
+    return NextResponse.json({ error: 'make, model and valid mode are required' }, { status: 400 });
+  }
+
+  const admin = createAdminClient();
+  let saludatum: string;
+  let autoRuleId: string | null = null;
+  let autoRuleVersion: number | null = null;
+  let autoMonthsApplied: number | null = null;
+  let manualMonths: number | null = null;
+
+  if (mode === 'MANUELL') {
+    if (!Number.isInteger(body.manualMonths) || Number(body.manualMonths) <= 0) {
+      return NextResponse.json({ error: 'manualMonths must be a positive integer' }, { status: 400 });
+    }
+    manualMonths = Number(body.manualMonths);
+    saludatum = addCalendarMonths(nyDate, manualMonths);
+  } else {
+    const { data: ruleRows, error: ruleError } = await admin
+      .from('salu_auto_rules')
+      .select('rule_id,rule_version,make,model_tokens,months,priority,active')
+      .eq('active', true);
+
+    if (ruleError) {
+      console.error('[SALU plan] Failed to load AUTO rules:', ruleError);
+      return NextResponse.json({ error: 'Failed to load SALU rules' }, { status: 500 });
+    }
+
+    const rules: SaluAutoRule[] = (ruleRows ?? []).map((row: any) => ({
+      id: row.rule_id,
+      version: row.rule_version,
+      make: row.make,
+      modelTokens: row.model_tokens ?? [],
+      months: row.months,
+      priority: row.priority,
+      active: row.active,
+    }));
+
+    const match = calculateAutoSaludatum({ nyDate, make, model, rules });
+    if (!match) {
+      return NextResponse.json(
+        { error: 'No AUTO rule matched; MANUELL is required' },
+        { status: 422 },
+      );
+    }
+
+    saludatum = match.saludatum;
+    autoRuleId = match.ruleId;
+    autoRuleVersion = match.ruleVersion;
+    autoMonthsApplied = match.monthsApplied;
+  }
+
+  const { data: existing, error: existingError } = await admin
+    .from('salu_vehicle_state')
+    .select('original_saludatum,current_saludatum')
+    .eq('regnr', regnr)
+    .maybeSingle();
+
+  if (existingError) {
+    console.error('[SALU plan] Failed to read vehicle state:', existingError);
+    return NextResponse.json({ error: 'Failed to read SALU vehicle state' }, { status: 500 });
+  }
+
+  const originalSaludatum = existing?.original_saludatum ?? saludatum;
+  const oldSaludatum = existing?.current_saludatum ?? null;
+
+  const { error: stateError } = await admin.from('salu_vehicle_state').upsert({
+    regnr,
+    ny_date: nyDate,
+    original_saludatum: originalSaludatum,
+    current_saludatum: saludatum,
+    control_mode: mode,
+    manual_months: manualMonths,
+    auto_rule_id: autoRuleId,
+    auto_rule_version: autoRuleVersion,
+    auto_months_applied: autoMonthsApplied,
+    updated_by: verification.user.id,
+    updated_at: new Date().toISOString(),
+  });
+
+  if (stateError) {
+    console.error('[SALU plan] Failed to save vehicle state:', stateError);
+    return NextResponse.json({ error: 'Failed to save SALU vehicle state' }, { status: 500 });
+  }
+
+  if (oldSaludatum !== saludatum) {
+    const { error: eventError } = await admin.from('salu_events').insert({
+      regnr,
+      event_type: 'SALU_SALUDATUM_CHANGED',
+      actor_id: verification.user.id,
+      actor_source: 'MANUELL',
+      payload: {
+        old_saludatum: oldSaludatum,
+        new_saludatum: saludatum,
+        source: mode,
+        auto_rule_id: autoRuleId,
+        auto_rule_version: autoRuleVersion,
+        months_applied: autoMonthsApplied ?? manualMonths,
+      },
+    });
+
+    if (eventError) {
+      console.error('[SALU plan] Failed to append plan event:', eventError);
+      return NextResponse.json({ error: 'SALU state saved but audit event failed' }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json({
+    data: {
+      regnr,
+      mode,
+      nyDate,
+      originalSaludatum,
+      saludatum,
+      autoRuleId,
+      autoRuleVersion,
+      monthsApplied: autoMonthsApplied ?? manualMonths,
+    },
+  });
+}

--- a/app/api/salu/plan/route.ts
+++ b/app/api/salu/plan/route.ts
@@ -20,6 +20,13 @@ type PlanRequest = {
   manualMonths?: number;
 };
 
+type PersistedPlanRow = {
+  original_saludatum: string;
+  previous_saludatum: string | null;
+  current_saludatum: string;
+  changed: boolean;
+};
+
 function cleanRegnr(value: string): string {
   return value.toUpperCase().replace(/\s+/g, '');
 }
@@ -120,59 +127,26 @@ export async function POST(request: Request) {
     autoMonthsApplied = match.monthsApplied;
   }
 
-  const { data: existing, error: existingError } = await admin
-    .from('salu_vehicle_state')
-    .select('original_saludatum,current_saludatum')
-    .eq('regnr', regnr)
-    .maybeSingle();
-
-  if (existingError) {
-    console.error('[SALU plan] Failed to read vehicle state:', existingError);
-    return NextResponse.json({ error: 'Failed to read SALU vehicle state' }, { status: 500 });
-  }
-
-  const originalSaludatum = existing?.original_saludatum ?? saludatum;
-  const oldSaludatum = existing?.current_saludatum ?? null;
-
-  const { error: stateError } = await admin.from('salu_vehicle_state').upsert({
-    regnr,
-    ny_date: nyDate,
-    original_saludatum: originalSaludatum,
-    current_saludatum: saludatum,
-    control_mode: mode,
-    manual_months: manualMonths,
-    auto_rule_id: autoRuleId,
-    auto_rule_version: autoRuleVersion,
-    auto_months_applied: autoMonthsApplied,
-    updated_by: verification.user.id,
-    updated_at: new Date().toISOString(),
+  const { data: persistedRows, error: persistError } = await admin.rpc('apply_salu_vehicle_plan', {
+    p_regnr: regnr,
+    p_ny_date: nyDate,
+    p_saludatum: saludatum,
+    p_control_mode: mode,
+    p_manual_months: manualMonths,
+    p_auto_rule_id: autoRuleId,
+    p_auto_rule_version: autoRuleVersion,
+    p_auto_months_applied: autoMonthsApplied,
+    p_actor_id: verification.user.id,
   });
 
-  if (stateError) {
-    console.error('[SALU plan] Failed to save vehicle state:', stateError);
-    return NextResponse.json({ error: 'Failed to save SALU vehicle state' }, { status: 500 });
+  if (persistError) {
+    console.error('[SALU plan] Failed to persist vehicle plan:', persistError);
+    return NextResponse.json({ error: 'Failed to persist SALU vehicle plan' }, { status: 500 });
   }
 
-  if (oldSaludatum !== saludatum) {
-    const { error: eventError } = await admin.from('salu_events').insert({
-      regnr,
-      event_type: 'SALU_SALUDATUM_CHANGED',
-      actor_id: verification.user.id,
-      actor_source: 'MANUELL',
-      payload: {
-        old_saludatum: oldSaludatum,
-        new_saludatum: saludatum,
-        source: mode,
-        auto_rule_id: autoRuleId,
-        auto_rule_version: autoRuleVersion,
-        months_applied: autoMonthsApplied ?? manualMonths,
-      },
-    });
-
-    if (eventError) {
-      console.error('[SALU plan] Failed to append plan event:', eventError);
-      return NextResponse.json({ error: 'SALU state saved but audit event failed' }, { status: 500 });
-    }
+  const persisted = (persistedRows?.[0] ?? null) as PersistedPlanRow | null;
+  if (!persisted) {
+    return NextResponse.json({ error: 'SALU plan persistence returned no result' }, { status: 500 });
   }
 
   return NextResponse.json({
@@ -180,8 +154,10 @@ export async function POST(request: Request) {
       regnr,
       mode,
       nyDate,
-      originalSaludatum,
-      saludatum,
+      originalSaludatum: persisted.original_saludatum,
+      previousSaludatum: persisted.previous_saludatum,
+      saludatum: persisted.current_saludatum,
+      changed: persisted.changed,
       autoRuleId,
       autoRuleVersion,
       monthsApplied: autoMonthsApplied ?? manualMonths,

--- a/lib/salu-core.ts
+++ b/lib/salu-core.ts
@@ -140,7 +140,12 @@ export function selectSaluAutoRule(
       return priorityDifference;
     }
 
-    return left.id.localeCompare(right.id);
+    const ruleIdDifference = left.id.localeCompare(right.id);
+    if (ruleIdDifference !== 0) {
+      return ruleIdDifference;
+    }
+
+    return right.version - left.version;
   })[0];
 }
 

--- a/migrations/20260820_add_salu_plan_rpc.sql
+++ b/migrations/20260820_add_salu_plan_rpc.sql
@@ -23,9 +23,12 @@ returns table (
 language plpgsql
 as $$
 declare
+  v_existing_ny_date date;
   v_existing_original date;
   v_existing_current date;
   v_original date;
+  v_active_flag_id uuid;
+  v_escalation_status text;
 begin
   if p_control_mode not in ('AUTO', 'MANUELL') then
     raise exception 'Invalid SALU control mode';
@@ -51,10 +54,21 @@ begin
     end if;
   end if;
 
-  select s.original_saludatum, s.current_saludatum
-    into v_existing_original, v_existing_current
+  select s.ny_date, s.original_saludatum, s.current_saludatum
+    into v_existing_ny_date, v_existing_original, v_existing_current
   from public.salu_vehicle_state s
   where s.regnr = p_regnr
+  for update;
+
+  if v_existing_ny_date is not null and v_existing_ny_date <> p_ny_date then
+    raise exception 'NY date cannot be changed through SALU plan update';
+  end if;
+
+  select f.flag_id
+    into v_active_flag_id
+  from public.salu_flags f
+  where f.regnr = p_regnr
+    and f.status <> 'STÄNGD'
   for update;
 
   v_original := coalesce(v_existing_original, p_saludatum);
@@ -85,7 +99,7 @@ begin
     now()
   )
   on conflict (regnr) do update set
-    ny_date = excluded.ny_date,
+    ny_date = public.salu_vehicle_state.ny_date,
     original_saludatum = public.salu_vehicle_state.original_saludatum,
     current_saludatum = excluded.current_saludatum,
     control_mode = excluded.control_mode,
@@ -97,14 +111,32 @@ begin
     updated_at = excluded.updated_at;
 
   if v_existing_current is distinct from p_saludatum then
+    if p_saludatum <= current_date then
+      v_escalation_status := 'PASSERAD';
+    elsif p_saludatum <= current_date + 10 then
+      v_escalation_status := 'T10';
+    else
+      v_escalation_status := 'NORMAL';
+    end if;
+
+    if v_active_flag_id is not null then
+      update public.salu_flags
+      set
+        current_saludatum = p_saludatum,
+        escalation_status = v_escalation_status
+      where flag_id = v_active_flag_id;
+    end if;
+
     insert into public.salu_events (
       regnr,
+      flag_id,
       event_type,
       actor_id,
       actor_source,
       payload
     ) values (
       p_regnr,
+      v_active_flag_id,
       'SALU_SALUDATUM_CHANGED',
       p_actor_id,
       'MANUELL',
@@ -114,7 +146,8 @@ begin
         'source', p_control_mode,
         'auto_rule_id', p_auto_rule_id,
         'auto_rule_version', p_auto_rule_version,
-        'months_applied', coalesce(p_auto_months_applied, p_manual_months)
+        'months_applied', coalesce(p_auto_months_applied, p_manual_months),
+        'escalation_status', v_escalation_status
       )
     );
   end if;

--- a/migrations/20260820_add_salu_plan_rpc.sql
+++ b/migrations/20260820_add_salu_plan_rpc.sql
@@ -1,0 +1,139 @@
+-- 4.1B SALU atomic vehicle-plan persistence.
+-- Application calls this server-side through service_role only.
+
+begin;
+
+create or replace function public.apply_salu_vehicle_plan(
+  p_regnr text,
+  p_ny_date date,
+  p_saludatum date,
+  p_control_mode text,
+  p_manual_months integer,
+  p_auto_rule_id uuid,
+  p_auto_rule_version integer,
+  p_auto_months_applied integer,
+  p_actor_id uuid
+)
+returns table (
+  original_saludatum date,
+  previous_saludatum date,
+  current_saludatum date,
+  changed boolean
+)
+language plpgsql
+as $$
+declare
+  v_existing_original date;
+  v_existing_current date;
+  v_original date;
+begin
+  if p_control_mode not in ('AUTO', 'MANUELL') then
+    raise exception 'Invalid SALU control mode';
+  end if;
+
+  if p_saludatum < p_ny_date then
+    raise exception 'SALU date cannot be before NY date';
+  end if;
+
+  if p_control_mode = 'MANUELL' then
+    if p_manual_months is null or p_manual_months <= 0 then
+      raise exception 'MANUELL requires positive manual months';
+    end if;
+    if p_auto_rule_id is not null or p_auto_rule_version is not null or p_auto_months_applied is not null then
+      raise exception 'MANUELL cannot persist AUTO rule metadata';
+    end if;
+  else
+    if p_manual_months is not null then
+      raise exception 'AUTO cannot persist manual months';
+    end if;
+    if p_auto_rule_id is null or p_auto_rule_version is null or p_auto_months_applied is null then
+      raise exception 'AUTO requires exact rule metadata';
+    end if;
+  end if;
+
+  select s.original_saludatum, s.current_saludatum
+    into v_existing_original, v_existing_current
+  from public.salu_vehicle_state s
+  where s.regnr = p_regnr
+  for update;
+
+  v_original := coalesce(v_existing_original, p_saludatum);
+
+  insert into public.salu_vehicle_state (
+    regnr,
+    ny_date,
+    original_saludatum,
+    current_saludatum,
+    control_mode,
+    manual_months,
+    auto_rule_id,
+    auto_rule_version,
+    auto_months_applied,
+    updated_by,
+    updated_at
+  ) values (
+    p_regnr,
+    p_ny_date,
+    v_original,
+    p_saludatum,
+    p_control_mode,
+    p_manual_months,
+    p_auto_rule_id,
+    p_auto_rule_version,
+    p_auto_months_applied,
+    p_actor_id,
+    now()
+  )
+  on conflict (regnr) do update set
+    ny_date = excluded.ny_date,
+    original_saludatum = public.salu_vehicle_state.original_saludatum,
+    current_saludatum = excluded.current_saludatum,
+    control_mode = excluded.control_mode,
+    manual_months = excluded.manual_months,
+    auto_rule_id = excluded.auto_rule_id,
+    auto_rule_version = excluded.auto_rule_version,
+    auto_months_applied = excluded.auto_months_applied,
+    updated_by = excluded.updated_by,
+    updated_at = excluded.updated_at;
+
+  if v_existing_current is distinct from p_saludatum then
+    insert into public.salu_events (
+      regnr,
+      event_type,
+      actor_id,
+      actor_source,
+      payload
+    ) values (
+      p_regnr,
+      'SALU_SALUDATUM_CHANGED',
+      p_actor_id,
+      'MANUELL',
+      jsonb_build_object(
+        'old_saludatum', v_existing_current,
+        'new_saludatum', p_saludatum,
+        'source', p_control_mode,
+        'auto_rule_id', p_auto_rule_id,
+        'auto_rule_version', p_auto_rule_version,
+        'months_applied', coalesce(p_auto_months_applied, p_manual_months)
+      )
+    );
+  end if;
+
+  return query
+  select
+    v_original,
+    v_existing_current,
+    p_saludatum,
+    v_existing_current is distinct from p_saludatum;
+end;
+$$;
+
+revoke all on function public.apply_salu_vehicle_plan(
+  text, date, date, text, integer, uuid, integer, integer, uuid
+) from public, anon, authenticated;
+
+grant execute on function public.apply_salu_vehicle_plan(
+  text, date, date, text, integer, uuid, integer, integer, uuid
+) to service_role;
+
+commit;

--- a/tests/salu-core.test.ts
+++ b/tests/salu-core.test.ts
@@ -94,6 +94,18 @@ test('most specific matching AUTO rule wins before priority', () => {
   assert.equal(selectSaluAutoRule('Ford', 'Transit Custom', localRules)?.id, 'transit-custom');
 });
 
+test('same AUTO rule id selects the highest active version deterministically', () => {
+  const versionedRules: SaluAutoRule[] = [
+    { id: 'vw-default', version: 1, make: 'VW', months: 12 },
+    { id: 'vw-default', version: 3, make: 'VW', months: 18 },
+    { id: 'vw-default', version: 2, make: 'VW', months: 15 },
+  ];
+
+  const selected = selectSaluAutoRule('VW', 'Golf', versionedRules);
+  assert.equal(selected?.version, 3);
+  assert.equal(selected?.months, 18);
+});
+
 test('T-30 flag date is exactly 30 calendar days before saludatum', () => {
   assert.equal(saluFlagDate('2027-01-31'), '2027-01-01');
   assert.equal(saluFlagDate('2026-03-01'), '2026-01-30');

--- a/tests/salu-plan-server-contract.test.ts
+++ b/tests/salu-plan-server-contract.test.ts
@@ -26,6 +26,12 @@ test('SALU plan endpoint keeps human MANUELL precedence and explicit AUTO fallba
   assert.match(route, /No AUTO rule matched; MANUELL is required/);
 });
 
+test('SALU plan endpoint validates a real calendar NY date and does not use explicit any for AUTO rows', () => {
+  assert.match(route, /isValidIsoDate\(nyDate\)/);
+  assert.match(route, /type SaluAutoRuleRow/);
+  assert.doesNotMatch(route, /row:\s*any/);
+});
+
 test('SALU plan persistence uses one atomic RPC instead of separate state and audit writes', () => {
   assert.match(route, /\.rpc\('apply_salu_vehicle_plan'/);
   assert.doesNotMatch(route, /from\('salu_vehicle_state'\)\.upsert/);
@@ -37,6 +43,21 @@ test('atomic plan RPC preserves original saludatum and appends audit on actual c
   assert.match(migration, /original_saludatum = public\.salu_vehicle_state\.original_saludatum/);
   assert.match(migration, /v_existing_current is distinct from p_saludatum/);
   assert.match(migration, /'SALU_SALUDATUM_CHANGED'/);
+});
+
+test('atomic plan RPC keeps NY immutable and synchronizes an active flag without changing cycle identity', () => {
+  assert.match(migration, /NY date cannot be changed through SALU plan update/);
+  assert.match(migration, /where f\.regnr = p_regnr[\s\S]*f\.status <> 'STÄNGD'/);
+  assert.match(migration, /update public\.salu_flags[\s\S]*current_saludatum = p_saludatum/);
+  assert.match(migration, /escalation_status = v_escalation_status/);
+  assert.doesNotMatch(migration, /cycle_saludatum\s*=\s*p_saludatum/);
+});
+
+test('active plan changes can move escalation backwards while history remains append-only', () => {
+  assert.match(migration, /p_saludatum <= current_date[\s\S]*'PASSERAD'/);
+  assert.match(migration, /p_saludatum <= current_date \+ 10[\s\S]*'T10'/);
+  assert.match(migration, /v_escalation_status := 'NORMAL'/);
+  assert.match(migration, /flag_id,[\s\S]*v_active_flag_id,[\s\S]*'SALU_SALUDATUM_CHANGED'/);
 });
 
 test('atomic plan RPC is server-only', () => {

--- a/tests/salu-plan-server-contract.test.ts
+++ b/tests/salu-plan-server-contract.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const route = readFileSync(
+  join(process.cwd(), 'app/api/salu/plan/route.ts'),
+  'utf8',
+);
+
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/20260820_add_salu_plan_rpc.sql'),
+  'utf8',
+);
+
+test('SALU plan write endpoint is authenticated and disabled by default', () => {
+  assert.match(route, /verifyApiUser\(request\)/);
+  assert.match(route, /process\.env\.SALU_WRITES_ENABLED !== 'true'/);
+  assert.match(route, /status: 503/);
+});
+
+test('SALU plan endpoint keeps human MANUELL precedence and explicit AUTO fallback behavior', () => {
+  assert.match(route, /mode === 'MANUELL'/);
+  assert.match(route, /manualMonths must be a positive integer/);
+  assert.match(route, /calculateAutoSaludatum/);
+  assert.match(route, /No AUTO rule matched; MANUELL is required/);
+});
+
+test('SALU plan persistence uses one atomic RPC instead of separate state and audit writes', () => {
+  assert.match(route, /\.rpc\('apply_salu_vehicle_plan'/);
+  assert.doesNotMatch(route, /from\('salu_vehicle_state'\)\.upsert/);
+  assert.doesNotMatch(route, /from\('salu_events'\)\.insert/);
+});
+
+test('atomic plan RPC preserves original saludatum and appends audit on actual change', () => {
+  assert.match(migration, /v_original := coalesce\(v_existing_original, p_saludatum\)/);
+  assert.match(migration, /original_saludatum = public\.salu_vehicle_state\.original_saludatum/);
+  assert.match(migration, /v_existing_current is distinct from p_saludatum/);
+  assert.match(migration, /'SALU_SALUDATUM_CHANGED'/);
+});
+
+test('atomic plan RPC is server-only', () => {
+  assert.match(migration, /revoke all on function public\.apply_salu_vehicle_plan[\s\S]*from public, anon, authenticated/i);
+  assert.match(migration, /grant execute on function public\.apply_salu_vehicle_plan[\s\S]*to service_role/i);
+});


### PR DESCRIPTION
## Syfte
Femte kontrollerade implementationen efter 4.1B teknisk gap-analys med GO.

## Ingår
- autentiserad server-endpoint för AUTO/MANUELL SALU-plan
- feature gate `SALU_WRITES_ENABLED=true`; avstängd som standard
- AUTO laddar endast aktiva versionerade regler och använder befintlig token-säker matchningsmotor
- MANUELL kräver positivt heltal kalender­månader och har företräde
- AUTO utan matchning gissar inte utan kräver MANUELL
- atomisk persistence via ny server-only RPC
- original_saludatum bevaras vid normal planändring
- audit-event `SALU_SALUDATUM_CHANGED` skapas endast när datum faktiskt ändras
- kontraktstester för auth, feature gate, atomisk write och audit

## Ingår inte
- migrationerna appliceras inte mot Production i denna PR
- `SALU_WRITES_ENABLED` aktiveras inte
- ingen Nybil-UI kopplas ännu
- ingen catch-up, flaggskapning eller scheduler
- ingen RBAC för Bilkontroll-stängning
- ingen Kistan/Planner

## Säkerhet
Endpointen är både auth-skyddad och explicit write-gated. Standarddeploy kan därför inte skriva SALU-data även om koden är mergad. Ingen Production-write eller DDL körs i denna PR.