### PR TITLE
4.1B-6: seed versioned SALU AUTO rules

### DIFF
--- a/app/api/salu/plan/route.ts
+++ b/app/api/salu/plan/route.ts
@@ -28,6 +28,7 @@ type SaluAutoRuleRow = {
   months: number;
   priority: number;
   active: boolean;
+  valid_from: string;
 };
 
 type PersistedPlanRow = {
@@ -51,6 +52,10 @@ function isValidIsoDate(value: string): boolean {
   } catch {
     return false;
   }
+}
+
+function currentUtcDate(): string {
+  return new Date().toISOString().slice(0, 10);
 }
 
 function createAdminClient() {
@@ -117,8 +122,9 @@ export async function POST(request: Request) {
   } else {
     const { data: ruleRows, error: ruleError } = await admin
       .from('salu_auto_rules')
-      .select('rule_id,rule_version,make,model_tokens,months,priority,active')
-      .eq('active', true);
+      .select('rule_id,rule_version,make,model_tokens,months,priority,active,valid_from')
+      .eq('active', true)
+      .lte('valid_from', currentUtcDate());
 
     if (ruleError) {
       console.error('[SALU plan] Failed to load AUTO rules:', ruleError);

--- a/migrations/20260820_seed_salu_auto_rules_v1.sql
+++ b/migrations/20260820_seed_salu_auto_rules_v1.sql
@@ -1,0 +1,30 @@
+-- 4.1B SALU AUTO rule baseline v1.
+-- Versioned configuration only; no vehicle rows are recalculated or backfilled.
+
+begin;
+
+insert into public.salu_auto_rules (
+  rule_id,
+  rule_version,
+  make,
+  model_tokens,
+  months,
+  priority,
+  active,
+  valid_from
+) values
+  ('10000000-0000-4000-8000-000000000001', 1, 'Mercedes-Benz', '{}', 6, 0, true, '2026-08-20'),
+  ('10000000-0000-4000-8000-000000000002', 1, 'Mercedes-Benz', '{Sprinter}', 24, 10, true, '2026-08-20'),
+  ('10000000-0000-4000-8000-000000000003', 1, 'Mercedes-Benz', '{Citan}', 24, 10, true, '2026-08-20'),
+  ('10000000-0000-4000-8000-000000000004', 1, 'Mercedes-Benz', '{Vito}', 24, 10, true, '2026-08-20'),
+  ('10000000-0000-4000-8000-000000000005', 1, 'Mercedes-Benz', '{V}', 24, 10, true, '2026-08-20'),
+  ('20000000-0000-4000-8000-000000000001', 1, 'BMW', '{}', 6, 0, true, '2026-08-20'),
+  ('30000000-0000-4000-8000-000000000001', 1, 'VW', '{}', 12, 0, true, '2026-08-20'),
+  ('40000000-0000-4000-8000-000000000001', 1, 'KIA', '{}', 12, 0, true, '2026-08-20'),
+  ('50000000-0000-4000-8000-000000000001', 1, 'FORD', '{}', 12, 0, true, '2026-08-20'),
+  ('50000000-0000-4000-8000-000000000002', 1, 'FORD', '{Transit}', 24, 10, true, '2026-08-20'),
+  ('50000000-0000-4000-8000-000000000003', 1, 'FORD', '{Connect}', 24, 10, true, '2026-08-20'),
+  ('50000000-0000-4000-8000-000000000004', 1, 'FORD', '{Tourneo}', 24, 10, true, '2026-08-20')
+on conflict (rule_id, rule_version) do nothing;
+
+commit;

--- a/tests/salu-auto-rules-contract.test.ts
+++ b/tests/salu-auto-rules-contract.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/20260820_seed_salu_auto_rules_v1.sql'),
+  'utf8',
+);
+
+const route = readFileSync(
+  join(process.cwd(), 'app/api/salu/plan/route.ts'),
+  'utf8',
+);
+
+test('SALU AUTO baseline contains the locked make defaults', () => {
+  assert.match(migration, /'Mercedes-Benz', '\{\}', 6/);
+  assert.match(migration, /'BMW', '\{\}', 6/);
+  assert.match(migration, /'VW', '\{\}', 12/);
+  assert.match(migration, /'KIA', '\{\}', 12/);
+  assert.match(migration, /'FORD', '\{\}', 12/);
+});
+
+test('SALU AUTO baseline contains the locked 24-month model exceptions', () => {
+  for (const model of ['Sprinter', 'Citan', 'Vito', 'V', 'Transit', 'Connect', 'Tourneo']) {
+    assert.match(migration, new RegExp(`'\\{${model}\\}', 24`));
+  }
+});
+
+test('AUTO seed is versioned, idempotent and does not update existing versions', () => {
+  assert.match(migration, /rule_version/);
+  assert.match(migration, /on conflict \(rule_id, rule_version\) do nothing/i);
+  assert.doesNotMatch(migration, /do update/i);
+  assert.doesNotMatch(migration, /salu_vehicle_state|nybil_inventering/i);
+});
+
+test('AUTO endpoint only loads active rules that are already valid', () => {
+  assert.match(route, /\.eq\('active', true\)/);
+  assert.match(route, /\.lte\('valid_from', currentUtcDate\(\)\)/);
+});


### PR DESCRIPTION
## Syfte
Sjätte kontrollerade implementationen efter 4.1B teknisk gap-analys med GO.

## Ingår
- versionerad v1-baseline för låsta AUTO-regler
- Mercedes-Benz 6 månader med 24-månadersundantag Sprinter/Citan/Vito/V
- BMW 6 månader
- VW/KIA/FORD 12 månader
- FORD-undantag Transit/Connect/Tourneo 24 månader
- idempotent seed: befintlig regelversion skrivs inte om
- AUTO-endpoint filtrerar på active=true och valid_from <= dagens datum
- regressionstester för regelmatris och icke-retroaktiv konfiguration

## Ingår inte
- migrationen appliceras inte mot Production i denna PR
- inga befintliga fordon räknas om
- `SALU_WRITES_ENABLED` aktiveras inte
- ingen Nybil-UI
- ingen scheduler/catch-up
- ingen RBAC för Bilkontroll-stängning

## Säkerhet
Detta är endast repo-konfiguration och serverlogik. Ingen Production-DDL, backfill eller verksamhetswrite körs.