### PR TITLE
Nybil: synka fysisk retirement av legacykolumner

### DIFF
--- a/docs/NYBIL_PHYSICAL_RETIREMENT_2026-08-20.md
+++ b/docs/NYBIL_PHYSICAL_RETIREMENT_2026-08-20.md
@@ -1,0 +1,54 @@
+# Nybil physical retirement — 2026-08-20
+
+## Status
+
+GO — fysisk retirement är genomförd i Production och repo:t är synkat med motsvarande migrationsfiler.
+
+## Bakgrund
+
+Steg 3.2D flyttade Nybil till kanoniska DB-fält och stoppade samtliga writes till sex historiska alias. Efter riktig Production-data och ny read-only preflight uppfylldes kriterierna för fysisk retirement.
+
+## Borttagna legacykolumner
+
+Följande kolumner har tagits bort från `public.nybil_inventering`:
+
+- `bilmodell` → canonical `modell`
+- `ankomstdatum` → canonical `registreringsdatum`
+- `monterade_dack` → canonical `hjultyp`
+- `hjul_till_forvaring` → canonical `hjul_ej_monterade`
+- `hjul_forvaring_station` → canonical `hjul_forvaring_ort`
+- `kompressor` → canonical `dackkompressor`
+
+Notifieringspayloadens fältnamn `hjul_till_forvaring` är ett separat API-/notifieringskontrakt och påverkas inte av att DB-kolumnen är borttagen.
+
+## Production-evidens före DROP
+
+- `public.nybil_inventering`: 198 rader.
+- Samtliga sex legacykolumner var nullable och saknade defaults.
+- 0 registrerade DB-dependencies på de sex kolumnerna.
+- Inga index eller constraints refererade legacykolumnerna.
+- Tre riktiga post-4E-rader (`AMJ52S`, `AMJ52B`, `AMJ52C`) använde canonical-fälten och hade samtliga sex legacyfält `NULL`.
+- `withNybilLegacyAliases(...)` var ren passthrough och genererade inga DB-alias.
+
+## Genomförande
+
+Kolumnerna droppades separat i Production och verifierades efter varje steg. Supabase migrationshistorik:
+
+- `20260820004314_retire_nybil_legacy_bilmodell`
+- `20260820004327_retire_nybil_legacy_ankomstdatum`
+- `20260820004336_retire_nybil_legacy_monterade_dack`
+- `20260820004344_retire_nybil_legacy_hjul_till_forvaring`
+- `20260820004352_retire_nybil_legacy_hjul_forvaring_station`
+- `20260820004401_retire_nybil_legacy_kompressor`
+
+## Verifiering efter DROP
+
+- 0 av de sex legacykolumnerna finns kvar i `public.nybil_inventering`.
+- Tabellen har fortsatt 198 rader.
+- `v_nybil_baseline` fungerar och returnerade 198 rader i slutkontrollen.
+- `v_wheel_storage_precedence` fungerar och returnerade 1288 rader i slutkontrollen.
+- Ingen kvarvarande DB-definition matchade de fysiskt borttagna legacykolumnerna som dependency.
+
+## Slutsats
+
+Nybil-datamodellen använder nu endast de kanoniska DB-kolumnerna för dessa sex begrepp. Den tidigare dubbellagringen är fysiskt borttagen.

--- a/migrations/20260820004314_retire_nybil_legacy_bilmodell.sql
+++ b/migrations/20260820004314_retire_nybil_legacy_bilmodell.sql
@@ -1,0 +1,1 @@
+alter table public.nybil_inventering drop column bilmodell;

--- a/migrations/20260820004327_retire_nybil_legacy_ankomstdatum.sql
+++ b/migrations/20260820004327_retire_nybil_legacy_ankomstdatum.sql
@@ -1,0 +1,1 @@
+alter table public.nybil_inventering drop column ankomstdatum;

--- a/migrations/20260820004336_retire_nybil_legacy_monterade_dack.sql
+++ b/migrations/20260820004336_retire_nybil_legacy_monterade_dack.sql
@@ -1,0 +1,1 @@
+alter table public.nybil_inventering drop column monterade_dack;

--- a/migrations/20260820004344_retire_nybil_legacy_hjul_till_forvaring.sql
+++ b/migrations/20260820004344_retire_nybil_legacy_hjul_till_forvaring.sql
@@ -1,0 +1,1 @@
+alter table public.nybil_inventering drop column hjul_till_forvaring;

--- a/migrations/20260820004352_retire_nybil_legacy_hjul_forvaring_station.sql
+++ b/migrations/20260820004352_retire_nybil_legacy_hjul_forvaring_station.sql
@@ -1,0 +1,1 @@
+alter table public.nybil_inventering drop column hjul_forvaring_station;

--- a/migrations/20260820004401_retire_nybil_legacy_kompressor.sql
+++ b/migrations/20260820004401_retire_nybil_legacy_kompressor.sql
@@ -1,0 +1,1 @@
+alter table public.nybil_inventering drop column kompressor;


### PR DESCRIPTION
## Sammanfattning

Synkar repo:t med redan genomförd och verifierad Production-retirement av sex överflödiga legacykolumner i `public.nybil_inventering`.

### Migrationer

- `bilmodell`
- `ankomstdatum`
- `monterade_dack`
- `hjul_till_forvaring`
- `hjul_forvaring_station`
- `kompressor`

Varje DROP ligger i en separat migrationsfil och motsvarar en registrerad Supabase Production-migration.

### Evidens

- Preflight: nullable, inga defaults, 0 registrerade DB-dependencies.
- Tre riktiga post-4E Nybil-rader använder canonical-fält och lämnar samtliga sex legacyfält tomma.
- Efter DROP finns 198 `nybil_inventering`-rader kvar.
- `v_nybil_baseline` och `v_wheel_storage_precedence` fungerar efter retirement.
- Notifieringsfältet `hjul_till_forvaring` är ett separat payloadkontrakt och påverkas inte av att DB-kolumnen är borttagen.

### Scope

Endast migrationshistorik och dokumentation för den redan genomförda Production-ändringen. Ingen ny DML eller ytterligare schemaändring ingår i PR:n.