### PR TITLE
Vagnkort: första fordonsrese-lagret och read model

### DIFF
--- a/app/api/vehicle-journey/route.ts
+++ b/app/api/vehicle-journey/route.ts
@@ -1,0 +1,376 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+const HOUR_MS = 60 * 60 * 1000;
+
+type QueryError = { message?: string } | null;
+
+function cleanRegnr(value: string): string {
+  return value.toUpperCase().replace(/\s+/g, '');
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing Supabase server configuration');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+function durationHours(startedAt: string, endedAt: string | null): number | null {
+  if (!endedAt) return null;
+  const start = new Date(startedAt).getTime();
+  const end = new Date(endedAt).getTime();
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
+  return Math.round(((end - start) / HOUR_MS) * 10) / 10;
+}
+
+function firstError(errors: Array<[string, QueryError]>): string | null {
+  for (const [label, error] of errors) {
+    if (error) {
+      console.error(`[vehicle-journey] ${label} query failed:`, error);
+      return label;
+    }
+  }
+  return null;
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const regnr = cleanRegnr(searchParams.get('reg') ?? searchParams.get('regnr') ?? '');
+
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-journey] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Vehicle journey unavailable' }, { status: 503 });
+  }
+
+  const [
+    nybilResponse,
+    vehicleResponse,
+    checkinResponse,
+    damagesResponse,
+    eventsResponse,
+    periodsResponse,
+    documentsResponse,
+    receiptsResponse,
+    saluStateResponse,
+    saluFlagsResponse,
+  ] = await Promise.all([
+    admin
+      .from('nybil_inventering')
+      .select([
+        'id',
+        'regnr',
+        'bilmarke',
+        'modell',
+        'registreringsdatum',
+        'matarstallning_inkop',
+        'matarstallning_aktuell',
+        'plats_mottagning_ort',
+        'plats_mottagning_station',
+        'plats_aktuell_ort',
+        'plats_aktuell_station',
+        'hjultyp',
+        'hjul_ej_monterade',
+        'hjul_forvaring_ort',
+        'hjul_forvaring_spec',
+        'antal_nycklar',
+        'antal_laddkablar',
+        'antal_insynsskydd',
+        'instruktionsbok',
+        'coc',
+        'lasbultar_med',
+        'dragkrok',
+        'gummimattor',
+        'dackkompressor',
+        'bransletyp',
+        'tankstatus',
+        'laddniva_procent',
+        'har_skador_vid_leverans',
+        'photo_urls',
+        'video_urls',
+        'media_folder',
+        'saludatum_planerat',
+        'saludatum',
+        'is_sold',
+        'sold_date',
+        'created_at',
+        'updated_at',
+      ].join(','))
+      .eq('regnr', regnr)
+      .order('created_at', { ascending: false })
+      .limit(1),
+    admin
+      .from('vehicles')
+      .select([
+        'regnr',
+        'brand',
+        'model',
+        'is_sold',
+        'sold_date',
+        'antal_nycklar',
+        'antal_laddkablar',
+        'antal_insynsskydd',
+        'har_kompressor',
+        'har_gummimattor',
+        'har_vinterdack',
+        'har_sommarhjul',
+        'hjul_pa_bilen',
+        'wheel_storage_location',
+        'coc_location',
+        'instruktionsbok_location',
+        'bransletyp',
+        'datum_ankomst_mabi',
+        'bilfakta_imported_at',
+      ].join(','))
+      .eq('regnr', regnr)
+      .limit(1),
+    admin
+      .from('checkins')
+      .select([
+        'id',
+        'status',
+        'completed_at',
+        'current_city',
+        'current_station',
+        'current_location_note',
+        'odometer_km',
+        'hjultyp',
+        'fuel_type',
+        'fuel_level',
+        'charge_level_percent',
+        'checklist',
+        'photo_urls',
+        'checker_name',
+        'checker_email',
+        'completed_by',
+      ].join(','))
+      .eq('regnr', regnr)
+      .eq('status', 'COMPLETED')
+      .order('completed_at', { ascending: false })
+      .limit(1),
+    admin
+      .from('damages')
+      .select('id,regnr,source,user_type,damage_type_raw,user_positions,damage_date,created_at,legacy_damage_source_text,uploads')
+      .eq('regnr', regnr)
+      .in('source', ['CHECK', 'NYBIL', 'BUHS'])
+      .order('created_at', { ascending: false }),
+    admin
+      .from('vehicle_journey_events')
+      .select('event_id,event_type,event_key,occurred_at,source_system,source_entity,source_record_id,actor_id,actor_source,actor_name,actor_email,payload,correction_of_event_id')
+      .eq('regnr', regnr)
+      .order('occurred_at', { ascending: false }),
+    admin
+      .from('vehicle_journey_periods')
+      .select('period_id,period_type,started_at,ended_at,reason_code,reason_text,source_system,source_entity,source_record_id,source_event_id,metadata')
+      .eq('regnr', regnr)
+      .order('started_at', { ascending: false }),
+    admin
+      .from('vehicle_documents')
+      .select('document_id,document_type,title,storage_bucket,storage_path,external_url,file_name,mime_type,size_bytes,journey_event_id,checkin_id,damage_id,salu_flag_id,salu_checkpoint_id,salu_child_process_id,source_system,source_record_id,metadata,uploaded_by,uploaded_by_name,uploaded_by_email,uploaded_at')
+      .eq('regnr', regnr)
+      .order('uploaded_at', { ascending: false }),
+    admin
+      .from('vehicle_receipts')
+      .select('id,checkin_id,receipt_type,file_url,file_path,file_name,mime_type,uploaded_by_email,uploaded_by_name,uploaded_at')
+      .eq('regnr', regnr)
+      .order('uploaded_at', { ascending: false }),
+    admin
+      .from('salu_vehicle_state')
+      .select('regnr,ny_date,original_saludatum,current_saludatum,control_mode,manual_months,auto_rule_id,auto_rule_version,auto_months_applied,final_slutbedomning_at,final_closed_at,stillestand_salu_days,stillestand_cause_code,updated_at')
+      .eq('regnr', regnr)
+      .limit(1),
+    admin
+      .from('salu_flags')
+      .select('flag_id,previous_flag_id,cycle_saludatum,current_saludatum,status,escalation_status,owner_function,created_at,acknowledged_at,closed_at,closure_outcome,closure_comment')
+      .eq('regnr', regnr)
+      .order('created_at', { ascending: false })
+      .limit(1),
+  ]);
+
+  const failedSource = firstError([
+    ['nybil', nybilResponse.error],
+    ['vehicle', vehicleResponse.error],
+    ['checkin', checkinResponse.error],
+    ['damages', damagesResponse.error],
+    ['journey events', eventsResponse.error],
+    ['journey periods', periodsResponse.error],
+    ['documents', documentsResponse.error],
+    ['legacy receipts', receiptsResponse.error],
+    ['SALU state', saluStateResponse.error],
+    ['SALU flags', saluFlagsResponse.error],
+  ]);
+
+  if (failedSource) {
+    return NextResponse.json({ error: `Failed to load ${failedSource}` }, { status: 500 });
+  }
+
+  const nybil = nybilResponse.data?.[0] ?? null;
+  const vehicle = vehicleResponse.data?.[0] ?? null;
+  const latestCheckin = checkinResponse.data?.[0] ?? null;
+  const saluState = saluStateResponse.data?.[0] ?? null;
+  const latestSaluFlag = saluFlagsResponse.data?.[0] ?? null;
+
+  const [checkpointResponse, childProcessesResponse] = latestSaluFlag
+    ? await Promise.all([
+        admin
+          .from('salu_checkpoints')
+          .select('checkpoint_id,checkpoint_code,status,evidence_refs,updated_at')
+          .eq('flag_id', latestSaluFlag.flag_id)
+          .order('checkpoint_code', { ascending: true }),
+        admin
+          .from('salu_child_processes')
+          .select('child_process_id,process_type,source_checkpoint,source_reason,owner_ref,execution_system,deadline_at,due_event,status,status_timestamp,blocking,blocks_step,outcome,evidence_refs,verified_at,cancel_reason,created_at')
+          .eq('flag_id', latestSaluFlag.flag_id)
+          .order('created_at', { ascending: false }),
+      ])
+    : [{ data: [], error: null }, { data: [], error: null }];
+
+  const saluFailedSource = firstError([
+    ['SALU checkpoints', checkpointResponse.error],
+    ['SALU child processes', childProcessesResponse.error],
+  ]);
+  if (saluFailedSource) {
+    return NextResponse.json({ error: `Failed to load ${saluFailedSource}` }, { status: 500 });
+  }
+
+  const periods = (periodsResponse.data ?? []).map((period) => ({
+    ...period,
+    durationHours: durationHours(period.started_at, period.ended_at),
+  }));
+
+  const periodHours = periods.reduce<Record<string, number>>((totals, period) => {
+    if (period.durationHours !== null) {
+      totals[period.period_type] = Math.round(((totals[period.period_type] ?? 0) + period.durationHours) * 10) / 10;
+    }
+    return totals;
+  }, {});
+
+  const equipmentBaseline = nybil
+    ? {
+        keys: nybil.antal_nycklar,
+        chargingCables: nybil.antal_laddkablar,
+        privacyCovers: nybil.antal_insynsskydd,
+        instructionBook: nybil.instruktionsbok,
+        coc: nybil.coc,
+        wheelLocks: nybil.lasbultar_med,
+        towbar: nybil.dragkrok,
+        rubberMats: nybil.gummimattor,
+        tireCompressor: nybil.dackkompressor,
+        mountedWheels: nybil.hjultyp,
+        looseWheels: nybil.hjul_ej_monterade,
+      }
+    : null;
+
+  const equipmentCurrent = vehicle
+    ? {
+        keys: vehicle.antal_nycklar,
+        chargingCables: vehicle.antal_laddkablar,
+        privacyCovers: vehicle.antal_insynsskydd,
+        instructionBookLocation: vehicle.instruktionsbok_location,
+        cocLocation: vehicle.coc_location,
+        rubberMats: vehicle.har_gummimattor,
+        tireCompressor: vehicle.har_kompressor,
+        mountedWheels: vehicle.hjul_pa_bilen,
+        hasWinterWheels: vehicle.har_vinterdack,
+        hasSummerWheels: vehicle.har_sommarhjul,
+      }
+    : null;
+
+  const documents = [
+    ...(documentsResponse.data ?? []).map((document) => ({
+      ...document,
+      sourceKind: 'vehicle_document' as const,
+    })),
+    ...(receiptsResponse.data ?? []).map((receipt) => ({
+      document_id: `legacy-receipt:${receipt.id}`,
+      document_type: receipt.receipt_type,
+      title: receipt.file_name,
+      storage_bucket: 'receipts',
+      storage_path: receipt.file_path,
+      external_url: receipt.file_url,
+      file_name: receipt.file_name,
+      mime_type: receipt.mime_type,
+      size_bytes: null,
+      journey_event_id: null,
+      checkin_id: receipt.checkin_id,
+      damage_id: null,
+      salu_flag_id: null,
+      salu_checkpoint_id: null,
+      salu_child_process_id: null,
+      source_system: 'LEGACY_RECEIPTS',
+      source_record_id: String(receipt.id),
+      metadata: {},
+      uploaded_by: null,
+      uploaded_by_name: receipt.uploaded_by_name,
+      uploaded_by_email: receipt.uploaded_by_email,
+      uploaded_at: receipt.uploaded_at,
+      sourceKind: 'legacy_receipt' as const,
+    })),
+  ].sort((left, right) => new Date(right.uploaded_at).getTime() - new Date(left.uploaded_at).getTime());
+
+  const found = Boolean(
+    nybil ||
+      vehicle ||
+      latestCheckin ||
+      (damagesResponse.data?.length ?? 0) > 0 ||
+      (eventsResponse.data?.length ?? 0) > 0 ||
+      periods.length > 0 ||
+      documents.length > 0 ||
+      saluState ||
+      latestSaluFlag,
+  );
+
+  return NextResponse.json({
+    data: {
+      found,
+      regnr,
+      identity: {
+        brand: nybil?.bilmarke ?? vehicle?.brand ?? null,
+        model: nybil?.modell ?? vehicle?.model ?? null,
+      },
+      baseline: nybil,
+      current: {
+        vehicle,
+        latestCheckin,
+        equipment: equipmentCurrent,
+      },
+      equipment: {
+        baseline: equipmentBaseline,
+        current: equipmentCurrent,
+      },
+      damages: damagesResponse.data ?? [],
+      journey: {
+        events: eventsResponse.data ?? [],
+        periods,
+        openPeriods: periods.filter((period) => period.ended_at === null),
+        totalHoursByType: periodHours,
+      },
+      documents,
+      salu: {
+        state: saluState,
+        latestFlag: latestSaluFlag,
+        checkpoints: checkpointResponse.data ?? [],
+        childProcesses: childProcessesResponse.data ?? [],
+      },
+    },
+  });
+}

--- a/app/api/vehicle-journey/route.ts
+++ b/app/api/vehicle-journey/route.ts
@@ -76,93 +76,18 @@ export async function GET(request: Request) {
   ] = await Promise.all([
     admin
       .from('nybil_inventering')
-      .select([
-        'id',
-        'regnr',
-        'bilmarke',
-        'modell',
-        'registreringsdatum',
-        'matarstallning_inkop',
-        'matarstallning_aktuell',
-        'plats_mottagning_ort',
-        'plats_mottagning_station',
-        'plats_aktuell_ort',
-        'plats_aktuell_station',
-        'hjultyp',
-        'hjul_ej_monterade',
-        'hjul_forvaring_ort',
-        'hjul_forvaring_spec',
-        'antal_nycklar',
-        'antal_laddkablar',
-        'antal_insynsskydd',
-        'instruktionsbok',
-        'coc',
-        'lasbultar_med',
-        'dragkrok',
-        'gummimattor',
-        'dackkompressor',
-        'bransletyp',
-        'tankstatus',
-        'laddniva_procent',
-        'har_skador_vid_leverans',
-        'photo_urls',
-        'video_urls',
-        'media_folder',
-        'saludatum_planerat',
-        'saludatum',
-        'is_sold',
-        'sold_date',
-        'created_at',
-        'updated_at',
-      ].join(','))
+      .select('id,regnr,bilmarke,modell,registreringsdatum,matarstallning_inkop,matarstallning_aktuell,plats_mottagning_ort,plats_mottagning_station,plats_aktuell_ort,plats_aktuell_station,hjultyp,hjul_ej_monterade,hjul_forvaring_ort,hjul_forvaring_spec,antal_nycklar,antal_laddkablar,antal_insynsskydd,instruktionsbok,coc,lasbultar_med,dragkrok,gummimattor,dackkompressor,bransletyp,tankstatus,laddniva_procent,har_skador_vid_leverans,photo_urls,video_urls,media_folder,saludatum_planerat,saludatum,is_sold,sold_date,created_at,updated_at')
       .eq('regnr', regnr)
       .order('created_at', { ascending: false })
       .limit(1),
     admin
       .from('vehicles')
-      .select([
-        'regnr',
-        'brand',
-        'model',
-        'is_sold',
-        'sold_date',
-        'antal_nycklar',
-        'antal_laddkablar',
-        'antal_insynsskydd',
-        'har_kompressor',
-        'har_gummimattor',
-        'har_vinterdack',
-        'har_sommarhjul',
-        'hjul_pa_bilen',
-        'wheel_storage_location',
-        'coc_location',
-        'instruktionsbok_location',
-        'bransletyp',
-        'datum_ankomst_mabi',
-        'bilfakta_imported_at',
-      ].join(','))
+      .select('regnr,brand,model,is_sold,sold_date,antal_nycklar,antal_laddkablar,antal_insynsskydd,har_kompressor,har_gummimattor,har_vinterdack,har_sommarhjul,hjul_pa_bilen,wheel_storage_location,coc_location,instruktionsbok_location,bransletyp,datum_ankomst_mabi,bilfakta_imported_at')
       .eq('regnr', regnr)
       .limit(1),
     admin
       .from('checkins')
-      .select([
-        'id',
-        'status',
-        'completed_at',
-        'current_city',
-        'current_station',
-        'current_location_note',
-        'odometer_km',
-        'hjultyp',
-        'fuel_type',
-        'fuel_level',
-        'charge_level_percent',
-        'checklist',
-        'photo_urls',
-        'checker_name',
-        'checker_email',
-        'completed_by',
-      ].join(','))
+      .select('id,status,completed_at,current_city,current_station,current_location_note,odometer_km,hjultyp,fuel_type,fuel_level,charge_level_percent,checklist,photo_urls,checker_name,checker_email,completed_by')
       .eq('regnr', regnr)
       .eq('status', 'COMPLETED')
       .order('completed_at', { ascending: false })

--- a/migrations/20260820184925_create_vehicle_journey_foundation.sql
+++ b/migrations/20260820184925_create_vehicle_journey_foundation.sql
@@ -1,0 +1,145 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Generic append-only timeline for the whole vehicle journey.
+-- No FK on regnr yet: current Production has journey-source vehicles that are
+-- not present in public.vehicles, so forcing that relation would reject valid history.
+create table public.vehicle_journey_events (
+  event_id uuid primary key default gen_random_uuid(),
+  regnr text not null check (length(trim(regnr)) > 0),
+  event_type text not null check (length(trim(event_type)) > 0),
+  event_key text,
+  occurred_at timestamptz not null default now(),
+  source_system text not null default 'INCHECKAD' check (length(trim(source_system)) > 0),
+  source_entity text,
+  source_record_id text,
+  actor_id uuid,
+  actor_source text not null default 'SYSTEM'
+    check (actor_source in ('SYSTEM', 'MANUELL', 'EXTERNAL')),
+  actor_name text,
+  actor_email text,
+  payload jsonb not null default '{}'::jsonb,
+  correction_of_event_id uuid references public.vehicle_journey_events(event_id) on delete restrict,
+  created_at timestamptz not null default now(),
+  unique (event_key),
+  check (correction_of_event_id is null or correction_of_event_id <> event_id)
+);
+
+create index vehicle_journey_events_regnr_time_idx
+  on public.vehicle_journey_events (regnr, occurred_at desc);
+create index vehicle_journey_events_source_idx
+  on public.vehicle_journey_events (source_system, source_entity, source_record_id)
+  where source_record_id is not null;
+
+create or replace function public.reject_vehicle_journey_event_mutation()
+returns trigger
+language plpgsql
+security invoker
+set search_path = pg_catalog
+as $$
+begin
+  raise exception 'vehicle_journey_events is append-only; write a correcting event instead';
+end;
+$$;
+
+create trigger vehicle_journey_events_append_only_update
+before update on public.vehicle_journey_events
+for each row execute function public.reject_vehicle_journey_event_mutation();
+
+create trigger vehicle_journey_events_append_only_delete
+before delete on public.vehicle_journey_events
+for each row execute function public.reject_vehicle_journey_event_mutation();
+
+create table public.vehicle_journey_periods (
+  period_id uuid primary key default gen_random_uuid(),
+  regnr text not null check (length(trim(regnr)) > 0),
+  period_type text not null
+    check (period_type in ('PREPARATION', 'AVAILABLE', 'RENTAL', 'DOWNTIME', 'WORKSHOP', 'TRANSPORT', 'SALU', 'OTHER')),
+  started_at timestamptz not null,
+  ended_at timestamptz,
+  reason_code text,
+  reason_text text,
+  source_system text not null default 'INCHECKAD' check (length(trim(source_system)) > 0),
+  source_entity text,
+  source_record_id text,
+  source_event_id uuid references public.vehicle_journey_events(event_id) on delete restrict,
+  metadata jsonb not null default '{}'::jsonb,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (ended_at is null or ended_at >= started_at)
+);
+
+create index vehicle_journey_periods_regnr_time_idx
+  on public.vehicle_journey_periods (regnr, started_at desc);
+create index vehicle_journey_periods_open_idx
+  on public.vehicle_journey_periods (regnr, period_type, started_at desc)
+  where ended_at is null;
+
+create table public.vehicle_documents (
+  document_id uuid primary key default gen_random_uuid(),
+  regnr text not null check (length(trim(regnr)) > 0),
+  document_type text not null check (length(trim(document_type)) > 0),
+  title text,
+  storage_bucket text,
+  storage_path text,
+  external_url text,
+  file_name text not null check (length(trim(file_name)) > 0),
+  mime_type text,
+  size_bytes bigint check (size_bytes is null or size_bytes >= 0),
+  journey_event_id uuid references public.vehicle_journey_events(event_id) on delete restrict,
+  checkin_id uuid references public.checkins(id) on delete restrict,
+  damage_id uuid references public.damages(id) on delete restrict,
+  salu_flag_id uuid references public.salu_flags(flag_id) on delete restrict,
+  salu_checkpoint_id uuid references public.salu_checkpoints(checkpoint_id) on delete restrict,
+  salu_child_process_id uuid references public.salu_child_processes(child_process_id) on delete restrict,
+  source_system text not null default 'INCHECKAD' check (length(trim(source_system)) > 0),
+  source_record_id text,
+  metadata jsonb not null default '{}'::jsonb,
+  uploaded_by uuid,
+  uploaded_by_name text,
+  uploaded_by_email text,
+  uploaded_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  check (
+    (storage_bucket is not null and storage_path is not null)
+    or external_url is not null
+  ),
+  check ((storage_bucket is null) = (storage_path is null))
+);
+
+create unique index vehicle_documents_storage_object_uidx
+  on public.vehicle_documents (storage_bucket, storage_path)
+  where storage_bucket is not null;
+create index vehicle_documents_regnr_time_idx
+  on public.vehicle_documents (regnr, uploaded_at desc);
+create index vehicle_documents_event_idx
+  on public.vehicle_documents (journey_event_id)
+  where journey_event_id is not null;
+create index vehicle_documents_checkin_idx
+  on public.vehicle_documents (checkin_id)
+  where checkin_id is not null;
+create index vehicle_documents_damage_idx
+  on public.vehicle_documents (damage_id)
+  where damage_id is not null;
+create index vehicle_documents_salu_flag_idx
+  on public.vehicle_documents (salu_flag_id)
+  where salu_flag_id is not null;
+
+alter table public.vehicle_journey_events enable row level security;
+alter table public.vehicle_journey_periods enable row level security;
+alter table public.vehicle_documents enable row level security;
+
+revoke all on public.vehicle_journey_events from public, anon, authenticated;
+revoke all on public.vehicle_journey_periods from public, anon, authenticated;
+revoke all on public.vehicle_documents from public, anon, authenticated;
+revoke execute on function public.reject_vehicle_journey_event_mutation() from public, anon, authenticated;
+
+grant select, insert on public.vehicle_journey_events to service_role;
+grant select, insert, update, delete on public.vehicle_journey_periods to service_role;
+grant select, insert, update, delete on public.vehicle_documents to service_role;
+grant execute on function public.reject_vehicle_journey_event_mutation() to service_role;
+
+commit;

--- a/migrations/20260820185009_index_vehicle_journey_foreign_keys.sql
+++ b/migrations/20260820185009_index_vehicle_journey_foreign_keys.sql
@@ -1,0 +1,22 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+create index if not exists vehicle_journey_events_correction_idx
+  on public.vehicle_journey_events (correction_of_event_id)
+  where correction_of_event_id is not null;
+
+create index if not exists vehicle_journey_periods_source_event_idx
+  on public.vehicle_journey_periods (source_event_id)
+  where source_event_id is not null;
+
+create index if not exists vehicle_documents_salu_checkpoint_idx
+  on public.vehicle_documents (salu_checkpoint_id)
+  where salu_checkpoint_id is not null;
+
+create index if not exists vehicle_documents_salu_child_process_idx
+  on public.vehicle_documents (salu_child_process_id)
+  where salu_child_process_id is not null;
+
+commit;

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -18,6 +18,7 @@ const protectedApiPaths = [
   '/api/notify-nybil',
   '/api/vehicle-edits',
   '/api/vehicle-info?reg=GEU29F',
+  '/api/vehicle-journey?reg=GEU29F',
 ]
 
 test('all central protected API paths reject unauthenticated requests', async (t) => {

--- a/tests/vehicle-journey-contract.test.ts
+++ b/tests/vehicle-journey-contract.test.ts
@@ -1,0 +1,86 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const route = readFileSync(
+  join(process.cwd(), 'app/api/vehicle-journey/route.ts'),
+  'utf8',
+);
+
+const foundationMigration = readFileSync(
+  join(process.cwd(), 'migrations/20260820184925_create_vehicle_journey_foundation.sql'),
+  'utf8',
+);
+
+const indexMigration = readFileSync(
+  join(process.cwd(), 'migrations/20260820185009_index_vehicle_journey_foreign_keys.sql'),
+  'utf8',
+);
+
+test('Vagnkort read model is authenticated and server-side', () => {
+  assert.match(route, /verifyApiUser\(request\)/);
+  assert.match(route, /SUPABASE_SERVICE_ROLE_KEY/);
+  assert.match(route, /persistSession: false/);
+});
+
+test('Vagnkort reads the vehicle journey without inventing business events', () => {
+  assert.match(route, /from\('vehicle_journey_events'\)/);
+  assert.match(route, /from\('vehicle_journey_periods'\)/);
+  assert.match(route, /from\('vehicle_documents'\)/);
+  assert.doesNotMatch(route, /\.insert\(/);
+  assert.doesNotMatch(route, /\.update\(/);
+  assert.doesNotMatch(route, /\.upsert\(/);
+  assert.doesNotMatch(route, /\.delete\(/);
+});
+
+test('Vagnkort composes existing Nybil, Check, damage, receipt and SALU sources', () => {
+  for (const source of [
+    'nybil_inventering',
+    'vehicles',
+    'checkins',
+    'damages',
+    'vehicle_receipts',
+    'salu_vehicle_state',
+    'salu_flags',
+    'salu_checkpoints',
+    'salu_child_processes',
+  ]) {
+    assert.match(route, new RegExp(`from\\('${source}'\\)`));
+  }
+});
+
+test('legacy receipts remain visible through the unified Vagnkort document list', () => {
+  assert.match(route, /sourceKind: 'legacy_receipt'/);
+  assert.match(route, /storage_bucket: 'receipts'/);
+  assert.match(route, /source_system: 'LEGACY_RECEIPTS'/);
+});
+
+test('journey foundation is server-only and events are append-only', () => {
+  for (const table of [
+    'vehicle_journey_events',
+    'vehicle_journey_periods',
+    'vehicle_documents',
+  ]) {
+    assert.match(foundationMigration, new RegExp(`alter table public\\.${table} enable row level security`, 'i'));
+    assert.match(foundationMigration, new RegExp(`revoke all on public\\.${table} from public, anon, authenticated`, 'i'));
+  }
+  assert.match(foundationMigration, /vehicle_journey_events is append-only/i);
+  assert.match(foundationMigration, /before update on public\.vehicle_journey_events/i);
+  assert.match(foundationMigration, /before delete on public\.vehicle_journey_events/i);
+});
+
+test('journey foundation preserves history and evidence links', () => {
+  assert.match(foundationMigration, /references public\.checkins\(id\) on delete restrict/i);
+  assert.match(foundationMigration, /references public\.damages\(id\) on delete restrict/i);
+  assert.match(foundationMigration, /references public\.salu_flags\(flag_id\) on delete restrict/i);
+  assert.match(foundationMigration, /references public\.salu_checkpoints\(checkpoint_id\) on delete restrict/i);
+  assert.match(foundationMigration, /references public\.salu_child_processes\(child_process_id\) on delete restrict/i);
+});
+
+test('all new foreign keys have deliberate supporting indexes', () => {
+  assert.match(indexMigration, /vehicle_journey_events_correction_idx/);
+  assert.match(indexMigration, /vehicle_journey_periods_source_event_idx/);
+  assert.match(indexMigration, /vehicle_documents_salu_checkpoint_idx/);
+  assert.match(indexMigration, /vehicle_documents_salu_child_process_idx/);
+});


### PR DESCRIPTION
## Sammanfattning
- synkar Production-migrationerna för `vehicle_journey_events`, `vehicle_journey_periods` och `vehicle_documents`
- lägger till autentiserad server-side read model på `/api/vehicle-journey`
- läser ihop Nybil-baseline, aktuell fordonsdata, senaste Check, skador, fordonsresan, dokument/kvitton och SALU-status
- behåller legacy-kvitton synliga i samma dokumentlista utan backfill eller syntetiska affärshändelser
- håller nya reselager server-only med RLS + explicita revoke/grants

## Säkerhet
- endpointen använder `verifyApiUser`
- service role används endast server-side
- de nya tabellerna är inte direkt browser-exponerade
- read-modellen gör inga INSERT/UPDATE/UPSERT/DELETE

## Production
Schemaändringarna är redan applicerade och verifierade i Production som migrationerna `20260820184925` och `20260820185009`. Den här PR:n synkar repo + lägger på första read-modellen.

## Test
- nytt kontraktstest för fordonsresan/Vagnkortet
- central API-boundary inkluderar `/api/vehicle-journey`
