### PR TITLE
4.1B-7: add gated SALU scheduler contract

### DIFF
--- a/app/api/salu/scheduler/route.ts
+++ b/app/api/salu/scheduler/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { evaluateSaluTriggers } from '@/lib/salu-trigger-engine';
+import type { SaluEscalationStatus } from '@/lib/salu-core';
+
+type VehicleStateRow = {
+  regnr: string;
+  current_saludatum: string | null;
+};
+
+type ActiveFlagRow = {
+  flag_id: string;
+  regnr: string;
+  escalation_status: SaluEscalationStatus;
+};
+
+type EventKeyRow = {
+  regnr: string;
+  event_key: string | null;
+};
+
+type SchedulerAction = {
+  regnr: string;
+  saludatum: string;
+  type: 'SALU_FLAG_CREATED' | 'SALU_T10_ESCALATED' | 'SALU_T0_PASSED';
+  eventKey: string;
+};
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing Supabase server configuration');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+function utcToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function isAuthorized(request: Request): boolean {
+  const token = process.env.SALU_SCHEDULER_TOKEN;
+  if (!token) return false;
+  return request.headers.get('authorization') === `Bearer ${token}`;
+}
+
+export async function POST(request: Request) {
+  if (process.env.SALU_SCHEDULER_ENABLED !== 'true') {
+    return NextResponse.json({ error: 'SALU scheduler is not enabled' }, { status: 503 });
+  }
+
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const dryRun = url.searchParams.get('dryRun') === 'true' || process.env.SALU_WRITES_ENABLED !== 'true';
+  const today = url.searchParams.get('date') ?? utcToday();
+  const admin = createAdminClient();
+
+  const [statesResult, flagsResult, eventsResult] = await Promise.all([
+    admin
+      .from('salu_vehicle_state')
+      .select('regnr,current_saludatum')
+      .not('current_saludatum', 'is', null),
+    admin
+      .from('salu_flags')
+      .select('flag_id,regnr,escalation_status')
+      .neq('status', 'STÄNGD'),
+    admin
+      .from('salu_events')
+      .select('regnr,event_key')
+      .not('event_key', 'is', null),
+  ]);
+
+  if (statesResult.error || flagsResult.error || eventsResult.error) {
+    console.error('[SALU scheduler] Failed to load scheduler state', {
+      statesError: statesResult.error,
+      flagsError: flagsResult.error,
+      eventsError: eventsResult.error,
+    });
+    return NextResponse.json({ error: 'Failed to load SALU scheduler state' }, { status: 500 });
+  }
+
+  const states = (statesResult.data ?? []) as VehicleStateRow[];
+  const flags = (flagsResult.data ?? []) as ActiveFlagRow[];
+  const events = (eventsResult.data ?? []) as EventKeyRow[];
+
+  const flagsByRegnr = new Map(flags.map((flag) => [flag.regnr, flag]));
+  const eventKeysByRegnr = new Map<string, Set<string>>();
+  for (const event of events) {
+    if (!event.event_key) continue;
+    const set = eventKeysByRegnr.get(event.regnr) ?? new Set<string>();
+    set.add(event.event_key);
+    eventKeysByRegnr.set(event.regnr, set);
+  }
+
+  const actions: SchedulerAction[] = [];
+  const catchUpRequired: Array<{ regnr: string; saludatum: string }> = [];
+
+  for (const state of states) {
+    if (!state.current_saludatum) continue;
+    const activeFlag = flagsByRegnr.get(state.regnr);
+    const evaluation = evaluateSaluTriggers({
+      today,
+      saludatum: state.current_saludatum,
+      hasActiveFlag: Boolean(activeFlag),
+      activeFlagEscalation: activeFlag?.escalation_status,
+      emittedEventKeys: eventKeysByRegnr.get(state.regnr),
+    });
+
+    if (evaluation.requiresCatchUpPolicy) {
+      catchUpRequired.push({ regnr: state.regnr, saludatum: state.current_saludatum });
+    }
+
+    for (const action of evaluation.actions) {
+      actions.push({
+        regnr: state.regnr,
+        saludatum: action.saludatum,
+        type: action.type,
+        eventKey: action.eventKey,
+      });
+    }
+  }
+
+  const applied: SchedulerAction[] = [];
+  if (!dryRun) {
+    for (const action of actions) {
+      const { data, error } = await admin.rpc('apply_salu_trigger_action', {
+        p_regnr: action.regnr,
+        p_saludatum: action.saludatum,
+        p_event_type: action.type,
+        p_event_key: action.eventKey,
+      });
+
+      if (error) {
+        console.error('[SALU scheduler] Failed to apply trigger action', { action, error });
+        return NextResponse.json(
+          { error: 'Failed to apply SALU trigger action', action },
+          { status: 500 },
+        );
+      }
+
+      if (Array.isArray(data) && data[0]?.applied === true) {
+        applied.push(action);
+      }
+    }
+  }
+
+  return NextResponse.json({
+    data: {
+      date: today,
+      dryRun,
+      evaluatedVehicles: states.length,
+      actions,
+      applied,
+      catchUpRequired,
+    },
+  });
+}

--- a/migrations/20260820_add_salu_trigger_rpc.sql
+++ b/migrations/20260820_add_salu_trigger_rpc.sql
@@ -1,0 +1,114 @@
+-- 4.1B SALU atomic scheduler trigger persistence.
+-- Server-side only. Catch-up policy is deliberately not implemented here.
+
+begin;
+
+create or replace function public.apply_salu_trigger_action(
+  p_regnr text,
+  p_saludatum date,
+  p_event_type text,
+  p_event_key text
+)
+returns table (
+  applied boolean,
+  flag_id uuid,
+  escalation_status text
+)
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_flag_id uuid;
+  v_escalation text;
+begin
+  if p_event_type not in ('SALU_FLAG_CREATED', 'SALU_T10_ESCALATED', 'SALU_T0_PASSED') then
+    raise exception 'Unsupported SALU trigger event';
+  end if;
+
+  perform pg_advisory_xact_lock(hashtext(p_regnr));
+
+  if exists (select 1 from public.salu_events e where e.event_key = p_event_key) then
+    select f.flag_id, f.escalation_status
+      into v_flag_id, v_escalation
+    from public.salu_flags f
+    where f.regnr = p_regnr and f.status <> 'STÄNGD'
+    limit 1;
+
+    return query select false, v_flag_id, v_escalation;
+    return;
+  end if;
+
+  if p_event_type = 'SALU_FLAG_CREATED' then
+    if exists (
+      select 1 from public.salu_flags f
+      where f.regnr = p_regnr and f.status <> 'STÄNGD'
+    ) then
+      raise exception 'Active SALU flag already exists';
+    end if;
+
+    insert into public.salu_flags (
+      regnr,
+      cycle_saludatum,
+      current_saludatum,
+      status,
+      escalation_status,
+      owner_function
+    ) values (
+      p_regnr,
+      p_saludatum,
+      p_saludatum,
+      'NY',
+      'NORMAL',
+      'BILKONTROLL'
+    )
+    returning salu_flags.flag_id into v_flag_id;
+
+    v_escalation := 'NORMAL';
+  else
+    select f.flag_id
+      into v_flag_id
+    from public.salu_flags f
+    where f.regnr = p_regnr and f.status <> 'STÄNGD'
+    for update;
+
+    if v_flag_id is null then
+      raise exception 'No active SALU flag exists for escalation';
+    end if;
+
+    v_escalation := case
+      when p_event_type = 'SALU_T0_PASSED' then 'PASSERAD'
+      else 'T10'
+    end;
+
+    update public.salu_flags
+    set escalation_status = v_escalation
+    where salu_flags.flag_id = v_flag_id;
+  end if;
+
+  insert into public.salu_events (
+    regnr,
+    flag_id,
+    event_type,
+    event_key,
+    actor_source,
+    payload
+  ) values (
+    p_regnr,
+    v_flag_id,
+    p_event_type,
+    p_event_key,
+    'SYSTEM',
+    jsonb_build_object('saludatum', p_saludatum)
+  );
+
+  return query select true, v_flag_id, v_escalation;
+end;
+$$;
+
+revoke all on function public.apply_salu_trigger_action(text, date, text, text)
+  from public, anon, authenticated;
+grant execute on function public.apply_salu_trigger_action(text, date, text, text)
+  to service_role;
+
+commit;

--- a/tests/salu-scheduler-contract.test.ts
+++ b/tests/salu-scheduler-contract.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const route = readFileSync(
+  join(process.cwd(), 'app/api/salu/scheduler/route.ts'),
+  'utf8',
+);
+
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/20260820_add_salu_trigger_rpc.sql'),
+  'utf8',
+);
+
+test('SALU scheduler is separately enabled, token protected and write-gated', () => {
+  assert.match(route, /SALU_SCHEDULER_ENABLED !== 'true'/);
+  assert.match(route, /SALU_SCHEDULER_TOKEN/);
+  assert.match(route, /SALU_WRITES_ENABLED !== 'true'/);
+  assert.match(route, /dryRun/);
+});
+
+test('SALU scheduler delegates timing decisions to the tested trigger engine', () => {
+  assert.match(route, /evaluateSaluTriggers/);
+  assert.match(route, /requiresCatchUpPolicy/);
+  assert.match(route, /catchUpRequired/);
+
+  const catchUpBlock = route.match(
+    /if \(evaluation\.requiresCatchUpPolicy\) \{([\s\S]*?)\n    \}/,
+  )?.[1] ?? '';
+  assert.match(catchUpBlock, /catchUpRequired\.push/);
+  assert.doesNotMatch(catchUpBlock, /apply_salu_trigger_action|admin\.rpc|actions\.push/);
+});
+
+test('trigger persistence is atomic, idempotent, pinned and server-only', () => {
+  assert.match(migration, /pg_advisory_xact_lock/);
+  assert.match(migration, /where e\.event_key = p_event_key/);
+  assert.match(migration, /apply_salu_trigger_action/);
+  assert.match(migration, /security invoker/i);
+  assert.match(migration, /set search_path = ''/i);
+  assert.match(migration, /revoke all on function public\.apply_salu_trigger_action[\s\S]*public, anon, authenticated/i);
+  assert.match(migration, /grant execute on function public\.apply_salu_trigger_action[\s\S]*service_role/i);
+});
+
+test('T-30 creates one Bilkontroll-owned NY flag and escalation events update the active flag', () => {
+  assert.match(migration, /'NY'/);
+  assert.match(migration, /'BILKONTROLL'/);
+  assert.match(migration, /'SALU_T10_ESCALATED'/);
+  assert.match(migration, /'SALU_T0_PASSED'/);
+  assert.match(migration, /set escalation_status = v_escalation/);
+});


### PR DESCRIPTION
## Syfte
Sjunde kontrollerade implementationen efter 4.1B teknisk gap-analys med GO.

## Ingår
- server-side SALU scheduler-endpoint
- separat gate `SALU_SCHEDULER_ENABLED=true`
- bearer-token skydd via `SALU_SCHEDULER_TOKEN`
- writes kräver dessutom `SALU_WRITES_ENABLED=true`
- dry-run stöds och blir automatiskt aktivt när SALU-writes är avstängda
- T-30/T-10/T-0 använder den redan testade trigger-motorn
- atomisk/idempotent RPC för flaggskapning och eskalerings-event
- T-30 skapar NY flagga med Bilkontroll som ägare
- catch-up efter passerad T-30 rapporteras separat och skrivs inte automatiskt
- kontraktstester för gates, auth, idempotens och catch-up-gräns

## Ingår inte
- ingen cron-konfiguration/deploy aktiveras i denna PR
- migrationen appliceras inte mot Production
- catch-up-policy beslutas inte här
- inga befintliga fordon backfillas
- `SALU_SCHEDULER_ENABLED` eller `SALU_WRITES_ENABLED` aktiveras inte
- ingen Nybil-UI eller Bilkontroll-UI
- ingen RBAC-stängning
- ingen Kistan/Planner

## Säkerhet
Mergad kod kan inte köra scheduler-writes i standarddeploy utan två explicita feature gates plus scheduler-token. Ingen Production-DDL eller verksamhetswrite görs i denna PR.