### PR TITLE
Supabase: cacha auth-email i RLS-policies

### DIFF
--- a/migrations/20260820012651_cache_auth_email_for_rls_policies.sql
+++ b/migrations/20260820012651_cache_auth_email_for_rls_policies.sql
@@ -1,0 +1,32 @@
+create or replace function private.current_auth_email()
+returns text
+language sql
+stable
+security invoker
+set search_path = ''
+as $$
+  select lower(auth.jwt() ->> 'email');
+$$;
+
+revoke all on function private.current_auth_email() from public, anon;
+grant execute on function private.current_auth_email() to authenticated, service_role;
+
+drop policy if exists employees_select_self_app on public.employees;
+create policy employees_select_self_app
+on public.employees
+for select
+to authenticated
+using (
+  (select private.is_app_user())
+  and lower(email) = (select private.current_auth_email())
+);
+
+drop policy if exists checkin_drafts_select_self_app on public.checkin_drafts;
+create policy checkin_drafts_select_self_app
+on public.checkin_drafts
+for select
+to authenticated
+using (
+  (select private.is_app_user())
+  and lower(user_email) = (select private.current_auth_email())
+);


### PR DESCRIPTION
## Sammanfattning

Synkar repo:t med Production-migrationen `cache_auth_email_for_rls_policies`.

Ändringen flyttar direkt `auth.jwt()`-läsning ur två RLS-policyuttryck till en privat `STABLE` helper, `private.current_auth_email()`, och låter policyerna använda `(select private.current_auth_email())`.

## Production-verifiering

- Migrationen är applicerad i Production som `20260820012651`.
- `private.current_auth_email()` är `SECURITY INVOKER`, `STABLE` och har tom `search_path`.
- `anon` saknar EXECUTE; `authenticated` och `service_role` har EXECUTE.
- `employees_select_self_app` och `checkin_drafts_select_self_app` behåller samma e-postmatchningskontrakt.
- Supabase Performance Advisor visar nu **0 `auth_rls_initplan`-varningar**.

## Scope

Endast RLS-performance hygiene. Ingen ny browser-access och ingen business logic ändras.