### PR TITLE
Supabase: RLS hygiene och dead policy cleanup

### DIFF
--- a/migrations/20260820011803_optimize_rls_initplan_and_remove_dead_damages_current_policies.sql
+++ b/migrations/20260820011803_optimize_rls_initplan_and_remove_dead_damages_current_policies.sql
@@ -1,0 +1,22 @@
+drop policy if exists employees_select_self_app on public.employees;
+create policy employees_select_self_app
+on public.employees
+for select
+to authenticated
+using (
+  (select private.is_app_user())
+  and lower(email) = lower((select auth.jwt() ->> 'email'))
+);
+
+drop policy if exists checkin_drafts_select_self_app on public.checkin_drafts;
+create policy checkin_drafts_select_self_app
+on public.checkin_drafts
+for select
+to authenticated
+using (
+  (select private.is_app_user())
+  and lower(user_email) = lower((select auth.jwt() ->> 'email'))
+);
+
+drop policy if exists "Enable read access for all users" on public.damages_current;
+drop policy if exists "Public read damages_current" on public.damages_current;


### PR DESCRIPTION
## Sammanfattning

Synkar repo:t med Production-migrationen `optimize_rls_initplan_and_remove_dead_damages_current_policies`.

Ändringen gör två avgränsade saker:

- skriver om `employees_select_self_app` och `checkin_drafts_select_self_app` så `auth.jwt()` ligger i en scalar subquery och kan initieras en gång per query;
- tar bort två döda permissiva SELECT-policies på `public.damages_current` som saknade motsvarande table grants och därför inte gav faktisk Data API-access.

## Production-verifiering

- Migrationen är applicerad i Production som `20260820011803`.
- `anon` har fortsatt ingen SELECT på `damages_current`.
- `authenticated` har fortsatt bara befintliga browser-grants på `employees` och `checkin_drafts`.
- Policydefinitionerna innehåller nu `(select auth.jwt() ->> 'email')`.
- Advisor-varningen `multiple_permissive_policies` för `damages_current` är borta.
- Supabase Advisor rapporterar fortfarande `auth_rls_initplan` för de två policyerna trots att katalogdefinitionen visar scalar-subquery-formen; detta behandlas som kvarvarande lint/advisor-signal, inte som ett bevis på att ändringen misslyckats.

## RLS/no-policy inventering

De tabeller som Security Advisor listar med `rls_enabled_no_policy` saknar samtidigt table privileges för både `anon` och `authenticated`. Det är därför avsiktligt stängda server-/backup-/stagingytor, inte öppna Data API-kontrakt. Ingen allow-policy läggs till i denna PR.

## Scope

Endast RLS/performance hygiene och borttagning av döda policies. Ingen business logic eller ny browser-access.