### PR TITLE
SALU: add decision cycle and PLANERING/INKÖP handoffs

### DIFF
--- a/app/api/salu/scheduler/route.ts
+++ b/app/api/salu/scheduler/route.ts
@@ -12,6 +12,7 @@ type ActiveFlagRow = {
   flag_id: string;
   regnr: string;
   escalation_status: SaluEscalationStatus;
+  created_at: string;
 };
 
 type EventKeyRow = {
@@ -22,7 +23,11 @@ type EventKeyRow = {
 type SchedulerAction = {
   regnr: string;
   saludatum: string;
-  type: 'SALU_FLAG_CREATED' | 'SALU_T10_ESCALATED' | 'SALU_T0_PASSED';
+  type:
+    | 'SALU_FLAG_CREATED'
+    | 'SALU_DECISION_REMINDER_DUE'
+    | 'SALU_T10_ESCALATED'
+    | 'SALU_T0_PASSED';
   eventKey: string;
 };
 
@@ -71,7 +76,7 @@ export async function POST(request: Request) {
       .not('current_saludatum', 'is', null),
     admin
       .from('salu_flags')
-      .select('flag_id,regnr,escalation_status')
+      .select('flag_id,regnr,escalation_status,created_at')
       .neq('status', 'STÄNGD'),
     admin
       .from('salu_events')
@@ -111,6 +116,8 @@ export async function POST(request: Request) {
       today,
       saludatum: state.current_saludatum,
       hasActiveFlag: Boolean(activeFlag),
+      activeFlagId: activeFlag?.flag_id,
+      activeFlagCreatedDate: activeFlag?.created_at.slice(0, 10),
       activeFlagEscalation: activeFlag?.escalation_status,
       emittedEventKeys: eventKeysByRegnr.get(state.regnr),
     });

--- a/lib/salu-process.ts
+++ b/lib/salu-process.ts
@@ -10,6 +10,22 @@ export type SaluChildStatus =
   | 'VERIFIED'
   | 'CANCELLED';
 
+export const SALU_CLOSURE_DECISIONS = [
+  'SÄLJAS',
+  'PLANERA VERKSTAD',
+  'LÅNGTID PLANERA SKIFTE',
+  'ANNAT',
+  'FÖRLÄNGA',
+] as const;
+
+export type SaluClosureDecision = (typeof SALU_CLOSURE_DECISIONS)[number];
+
+export type SaluClosureDecisionInput = {
+  decision: SaluClosureDecision;
+  comment?: string | null;
+  newSaludatum?: string | null;
+};
+
 export type SaluFlagSnapshot = {
   flagId: string;
   regnr: string;
@@ -36,6 +52,9 @@ export const SALU_EVENTS = [
   'SALU_SALUDATUM_CHANGED',
   'SALU_SOLD_RECORDED',
   'SALU_HANDOVER_RECORDED',
+  'SALU_PLANERING_HANDOFF_REQUESTED',
+  'SALU_INKOP_HANDOFF_REQUESTED',
+  'SALU_DECISION_REMINDER_DUE',
   'SALU_T10_ESCALATED',
   'SALU_T0_PASSED',
   'SALU_FLAG_READY_FOR_OWNER_DECISION',
@@ -120,9 +139,20 @@ export function moveSaluFlagToFinalAssessment(
   return { ...snapshot, status: 'SLUTBEDÖMNING' };
 }
 
+export function validateSaluClosureDecision(input: SaluClosureDecisionInput): void {
+  if (input.decision === 'ANNAT' && !input.comment?.trim()) {
+    throw new Error('ANNAT requires a closure comment');
+  }
+
+  if (input.decision === 'FÖRLÄNGA' && !input.newSaludatum) {
+    throw new Error('FÖRLÄNGA requires a new saludatum');
+  }
+}
+
 export function closeSaluFlagManually(
   snapshot: SaluFlagSnapshot,
   readiness: SaluCloseReadiness,
+  closure: SaluClosureDecisionInput,
 ): SaluFlagSnapshot {
   if (snapshot.status !== 'SLUTBEDÖMNING') {
     throw new Error('Manual closure requires SLUTBEDÖMNING');
@@ -131,6 +161,8 @@ export function closeSaluFlagManually(
   if (!readiness.ready) {
     throw new Error('SALU flag cannot close while blocking conditions remain');
   }
+
+  validateSaluClosureDecision(closure);
 
   return { ...snapshot, status: 'STÄNGD' };
 }

--- a/lib/salu-trigger-engine.ts
+++ b/lib/salu-trigger-engine.ts
@@ -3,6 +3,7 @@ import type { SaluEscalationStatus } from './salu-core';
 
 export type SaluTriggerEvent =
   | 'SALU_FLAG_CREATED'
+  | 'SALU_DECISION_REMINDER_DUE'
   | 'SALU_T10_ESCALATED'
   | 'SALU_T0_PASSED';
 
@@ -47,14 +48,20 @@ function compareDates(left: string, right: string): number {
   return Math.sign(parseIsoDate(left).getTime() - parseIsoDate(right).getTime());
 }
 
-function eventKey(type: SaluTriggerEvent, saludatum: string): string {
+function eventKey(type: Exclude<SaluTriggerEvent, 'SALU_DECISION_REMINDER_DUE'>, saludatum: string): string {
   return `${type}:${saludatum}`;
+}
+
+function decisionReminderEventKey(flagId: string, cycle: number): string {
+  return `SALU_DECISION_REMINDER_DUE:${flagId}:${cycle}`;
 }
 
 export function evaluateSaluTriggers(input: {
   today: string;
   saludatum: string;
   hasActiveFlag: boolean;
+  activeFlagId?: string;
+  activeFlagCreatedDate?: string;
   activeFlagEscalation?: SaluEscalationStatus;
   emittedEventKeys?: Iterable<string>;
 }): SaluTriggerEvaluation {
@@ -78,23 +85,36 @@ export function evaluateSaluTriggers(input: {
     };
   }
 
-  if (compareDates(input.today, input.saludatum) >= 0) {
-    if (input.activeFlagEscalation === 'PASSERAD') {
-      return { actions, requiresCatchUpPolicy: false };
+  if (input.activeFlagId && input.activeFlagCreatedDate) {
+    const elapsedDays = daysBetween(input.activeFlagCreatedDate, input.today);
+    const cycle = Math.floor(elapsedDays / 10);
+    if (cycle >= 1) {
+      const key = decisionReminderEventKey(input.activeFlagId, cycle);
+      if (!emitted.has(key)) {
+        actions.push({
+          type: 'SALU_DECISION_REMINDER_DUE',
+          eventKey: key,
+          saludatum: input.saludatum,
+        });
+      }
     }
+  }
 
-    const key = eventKey('SALU_T0_PASSED', input.saludatum);
-    if (!emitted.has(key)) {
-      actions.push({ type: 'SALU_T0_PASSED', eventKey: key, saludatum: input.saludatum });
+  if (compareDates(input.today, input.saludatum) >= 0) {
+    if (input.activeFlagEscalation !== 'PASSERAD') {
+      const key = eventKey('SALU_T0_PASSED', input.saludatum);
+      if (!emitted.has(key)) {
+        actions.push({ type: 'SALU_T0_PASSED', eventKey: key, saludatum: input.saludatum });
+      }
     }
     return { actions, requiresCatchUpPolicy: false };
   }
 
-  if (compareDates(input.today, t10) >= 0) {
-    if (input.activeFlagEscalation === 'T10' || input.activeFlagEscalation === 'PASSERAD') {
-      return { actions, requiresCatchUpPolicy: false };
-    }
-
+  if (
+    compareDates(input.today, t10) >= 0 &&
+    input.activeFlagEscalation !== 'T10' &&
+    input.activeFlagEscalation !== 'PASSERAD'
+  ) {
     const key = eventKey('SALU_T10_ESCALATED', input.saludatum);
     if (!emitted.has(key)) {
       actions.push({ type: 'SALU_T10_ESCALATED', eventKey: key, saludatum: input.saludatum });

--- a/migrations/20260820095900_salu_decision_cycle_handoffs.sql
+++ b/migrations/20260820095900_salu_decision_cycle_handoffs.sql
@@ -1,0 +1,214 @@
+-- SALU decision-cycle and handoff contract.
+-- Keeps SALU as the source process while emitting explicit events for future
+-- PLANERING and INKÖP layers. Server-side only.
+
+begin;
+
+set local lock_timeout = '5s';
+
+alter table public.salu_flags
+  drop constraint if exists salu_flags_closure_outcome_check;
+
+alter table public.salu_flags
+  add constraint salu_flags_closure_outcome_check
+  check (
+    closure_outcome is null
+    or closure_outcome in (
+      'SÄLJAS',
+      'PLANERA VERKSTAD',
+      'LÅNGTID PLANERA SKIFTE',
+      'ANNAT',
+      'FÖRLÄNGA'
+    )
+  );
+
+alter table public.salu_events
+  drop constraint if exists salu_events_event_type_check;
+
+alter table public.salu_events
+  add constraint salu_events_event_type_check
+  check (event_type in (
+    'SALU_FLAG_CREATED',
+    'SALU_FLAG_ACKNOWLEDGED',
+    'SALU_ASSESSMENT_RECORDED',
+    'SALU_CHECKPOINT_CHANGED',
+    'SALU_INLINE_ACTION_CREATED',
+    'SALU_CHILD_PROCESS_CREATED',
+    'SALU_CHILD_STATUS_REPORTED',
+    'SALU_SALUDATUM_CHANGED',
+    'SALU_SOLD_RECORDED',
+    'SALU_HANDOVER_RECORDED',
+    'SALU_PLANERING_HANDOFF_REQUESTED',
+    'SALU_INKOP_HANDOFF_REQUESTED',
+    'SALU_DECISION_REMINDER_DUE',
+    'SALU_T10_ESCALATED',
+    'SALU_T0_PASSED',
+    'SALU_FLAG_READY_FOR_OWNER_DECISION',
+    'SALU_FLAG_CLOSED_MANUALLY'
+  ));
+
+create or replace function public.apply_salu_trigger_action(
+  p_regnr text,
+  p_saludatum date,
+  p_event_type text,
+  p_event_key text
+)
+returns table (
+  applied boolean,
+  flag_id uuid,
+  escalation_status text
+)
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_flag_id uuid;
+  v_escalation text;
+begin
+  if p_event_type not in (
+    'SALU_FLAG_CREATED',
+    'SALU_DECISION_REMINDER_DUE',
+    'SALU_T10_ESCALATED',
+    'SALU_T0_PASSED'
+  ) then
+    raise exception 'Unsupported SALU trigger event';
+  end if;
+
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtext(p_regnr));
+
+  if exists (select 1 from public.salu_events e where e.event_key = p_event_key) then
+    select f.flag_id, f.escalation_status
+      into v_flag_id, v_escalation
+    from public.salu_flags f
+    where f.regnr = p_regnr and f.status <> 'STÄNGD'
+    limit 1;
+
+    return query select false, v_flag_id, v_escalation;
+    return;
+  end if;
+
+  if p_event_type = 'SALU_FLAG_CREATED' then
+    if exists (
+      select 1 from public.salu_flags f
+      where f.regnr = p_regnr and f.status <> 'STÄNGD'
+    ) then
+      raise exception 'Active SALU flag already exists';
+    end if;
+
+    insert into public.salu_flags (
+      regnr,
+      cycle_saludatum,
+      current_saludatum,
+      status,
+      escalation_status,
+      owner_function
+    ) values (
+      p_regnr,
+      p_saludatum,
+      p_saludatum,
+      'NY',
+      'NORMAL',
+      'BILKONTROLL'
+    )
+    returning salu_flags.flag_id into v_flag_id;
+
+    v_escalation := 'NORMAL';
+
+    insert into public.salu_events (
+      regnr,
+      flag_id,
+      event_type,
+      event_key,
+      actor_source,
+      payload
+    ) values
+      (
+        p_regnr,
+        v_flag_id,
+        'SALU_PLANERING_HANDOFF_REQUESTED',
+        'SALU_PLANERING_HANDOFF_REQUESTED:' || v_flag_id::text,
+        'SYSTEM',
+        pg_catalog.jsonb_build_object(
+          'source_event_key', p_event_key,
+          'saludatum', p_saludatum,
+          'target_layer', 'PLANERING'
+        )
+      ),
+      (
+        p_regnr,
+        v_flag_id,
+        'SALU_INKOP_HANDOFF_REQUESTED',
+        'SALU_INKOP_HANDOFF_REQUESTED:' || v_flag_id::text,
+        'SYSTEM',
+        pg_catalog.jsonb_build_object(
+          'source_event_key', p_event_key,
+          'saludatum', p_saludatum,
+          'target_layer', 'INKÖP'
+        )
+      )
+    on conflict (event_key) do nothing;
+  else
+    select f.flag_id, f.escalation_status
+      into v_flag_id, v_escalation
+    from public.salu_flags f
+    where f.regnr = p_regnr and f.status <> 'STÄNGD'
+    for update;
+
+    if v_flag_id is null then
+      raise exception 'No active SALU flag exists for trigger action';
+    end if;
+
+    if p_event_type = 'SALU_T0_PASSED' then
+      v_escalation := 'PASSERAD';
+      update public.salu_flags
+      set escalation_status = v_escalation
+      where salu_flags.flag_id = v_flag_id;
+    elsif p_event_type = 'SALU_T10_ESCALATED' then
+      v_escalation := 'T10';
+      update public.salu_flags
+      set escalation_status = v_escalation
+      where salu_flags.flag_id = v_flag_id;
+    end if;
+  end if;
+
+  insert into public.salu_events (
+    regnr,
+    flag_id,
+    event_type,
+    event_key,
+    actor_source,
+    payload
+  ) values (
+    p_regnr,
+    v_flag_id,
+    p_event_type,
+    p_event_key,
+    'SYSTEM',
+    case
+      when p_event_type = 'SALU_DECISION_REMINDER_DUE' then
+        pg_catalog.jsonb_build_object(
+          'saludatum', p_saludatum,
+          'decision_required', true,
+          'decision_options', pg_catalog.jsonb_build_array(
+            'SÄLJAS',
+            'PLANERA VERKSTAD',
+            'LÅNGTID PLANERA SKIFTE',
+            'ANNAT',
+            'FÖRLÄNGA'
+          )
+        )
+      else pg_catalog.jsonb_build_object('saludatum', p_saludatum)
+    end
+  );
+
+  return query select true, v_flag_id, v_escalation;
+end;
+$$;
+
+revoke all on function public.apply_salu_trigger_action(text, date, text, text)
+  from public, anon, authenticated;
+grant execute on function public.apply_salu_trigger_action(text, date, text, text)
+  to service_role;
+
+commit;

--- a/tests/salu-decision-cycle-contract.test.ts
+++ b/tests/salu-decision-cycle-contract.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/20260820095900_salu_decision_cycle_handoffs.sql'),
+  'utf8',
+);
+
+const scheduler = readFileSync(
+  join(process.cwd(), 'app/api/salu/scheduler/route.ts'),
+  'utf8',
+);
+
+test('T-30 persistence emits idempotent PLANERING and INKÖP handoff events', () => {
+  assert.match(migration, /SALU_PLANERING_HANDOFF_REQUESTED/);
+  assert.match(migration, /SALU_INKOP_HANDOFF_REQUESTED/);
+  assert.match(migration, /target_layer', 'PLANERING'/);
+  assert.match(migration, /target_layer', 'INKÖP'/);
+  assert.match(migration, /on conflict \(event_key\) do nothing/i);
+});
+
+test('decision reminders are persisted as a supported system trigger without changing escalation status', () => {
+  assert.match(migration, /SALU_DECISION_REMINDER_DUE/);
+  assert.match(migration, /decision_required', true/);
+  assert.match(migration, /decision_options/);
+  assert.match(migration, /security invoker/i);
+  assert.match(migration, /set search_path = ''/i);
+});
+
+test('manual closure outcome is restricted to the five active decisions', () => {
+  for (const decision of [
+    'SÄLJAS',
+    'PLANERA VERKSTAD',
+    'LÅNGTID PLANERA SKIFTE',
+    'ANNAT',
+    'FÖRLÄNGA',
+  ]) {
+    assert.match(migration, new RegExp(`'${decision}'`));
+  }
+
+  assert.doesNotMatch(migration, /FARDIGBEHANDLAD/);
+  assert.doesNotMatch(migration, /PLAN_ANDRAD_AVBRUTEN/);
+  assert.doesNotMatch(migration, /FARDIG_MED_ACCEPTERAD_AVVIKELSE/);
+});
+
+test('scheduler supplies active flag identity and creation date to the ten-day clock', () => {
+  assert.match(scheduler, /flag_id,regnr,escalation_status,created_at/);
+  assert.match(scheduler, /activeFlagId: activeFlag\?\.flag_id/);
+  assert.match(scheduler, /activeFlagCreatedDate: activeFlag\?\.created_at\.slice\(0, 10\)/);
+});

--- a/tests/salu-process.test.ts
+++ b/tests/salu-process.test.ts
@@ -9,6 +9,7 @@ import {
   createReopenedSaluFlag,
   moveSaluFlagToFinalAssessment,
   transitionSaluChildStatus,
+  validateSaluClosureDecision,
   type SaluFlagSnapshot,
 } from '../lib/salu-process';
 
@@ -73,14 +74,31 @@ test('VERIFIED and CANCELLED are terminal child statuses for close readiness', (
   assert.deepEqual(readiness, { ready: true, reasons: [] });
 });
 
-test('manual close requires SLUTBEDÖMNING and ready conditions', () => {
+test('manual close requires SLUTBEDÖMNING, ready conditions and an explicit decision', () => {
   const acknowledged = acknowledgeSaluFlag(activeFlag);
   const readiness = assessSaluCloseReadiness({ checkpointStatuses: ['GODKÄND'], childStatuses: ['VERIFIED'] });
   const finalAssessment = moveSaluFlagToFinalAssessment(acknowledged, readiness);
-  const closed = closeSaluFlagManually(finalAssessment, readiness);
+  const closed = closeSaluFlagManually(finalAssessment, readiness, { decision: 'SÄLJAS' });
 
   assert.equal(finalAssessment.status, 'SLUTBEDÖMNING');
   assert.equal(closed.status, 'STÄNGD');
+});
+
+test('ANNAT requires comment and FÖRLÄNGA requires a new saludatum', () => {
+  assert.throws(
+    () => validateSaluClosureDecision({ decision: 'ANNAT' }),
+    /requires a closure comment/,
+  );
+  assert.doesNotThrow(() => validateSaluClosureDecision({ decision: 'ANNAT', comment: 'Specialfall' }));
+
+  assert.throws(
+    () => validateSaluClosureDecision({ decision: 'FÖRLÄNGA' }),
+    /requires a new saludatum/,
+  );
+  assert.doesNotThrow(() => validateSaluClosureDecision({
+    decision: 'FÖRLÄNGA',
+    newSaludatum: '2026-10-31',
+  }));
 });
 
 test('final assessment cannot be entered directly from NY', () => {

--- a/tests/salu-trigger-engine.test.ts
+++ b/tests/salu-trigger-engine.test.ts
@@ -42,6 +42,50 @@ test('before T-30 no flag action is due', () => {
   assert.deepEqual(result, { actions: [], requiresCatchUpPolicy: false });
 });
 
+test('active flag starts a ten-day decision clock from flag creation', () => {
+  const before = evaluateSaluTriggers({
+    today: '2026-08-10',
+    saludatum: '2026-09-30',
+    hasActiveFlag: true,
+    activeFlagId: 'flag-1',
+    activeFlagCreatedDate: '2026-08-01',
+    activeFlagEscalation: 'NORMAL',
+  });
+  assert.deepEqual(before.actions, []);
+
+  const due = evaluateSaluTriggers({
+    today: '2026-08-11',
+    saludatum: '2026-09-30',
+    hasActiveFlag: true,
+    activeFlagId: 'flag-1',
+    activeFlagCreatedDate: '2026-08-01',
+    activeFlagEscalation: 'NORMAL',
+  });
+  assert.deepEqual(due.actions, [{
+    type: 'SALU_DECISION_REMINDER_DUE',
+    eventKey: 'SALU_DECISION_REMINDER_DUE:flag-1:1',
+    saludatum: '2026-09-30',
+  }]);
+});
+
+test('decision reminder is emitted once per ten-day cycle while the flag remains active', () => {
+  const result = evaluateSaluTriggers({
+    today: '2026-08-25',
+    saludatum: '2026-09-30',
+    hasActiveFlag: true,
+    activeFlagId: 'flag-1',
+    activeFlagCreatedDate: '2026-08-01',
+    activeFlagEscalation: 'NORMAL',
+    emittedEventKeys: ['SALU_DECISION_REMINDER_DUE:flag-1:1'],
+  });
+
+  assert.deepEqual(result.actions, [{
+    type: 'SALU_DECISION_REMINDER_DUE',
+    eventKey: 'SALU_DECISION_REMINDER_DUE:flag-1:2',
+    saludatum: '2026-09-30',
+  }]);
+});
+
 test('NORMAL active flag reaching T10 emits T10 once for the current saludatum', () => {
   const first = evaluateSaluTriggers({
     today: '2026-08-21',


### PR DESCRIPTION
## Summary
- start a 10-day decision reminder clock from active SALU flag creation
- emit explicit T-30 handoff events for both PLANERING and INKÖP
- require explicit manual SALU closure decision: SÄLJAS, PLANERA VERKSTAD, LÅNGTID PLANERA SKIFTE, ANNAT or FÖRLÄNGA
- require comment for ANNAT and new saludatum for FÖRLÄNGA
- extend the atomic trigger RPC to persist reminders and handoff events idempotently
- add regression/contract tests

## Boundary
This PR creates the handoff events only. The PLANERING and INKÖP target layers themselves are intentionally deferred to the next layer.

## Runtime safety
No Production environment variables are changed here and scheduler writes remain separately gated.