### PR TITLE
Supabase: ta bort verifierade dubblettindex

### DIFF
--- a/migrations/20260820012045_remove_verified_duplicate_indexes.sql
+++ b/migrations/20260820012045_remove_verified_duplicate_indexes.sql
@@ -1,0 +1,2 @@
+drop index if exists public.damages_regnr_idx;
+alter table public.vehicles drop constraint if exists vehicles_regnr_key;


### PR DESCRIPTION
## Sammanfattning

Synkar repo:t med Production-migrationen `remove_verified_duplicate_indexes`.

Ändringen tar bort två bevisat redundanta index/constraints:

- `public.damages_regnr_idx`, identisk med kvarvarande `public.idx_damages_regnr`;
- unique constraint `vehicles_regnr_key`, redundant mot primärnyckeln `vehicles_pkey` på samma kolumn `regnr`.

## Production-verifiering

- Migrationen är applicerad i Production som `20260820012045`.
- `idx_damages_regnr` finns kvar.
- `vehicles_pkey` finns kvar och är fortsatt `PRIMARY KEY (regnr)`.
- `vehicles` har 0 dubletter på `regnr`.
- `damages`: 1373 rader kvar.
- `vehicles`: 1263 rader kvar.
- Ingen repo-kod refererar de borttagna indexnamnen som runtime-kontrakt.

## Scope

Endast borttagning av verifierade dubblettindex. Ingen dataändring eller business logic.