### PR TITLE
SALU: normalize MB make alias

### DIFF
--- a/lib/salu-core.ts
+++ b/lib/salu-core.ts
@@ -106,8 +106,13 @@ function normalizedText(value: string): string {
   return normalizeSaluTokenText(value).join(' ');
 }
 
+function normalizedMake(value: string): string {
+  const normalized = normalizedText(value);
+  return normalized === 'MB' ? 'MERCEDES BENZ' : normalized;
+}
+
 function ruleMatches(rule: SaluAutoRule, make: string, modelTokens: Set<string>): boolean {
-  if (rule.active === false || normalizedText(rule.make) !== normalizedText(make)) {
+  if (rule.active === false || normalizedMake(rule.make) !== normalizedMake(make)) {
     return false;
   }
 

--- a/tests/salu-core.test.ts
+++ b/tests/salu-core.test.ts
@@ -80,6 +80,12 @@ test('AUTO normalization ignores case, whitespace, hyphens and punctuation', () 
   assert.equal(selectSaluAutoRule('MERCEDES BENZ', 'SPRINTER-316 CDI', rules)?.id, 'mb-sprinter');
 });
 
+test('verified Nybil make alias MB maps to Mercedes-Benz rules only', () => {
+  assert.equal(selectSaluAutoRule('MB', 'Sprinter 316 CDI', rules)?.id, 'mb-sprinter');
+  assert.equal(selectSaluAutoRule('MB', 'EQA 250 Advanced', rules)?.id, 'mb-default');
+  assert.equal(selectSaluAutoRule('BMW', 'X1', rules)?.id, 'bmw-default');
+});
+
 test('AUTO never guesses when the make has no rule', () => {
   assert.equal(calculateAutoSaludatum({ nyDate: '2026-01-15', make: 'Volvo', model: 'XC40', rules }), null);
 });


### PR DESCRIPTION
## Syfte
Löser verifierad SALU AUTO-matchningsblocker där Production-data använder bilmärket `MB` medan SALU-reglerna använder `Mercedes-Benz`.

## Ändring
- normaliserar endast den verifierade aliasen `MB` -> `Mercedes-Benz` i SALU make-matchningen
- behåller övrig token-/modellmatchning oförändrad
- lägger regressionstester för MB standardregel och MB modellundantag

## Verifierat mot Production-data
- före aliasfix: 49/196 icke-dubbletter matchade AUTO-regler på märke
- efter aliasfix: 177/196 matchar
- kvarvarande 19 saknar fortsatt avsiktligt AUTO-regel och gissas inte

## Ingår inte
- inga Production-writes
- ingen backfill
- inga SALU-flaggor/events
- ingen aktivering av `SALU_WRITES_ENABLED` eller scheduler
- ingen catch-up-policy