### PR TITLE
Vagnkort: säker drag-and-drop för dokument

### DIFF
--- a/app/api/vehicle-documents/[id]/route.ts
+++ b/app/api/vehicle-documents/[id]/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export async function GET(request: Request, context: { params: Promise<{ id: string }> }) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const { id } = await context.params;
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-documents] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Document service unavailable' }, { status: 503 });
+  }
+
+  const { data: document, error } = await admin
+    .from('vehicle_documents')
+    .select('document_id,storage_bucket,storage_path,external_url,file_name')
+    .eq('document_id', id)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[vehicle-documents] Document lookup failed:', error);
+    return NextResponse.json({ error: 'Could not load document' }, { status: 500 });
+  }
+  if (!document) return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+
+  if (document.external_url) {
+    return NextResponse.json({ data: { url: document.external_url, fileName: document.file_name } });
+  }
+  if (!document.storage_bucket || !document.storage_path) {
+    return NextResponse.json({ error: 'Document has no file location' }, { status: 409 });
+  }
+
+  const { data, error: signedUrlError } = await admin.storage
+    .from(document.storage_bucket)
+    .createSignedUrl(document.storage_path, 300, { download: document.file_name });
+
+  if (signedUrlError || !data?.signedUrl) {
+    console.error('[vehicle-documents] Signed URL creation failed:', signedUrlError);
+    return NextResponse.json({ error: 'Could not open document' }, { status: 500 });
+  }
+
+  return NextResponse.json({ data: { url: data.signedUrl, fileName: document.file_name } });
+}

--- a/app/api/vehicle-documents/route.ts
+++ b/app/api/vehicle-documents/route.ts
@@ -1,0 +1,199 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+const BUCKET = 'vehicle-documents';
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
+
+function cleanRegnr(value: unknown): string {
+  return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
+}
+
+function cleanFileName(value: unknown): string {
+  const fileName = typeof value === 'string' ? value.trim() : '';
+  const base = fileName.split(/[\\/]/).pop() || 'document';
+  return base.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'document';
+}
+
+function cleanDocumentType(value: unknown): string {
+  const documentType = typeof value === 'string' ? value.trim().toUpperCase() : '';
+  return documentType.replace(/[^A-Z0-9_-]+/g, '_').slice(0, 80) || 'OVRIGT';
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr: string) {
+  const [vehicle, nybil, checkin, salu] = await Promise.all([
+    admin.from('vehicles').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('nybil_inventering').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('checkins').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('salu_vehicle_state').select('regnr').eq('regnr', regnr).limit(1),
+  ]);
+  const failed = [vehicle, nybil, checkin, salu].find((response) => response.error);
+  if (failed?.error) throw failed.error;
+  return [vehicle, nybil, checkin, salu].some((response) => (response.data?.length ?? 0) > 0);
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const action = body.action;
+  const regnr = cleanRegnr(body.regnr);
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-documents] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Document service unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    if (action === 'prepare') {
+      const fileName = cleanFileName(body.fileName);
+      const sizeBytes = Number(body.sizeBytes);
+      if (!Number.isFinite(sizeBytes) || sizeBytes <= 0 || sizeBytes > MAX_FILE_SIZE) {
+        return NextResponse.json({ error: 'File must be between 1 byte and 50 MB' }, { status: 400 });
+      }
+
+      const now = new Date();
+      const year = String(now.getUTCFullYear());
+      const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+      const path = `${regnr}/${year}/${month}/${crypto.randomUUID()}-${fileName}`;
+      const { data, error } = await admin.storage.from(BUCKET).createSignedUploadUrl(path, { upsert: false });
+      if (error || !data?.token) {
+        console.error('[vehicle-documents] Could not create signed upload URL:', error);
+        return NextResponse.json({ error: 'Could not prepare upload' }, { status: 500 });
+      }
+
+      return NextResponse.json({ data: { bucket: BUCKET, path, token: data.token } });
+    }
+
+    if (action === 'complete') {
+      const path = typeof body.path === 'string' ? body.path.trim() : '';
+      const fileName = cleanFileName(body.fileName);
+      const documentType = cleanDocumentType(body.documentType);
+      const title = typeof body.title === 'string' && body.title.trim() ? body.title.trim().slice(0, 200) : null;
+      const mimeType = typeof body.mimeType === 'string' && body.mimeType.trim() ? body.mimeType.trim().slice(0, 200) : null;
+      const expectedSize = Number(body.sizeBytes);
+
+      if (!path.startsWith(`${regnr}/`) || path.includes('..')) {
+        return NextResponse.json({ error: 'Invalid storage path' }, { status: 400 });
+      }
+
+      const slash = path.lastIndexOf('/');
+      const folder = slash >= 0 ? path.slice(0, slash) : '';
+      const storedName = slash >= 0 ? path.slice(slash + 1) : path;
+      const { data: storedObjects, error: listError } = await admin.storage
+        .from(BUCKET)
+        .list(folder, { limit: 10, search: storedName });
+      if (listError) {
+        console.error('[vehicle-documents] Could not verify uploaded object:', listError);
+        return NextResponse.json({ error: 'Could not verify upload' }, { status: 500 });
+      }
+      const storedObject = storedObjects?.find((item) => item.name === storedName);
+      if (!storedObject) {
+        return NextResponse.json({ error: 'Uploaded file not found' }, { status: 409 });
+      }
+
+      const storedSize = Number(storedObject.metadata?.size ?? expectedSize);
+      if (Number.isFinite(expectedSize) && expectedSize > 0 && Number.isFinite(storedSize) && storedSize !== expectedSize) {
+        return NextResponse.json({ error: 'Uploaded file size mismatch' }, { status: 409 });
+      }
+
+      const { data: document, error: documentError } = await admin
+        .from('vehicle_documents')
+        .insert({
+          regnr,
+          document_type: documentType,
+          title,
+          storage_bucket: BUCKET,
+          storage_path: path,
+          file_name: fileName,
+          mime_type: mimeType,
+          size_bytes: Number.isFinite(storedSize) ? storedSize : null,
+          source_system: 'VAGNKORT',
+          source_record_id: path,
+          metadata: { uploadedVia: 'VAGNKORT' },
+          uploaded_by: verification.user.id,
+          uploaded_by_email: verification.user.email,
+        })
+        .select('document_id,document_type,title,file_name,mime_type,size_bytes,storage_bucket,storage_path,uploaded_at')
+        .single();
+
+      if (documentError || !document) {
+        if (documentError?.code === '23505') {
+          return NextResponse.json({ error: 'Document is already registered' }, { status: 409 });
+        }
+        console.error('[vehicle-documents] Could not register document:', documentError);
+        return NextResponse.json({ error: 'Could not register document' }, { status: 500 });
+      }
+
+      const { data: event, error: eventError } = await admin
+        .from('vehicle_journey_events')
+        .insert({
+          regnr,
+          event_type: 'DOCUMENT_UPLOADED',
+          event_key: `vehicle-document:${document.document_id}`,
+          occurred_at: document.uploaded_at,
+          source_system: 'VAGNKORT',
+          source_entity: 'vehicle_documents',
+          source_record_id: document.document_id,
+          actor_id: verification.user.id,
+          actor_source: 'MANUELL',
+          actor_email: verification.user.email,
+          payload: {
+            documentType,
+            title,
+            fileName,
+            mimeType,
+            sizeBytes: document.size_bytes,
+          },
+        })
+        .select('event_id')
+        .single();
+
+      if (eventError || !event) {
+        console.error('[vehicle-documents] Document registered but journey event failed:', eventError);
+      } else {
+        const { error: linkError } = await admin
+          .from('vehicle_documents')
+          .update({ journey_event_id: event.event_id })
+          .eq('document_id', document.document_id);
+        if (linkError) console.error('[vehicle-documents] Could not link journey event:', linkError);
+      }
+
+      return NextResponse.json({ data: document }, { status: 201 });
+    }
+
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+  } catch (error) {
+    console.error('[vehicle-documents] Unexpected error:', error);
+    return NextResponse.json({ error: 'Document operation failed' }, { status: 500 });
+  }
+}

--- a/app/vagnkort/document-upload.tsx
+++ b/app/vagnkort/document-upload.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { ChangeEvent, DragEvent, useRef, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+
+const DOCUMENT_TYPES = [
+  ['LEVERANTORSFAKTURA', 'Leverantörsfaktura'],
+  ['KVITTO', 'Kvitto'],
+  ['SKADEBILD', 'Skadebild'],
+  ['SKADEANMALAN', 'Skadeanmälan'],
+  ['VERKSTADSUNDERLAG', 'Verkstadsunderlag'],
+  ['SERVICE', 'Service / reparation'],
+  ['TRANSPORT', 'Transportdokument'],
+  ['COC', 'COC / fordonsdokument'],
+  ['RETURBLANKETT', 'Returblankett'],
+  ['OVRIGT', 'Övrigt'],
+] as const;
+
+type Props = {
+  regnr: string;
+  onUploaded: () => void;
+};
+
+type PrepareResponse = {
+  data?: { bucket: string; path: string; token: string };
+  error?: string;
+};
+
+type CompleteResponse = { data?: { document_id: string }; error?: string };
+
+export default function DocumentUpload({ regnr, onUploaded }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [documentType, setDocumentType] = useState('OVRIGT');
+  const [title, setTitle] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const [message, setMessage] = useState('');
+
+  async function uploadFiles(files: File[]) {
+    if (!files.length || uploading) return;
+    setUploading(true);
+    setMessage('');
+
+    try {
+      for (const file of files) {
+        if (file.size > 50 * 1024 * 1024) throw new Error(`${file.name} är större än 50 MB.`);
+
+        const prepareResponse = await fetch('/api/vehicle-documents', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'prepare',
+            regnr,
+            fileName: file.name,
+            mimeType: file.type || null,
+            sizeBytes: file.size,
+          }),
+        });
+        const prepared = (await prepareResponse.json()) as PrepareResponse;
+        if (!prepareResponse.ok || !prepared.data) {
+          throw new Error(prepared.error || `Kunde inte förbereda ${file.name}`);
+        }
+
+        const { bucket, path, token } = prepared.data;
+        const { error: uploadError } = await supabase.storage
+          .from(bucket)
+          .uploadToSignedUrl(path, token, file, {
+            contentType: file.type || 'application/octet-stream',
+          });
+        if (uploadError) throw new Error(`Uppladdning misslyckades för ${file.name}: ${uploadError.message}`);
+
+        const completeResponse = await fetch('/api/vehicle-documents', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'complete',
+            regnr,
+            path,
+            fileName: file.name,
+            mimeType: file.type || null,
+            sizeBytes: file.size,
+            documentType,
+            title: title.trim() || null,
+          }),
+        });
+        const completed = (await completeResponse.json()) as CompleteResponse;
+        if (!completeResponse.ok || !completed.data) {
+          throw new Error(completed.error || `Kunde inte registrera ${file.name}`);
+        }
+      }
+
+      setMessage(files.length === 1 ? 'Dokumentet är sparat på Vagnkortet.' : `${files.length} dokument är sparade på Vagnkortet.`);
+      setTitle('');
+      if (inputRef.current) inputRef.current.value = '';
+      onUploaded();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Uppladdningen misslyckades.');
+    } finally {
+      setUploading(false);
+      setDragging(false);
+    }
+  }
+
+  function onFileInput(event: ChangeEvent<HTMLInputElement>) {
+    void uploadFiles(Array.from(event.target.files ?? []));
+  }
+
+  function onDrop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    setDragging(false);
+    void uploadFiles(Array.from(event.dataTransfer.files));
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: '.75rem' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: '.6rem' }}>
+        <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+          Dokumenttyp
+          <select value={documentType} onChange={(event) => setDocumentType(event.target.value)} disabled={uploading} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
+            {DOCUMENT_TYPES.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+          </select>
+        </label>
+        <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+          Rubrik (valfri)
+          <input value={title} onChange={(event) => setTitle(event.target.value)} disabled={uploading} placeholder="T.ex. Faktura Werksta 20/8" style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
+        </label>
+      </div>
+
+      <div
+        onDragEnter={(event) => { event.preventDefault(); setDragging(true); }}
+        onDragOver={(event) => { event.preventDefault(); setDragging(true); }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={onDrop}
+        onClick={() => !uploading && inputRef.current?.click()}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(event) => { if ((event.key === 'Enter' || event.key === ' ') && !uploading) inputRef.current?.click(); }}
+        style={{
+          border: `2px dashed ${dragging ? '#222' : '#aaa'}`,
+          background: dragging ? '#f0f0f0' : '#fafafa',
+          borderRadius: 10,
+          padding: '1.4rem',
+          textAlign: 'center',
+          cursor: uploading ? 'wait' : 'pointer',
+        }}
+      >
+        <strong>{uploading ? 'Laddar upp…' : 'Släpp filer här'}</strong>
+        <div style={{ marginTop: '.25rem', color: '#666', fontSize: 13 }}>eller klicka för att välja · max 50 MB per fil</div>
+        <input ref={inputRef} type="file" multiple onChange={onFileInput} disabled={uploading} style={{ display: 'none' }} />
+      </div>
+
+      {message && <div style={{ fontSize: 13, color: message.includes('misslyck') || message.includes('Kunde') || message.includes('större') ? '#a00' : '#176b2c' }}>{message}</div>}
+    </div>
+  );
+}

--- a/app/vagnkort/vagnkort-client.tsx
+++ b/app/vagnkort/vagnkort-client.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
+import DocumentUpload from './document-upload';
 
 type JourneyPeriod = {
   period_id: string;
@@ -28,6 +29,7 @@ type VehicleDocument = {
   file_name: string;
   external_url: string | null;
   uploaded_at: string;
+  sourceKind?: 'vehicle_document' | 'legacy_receipt';
 };
 
 type Damage = {
@@ -132,6 +134,8 @@ export default function VagnkortClient() {
   const [data, setData] = useState<JourneyResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const [openingDocument, setOpeningDocument] = useState<string | null>(null);
 
   useEffect(() => {
     if (!activeRegnr) return;
@@ -161,7 +165,7 @@ export default function VagnkortClient() {
     });
 
     return () => { cancelled = true; };
-  }, [activeRegnr]);
+  }, [activeRegnr, refreshNonce]);
 
   const equipmentDiffs = useMemo(() => {
     const baseline = data?.equipment.baseline;
@@ -184,6 +188,25 @@ export default function VagnkortClient() {
     window.history.replaceState(null, '', `/vagnkort?reg=${encodeURIComponent(normalized)}`);
   }
 
+  async function openDocument(document: VehicleDocument) {
+    if (document.external_url) {
+      window.open(document.external_url, '_blank', 'noopener,noreferrer');
+      return;
+    }
+
+    setOpeningDocument(document.document_id);
+    try {
+      const response = await fetch(`/api/vehicle-documents/${encodeURIComponent(document.document_id)}`);
+      const body = await response.json() as { data?: { url: string }; error?: string };
+      if (!response.ok || !body.data?.url) throw new Error(body.error || 'Kunde inte öppna dokumentet');
+      window.open(body.data.url, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Kunde inte öppna dokumentet');
+    } finally {
+      setOpeningDocument(null);
+    }
+  }
+
   return (
     <main style={{ minHeight: '100vh', background: '#f2f4f5', padding: '1.5rem' }}>
       <div style={{ maxWidth: 1200, margin: '0 auto' }}>
@@ -201,7 +224,7 @@ export default function VagnkortClient() {
         </form>
 
         {loading && <div style={card}>Hämtar bilens resa…</div>}
-        {error && <div style={{ ...card, color: '#a00' }}>{error}</div>}
+        {error && <div style={{ ...card, color: '#a00', marginBottom: '1rem' }}>{error}</div>}
         {!loading && data && !data.found && <div style={card}>Ingen fordonsdata hittades för {data.regnr}.</div>}
 
         {!loading && data?.found && (
@@ -244,7 +267,20 @@ export default function VagnkortClient() {
               </section>
               <section style={card}>
                 <h2 style={{ marginTop: 0 }}>Dokument</h2>
-                {data.documents.length === 0 ? <p>Inga dokument registrerade ännu.</p> : data.documents.slice(0, 12).map((document) => <div key={document.document_id} style={{ padding: '.55rem 0', borderBottom: '1px solid #eee' }}>{document.external_url ? <a href={document.external_url} target="_blank" rel="noreferrer"><strong>{document.title || document.file_name}</strong></a> : <strong>{document.title || document.file_name}</strong>}<div style={{ color: '#666', fontSize: 13 }}>{document.document_type} · {formatDate(document.uploaded_at)}</div></div>)}
+                <DocumentUpload regnr={data.regnr} onUploaded={() => setRefreshNonce((value) => value + 1)} />
+                <div style={{ marginTop: '1rem' }}>
+                  {data.documents.length === 0 ? <p>Inga dokument registrerade ännu.</p> : data.documents.slice(0, 20).map((document) => (
+                    <div key={document.document_id} style={{ padding: '.55rem 0', borderBottom: '1px solid #eee', display: 'flex', gap: '.7rem', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <div>
+                        <strong>{document.title || document.file_name}</strong>
+                        <div style={{ color: '#666', fontSize: 13 }}>{document.document_type} · {formatDate(document.uploaded_at)}</div>
+                      </div>
+                      <button type="button" onClick={() => void openDocument(document)} disabled={openingDocument === document.document_id} style={{ border: '1px solid #bbb', borderRadius: 7, background: '#fff', padding: '.45rem .7rem', cursor: 'pointer' }}>
+                        {openingDocument === document.document_id ? 'Öppnar…' : 'Öppna'}
+                      </button>
+                    </div>
+                  ))}
+                </div>
               </section>
             </div>
 

--- a/migrations/20260820191700_create_vehicle_documents_bucket.sql
+++ b/migrations/20260820191700_create_vehicle_documents_bucket.sql
@@ -1,0 +1,9 @@
+-- Private Storage bucket for Vagnkort documents.
+-- File operations go through the Supabase Storage API; the bucket stays private
+-- and document access is issued by authenticated server routes using signed URLs.
+insert into storage.buckets (id, name, public, file_size_limit)
+values ('vehicle-documents', 'vehicle-documents', false, 52428800)
+on conflict (id) do update
+set name = excluded.name,
+    public = excluded.public,
+    file_size_limit = excluded.file_size_limit;

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -16,6 +16,8 @@ const protectedApiPaths = [
   '/api/notify',
   '/api/notify-arrival',
   '/api/notify-nybil',
+  '/api/vehicle-documents',
+  '/api/vehicle-documents/00000000-0000-4000-8000-000000000000',
   '/api/vehicle-edits',
   '/api/vehicle-info?reg=GEU29F',
   '/api/vehicle-journey?reg=GEU29F',

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -5,6 +5,9 @@ import { join } from 'node:path';
 
 const page = readFileSync(join(process.cwd(), 'app/vagnkort/page.tsx'), 'utf8');
 const client = readFileSync(join(process.cwd(), 'app/vagnkort/vagnkort-client.tsx'), 'utf8');
+const upload = readFileSync(join(process.cwd(), 'app/vagnkort/document-upload.tsx'), 'utf8');
+const uploadApi = readFileSync(join(process.cwd(), 'app/api/vehicle-documents/route.ts'), 'utf8');
+const documentApi = readFileSync(join(process.cwd(), 'app/api/vehicle-documents/[id]/route.ts'), 'utf8');
 const home = readFileSync(join(process.cwd(), 'app/page.tsx'), 'utf8');
 
 test('Vagnkort page stays behind the existing LoginGate', () => {
@@ -21,11 +24,30 @@ test('Vagnkort reads the authenticated vehicle journey API', () => {
   assert.match(client, /Tidslinje/);
 });
 
-test('Vagnkort surfaces baseline/current equipment changes without writing data', () => {
+test('Vagnkort surfaces baseline/current equipment changes', () => {
   assert.match(client, /baseline\[key\] !== current\[key\]/);
-  assert.doesNotMatch(client, /method:\s*['"]POST['"]/);
-  assert.doesNotMatch(client, /method:\s*['"]PUT['"]/);
-  assert.doesNotMatch(client, /method:\s*['"]DELETE['"]/);
+  assert.match(client, /Förändrat/);
+});
+
+test('Vagnkort document upload uses authenticated prepare/complete and signed Storage upload', () => {
+  assert.match(client, /<DocumentUpload regnr=/);
+  assert.match(upload, /action:\s*'prepare'/);
+  assert.match(upload, /uploadToSignedUrl/);
+  assert.match(upload, /action:\s*'complete'/);
+  assert.match(upload, /Släpp filer här/);
+  assert.match(upload, /Leverantörsfaktura/);
+  assert.match(upload, /Skadebild/);
+});
+
+test('document server API verifies identity, keeps private storage server controlled and appends a journey event', () => {
+  assert.match(uploadApi, /verifyApiUser\(request\)/);
+  assert.match(uploadApi, /createSignedUploadUrl/);
+  assert.match(uploadApi, /vehicle_documents/);
+  assert.match(uploadApi, /DOCUMENT_UPLOADED/);
+  assert.match(uploadApi, /uploaded_by:\s*verification\.user\.id/);
+  assert.match(documentApi, /verifyApiUser\(request\)/);
+  assert.match(documentApi, /createSignedUrl/);
+  assert.match(documentApi, /300/);
 });
 
 test('start page links to Vagnkort', () => {


### PR DESCRIPTION
## Sammanfattning
- lägger till privat Storage-bucket `vehicle-documents` (50 MiB per fil)
- lägger till autentiserad prepare/complete-API för Vagnkortsdokument
- uppladdning sker direkt till privat Supabase Storage via tidsbegränsad signed upload-token
- registrerar filen i `vehicle_documents` och skapar append-only `DOCUMENT_UPLOADED` i fordonsresan
- lägger till drag-and-drop/fILväljare på Vagnkortet med dokumentklassning och valfri rubrik
- privata dokument öppnas via autentiserad serverroute som skapar 5 min signed URL
- legacy/external documents fortsätter fungera

## Säkerhet
- `verifyApiUser` krävs för prepare, complete och dokumentöppning
- service role stannar server-side
- bucket är privat
- storage-path binds till aktuellt regnr och servern verifierar att bilen finns
- uppladdad fil verifieras innan metadata registreras
- max 50 MiB per fil

## Production
Bucket `vehicle-documents` är redan skapad och verifierad i Production som privat med 50 MiB gräns. Migrationen i PR:n synkar detta till repository.

## Avgränsning
Dokument kopplas i detta steg till bilen och en generisk fordonsrese-händelse. Val av specifik skada, verkstadsåtgärd eller SALU-checkpoint kommer separat.