### PR TITLE
Supabase: hårdna function search_path

### DIFF
--- a/migrations/20260820010711_harden_public_function_search_paths.sql
+++ b/migrations/20260820010711_harden_public_function_search_paths.sql
@@ -1,0 +1,11 @@
+alter function public._coalesce_expr(text, text, text, text[], text) set search_path = pg_catalog, public;
+alter function public.car_lookup_any(text) set search_path = pg_catalog, public;
+alter function public.damages_lookup_any(text, text) set search_path = pg_catalog, public;
+alter function public.get_documented_legacy_texts(text) set search_path = pg_catalog, public;
+alter function public.get_nybil_baseline(text) set search_path = pg_catalog, public;
+alter function public.heartbeat_lock(text) set search_path = pg_catalog, public;
+alter function public.release_lock(text) set search_path = pg_catalog, public;
+alter function public.set_updated_at() set search_path = pg_catalog, public;
+alter function public.try_lock_checkin(text) set search_path = pg_catalog, public;
+alter function public.upsert_vehicles_from_staging() set search_path = pg_catalog, public;
+alter function public.wheel_lookup_any(text, text) set search_path = pg_catalog, public;


### PR DESCRIPTION
## Sammanfattning

Synkar repo:t med Production-migrationen `harden_public_function_search_paths`.

Migrationen sätter explicit `search_path = pg_catalog, public` på de 11 publika funktioner som Supabase Security Advisor tidigare flaggade med `function_search_path_mutable`.

## Funktioner

- `_coalesce_expr`
- `car_lookup_any`
- `damages_lookup_any`
- `get_documented_legacy_texts`
- `get_nybil_baseline`
- `heartbeat_lock`
- `release_lock`
- `set_updated_at`
- `try_lock_checkin`
- `upsert_vehicles_from_staging`
- `wheel_lookup_any`

## Production-verifiering

- Migrationen är applicerad i Production.
- Alla 11 funktioner har nu explicit `search_path`.
- Regressionstest på befintliga read-kontrakt gav samma resultat före och efter ändringen.
- Supabase Security Advisor visar inte längre några `function_search_path_mutable`-varningar.
- Inga EXECUTE-grants till `anon` eller `authenticated` ändrades.

## Scope

Endast `search_path`-härdning. PostgreSQL-plattformsuppgraderingen hanteras separat.