### PR TITLE
Supabase: lägg till saknade FK-index

### DIFF
--- a/migrations/20260820012308_add_missing_foreign_key_indexes.sql
+++ b/migrations/20260820012308_add_missing_foreign_key_indexes.sql
@@ -1,0 +1,7 @@
+create index if not exists idx_checkins_completed_by on public.checkins (completed_by);
+create index if not exists idx_checkins_employee_id on public.checkins (employee_id);
+create index if not exists idx_checkins_locked_by on public.checkins (locked_by);
+create index if not exists idx_checkins_started_by on public.checkins (started_by);
+create index if not exists idx_checkins_station_id on public.checkins (station_id);
+create index if not exists idx_damage_media_damage_id on public.damage_media (damage_id);
+create index if not exists idx_damage_type_ref_parent_code on public.damage_type_ref (parent_code);


### PR DESCRIPTION
## Sammanfattning

Synkar repo:t med Production-migrationen `add_missing_foreign_key_indexes`.

Ändringen lägger till de sju B-tree-index som Supabase Performance Advisor flaggade som saknade för foreign keys:

- `checkins.completed_by`
- `checkins.employee_id`
- `checkins.locked_by`
- `checkins.started_by`
- `checkins.station_id`
- `damage_media.damage_id`
- `damage_type_ref.parent_code`

## Production-verifiering

- Migrationen är applicerad i Production som `20260820012308`.
- Alla sju index finns i katalogen efter migrationen.
- Berörda tabeller är små: `checkins` cirka 3 MB / 3,7k rader; `damage_media` och `damage_type_ref` är mycket små.
- Ingen business logic eller data ändras.

## Scope

Endast indexering av befintliga foreign-key-kolumner.