### PR TITLE
SALU: harden cron auth and catch-up escalation

### DIFF
--- a/lib/salu-trigger-engine.ts
+++ b/lib/salu-trigger-engine.ts
@@ -79,6 +79,10 @@ export function evaluateSaluTriggers(input: {
   }
 
   if (compareDates(input.today, input.saludatum) >= 0) {
+    if (input.activeFlagEscalation === 'PASSERAD') {
+      return { actions, requiresCatchUpPolicy: false };
+    }
+
     const key = eventKey('SALU_T0_PASSED', input.saludatum);
     if (!emitted.has(key)) {
       actions.push({ type: 'SALU_T0_PASSED', eventKey: key, saludatum: input.saludatum });
@@ -87,6 +91,10 @@ export function evaluateSaluTriggers(input: {
   }
 
   if (compareDates(input.today, t10) >= 0) {
+    if (input.activeFlagEscalation === 'T10' || input.activeFlagEscalation === 'PASSERAD') {
+      return { actions, requiresCatchUpPolicy: false };
+    }
+
     const key = eventKey('SALU_T10_ESCALATED', input.saludatum);
     if (!emitted.has(key)) {
       actions.push({ type: 'SALU_T10_ESCALATED', eventKey: key, saludatum: input.saludatum });

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,17 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { verifyApiUser } from '@/lib/server-auth';
 
+function isSaluSchedulerRequestAuthorized(request: NextRequest): boolean {
+  if (request.nextUrl.pathname !== '/api/salu/scheduler') return false;
+
+  const authorization = request.headers.get('authorization');
+  const tokens = [process.env.SALU_SCHEDULER_TOKEN, process.env.CRON_SECRET].filter(
+    (token): token is string => Boolean(token),
+  );
+
+  return tokens.some((token) => authorization === `Bearer ${token}`);
+}
+
 export async function proxy(request: NextRequest) {
   const url = request.nextUrl.clone();
 
@@ -10,6 +21,10 @@ export async function proxy(request: NextRequest) {
   }
 
   if (!url.pathname.startsWith('/api/') || url.pathname === '/api/health') {
+    return NextResponse.next();
+  }
+
+  if (isSaluSchedulerRequestAuthorized(request)) {
     return NextResponse.next();
   }
 

--- a/tests/salu-trigger-engine.test.ts
+++ b/tests/salu-trigger-engine.test.ts
@@ -42,11 +42,12 @@ test('before T-30 no flag action is due', () => {
   assert.deepEqual(result, { actions: [], requiresCatchUpPolicy: false });
 });
 
-test('active flag emits T10 once for the current saludatum', () => {
+test('NORMAL active flag reaching T10 emits T10 once for the current saludatum', () => {
   const first = evaluateSaluTriggers({
     today: '2026-08-21',
     saludatum: '2026-08-31',
     hasActiveFlag: true,
+    activeFlagEscalation: 'NORMAL',
   });
 
   assert.equal(first.actions[0]?.type, 'SALU_T10_ESCALATED');
@@ -55,17 +56,59 @@ test('active flag emits T10 once for the current saludatum', () => {
     today: '2026-08-22',
     saludatum: '2026-08-31',
     hasActiveFlag: true,
+    activeFlagEscalation: 'NORMAL',
     emittedEventKeys: [first.actions[0]!.eventKey],
   });
 
   assert.deepEqual(second.actions, []);
 });
 
-test('active flag emits T0/PASSERAD on saludatum and suppresses retrospective T10', () => {
+test('T10 catch-up flag does not emit a synthetic T10 event inside the T10 window', () => {
+  const result = evaluateSaluTriggers({
+    today: '2026-08-22',
+    saludatum: '2026-08-31',
+    hasActiveFlag: true,
+    activeFlagEscalation: 'T10',
+  });
+
+  assert.deepEqual(result.actions, []);
+});
+
+test('PASSERAD catch-up flag does not emit synthetic T10 or T0 events', () => {
+  const atT0 = evaluateSaluTriggers({
+    today: '2026-08-31',
+    saludatum: '2026-08-31',
+    hasActiveFlag: true,
+    activeFlagEscalation: 'PASSERAD',
+  });
+  assert.deepEqual(atT0.actions, []);
+
+  const afterT0 = evaluateSaluTriggers({
+    today: '2026-09-10',
+    saludatum: '2026-08-31',
+    hasActiveFlag: true,
+    activeFlagEscalation: 'PASSERAD',
+  });
+  assert.deepEqual(afterT0.actions, []);
+});
+
+test('T10 active flag reaching T0 emits the normal T0 transition', () => {
   const result = evaluateSaluTriggers({
     today: '2026-08-31',
     saludatum: '2026-08-31',
     hasActiveFlag: true,
+    activeFlagEscalation: 'T10',
+  });
+
+  assert.deepEqual(result.actions.map((action) => action.type), ['SALU_T0_PASSED']);
+});
+
+test('active NORMAL flag emits T0/PASSERAD on saludatum and suppresses retrospective T10', () => {
+  const result = evaluateSaluTriggers({
+    today: '2026-08-31',
+    saludatum: '2026-08-31',
+    hasActiveFlag: true,
+    activeFlagEscalation: 'NORMAL',
   });
 
   assert.deepEqual(result.actions.map((action) => action.type), ['SALU_T0_PASSED']);
@@ -76,6 +119,7 @@ test('a changed saludatum gets its own idempotency key so a later T10 can be emi
     today: '2026-10-21',
     saludatum: '2026-10-31',
     hasActiveFlag: true,
+    activeFlagEscalation: 'NORMAL',
     emittedEventKeys: ['SALU_T10_ESCALATED:2026-08-31'],
   });
 
@@ -93,6 +137,7 @@ test('T0 catch-up for an active flag is idempotent for the current saludatum', (
     today: '2026-09-02',
     saludatum: '2026-08-31',
     hasActiveFlag: true,
+    activeFlagEscalation: 'T10',
     emittedEventKeys: ['SALU_T0_PASSED:2026-08-31'],
   });
 

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -37,6 +37,36 @@ test('/api/health stays outside the API authentication boundary', async () => {
   assert.equal(response.status, 200)
 })
 
+test('SALU scheduler stays protected unless a configured scheduler token matches', async () => {
+  const originalSchedulerToken = process.env.SALU_SCHEDULER_TOKEN
+  const originalCronSecret = process.env.CRON_SECRET
+
+  delete process.env.SALU_SCHEDULER_TOKEN
+  delete process.env.CRON_SECRET
+
+  try {
+    const unauthenticated = await proxy(
+      new NextRequest('http://localhost/api/salu/scheduler'),
+    )
+    assert.equal(unauthenticated.status, 401)
+    assert.deepEqual(await unauthenticated.json(), { error: 'Authentication required' })
+
+    process.env.CRON_SECRET = 'test-cron-secret'
+    const authorized = await proxy(
+      new NextRequest('http://localhost/api/salu/scheduler', {
+        headers: { authorization: 'Bearer test-cron-secret' },
+      }),
+    )
+    assert.equal(authorized.status, 200)
+  } finally {
+    if (originalSchedulerToken === undefined) delete process.env.SALU_SCHEDULER_TOKEN
+    else process.env.SALU_SCHEDULER_TOKEN = originalSchedulerToken
+
+    if (originalCronSecret === undefined) delete process.env.CRON_SECRET
+    else process.env.CRON_SECRET = originalCronSecret
+  }
+})
+
 test('non-API application routes stay outside the API authentication boundary', async () => {
   for (const path of ['/', '/check', '/ankomst', '/status', '/nybil', '/rapport']) {
     const response = await proxy(new NextRequest(`http://localhost${path}`))


### PR DESCRIPTION
## Summary
- allow secured SALU cron requests through the central API auth boundary
- suppress duplicate T10/T0 trigger actions for already catch-up-escalated flags
- add regression coverage for both behaviors

## Why
Production catch-up flags already reflect current escalation state. Without this fix, enabling the scheduler could create redundant threshold events for those flags. Also, the central API authentication boundary currently rejects Vercel Cron before the scheduler route can validate `CRON_SECRET`.

## Activation boundary
This PR does not enable `SALU_SCHEDULER_ENABLED`, `SALU_WRITES_ENABLED`, or set `CRON_SECRET`. Scheduler activation remains a separate Production configuration step after this PR is green and merged.