### PR TITLE
Vagnkort: koppla dokument till skada och SALU

### DIFF
--- a/app/api/vehicle-documents/route.ts
+++ b/app/api/vehicle-documents/route.ts
@@ -3,8 +3,28 @@ import { createClient } from '@supabase/supabase-js';
 import { verifyApiUser } from '@/lib/server-auth';
 
 const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const BUCKET = 'vehicle-documents';
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
+
+type ContextType = 'VEHICLE' | 'DAMAGE' | 'SALU_CHECKPOINT' | 'SALU_CHILD_PROCESS';
+
+type ContextResolution =
+  | {
+      ok: true;
+      links: {
+        damage_id: string | null;
+        salu_flag_id: string | null;
+        salu_checkpoint_id: string | null;
+        salu_child_process_id: string | null;
+      };
+      payload: {
+        type: ContextType;
+        id: string | null;
+        label: string | null;
+      };
+    }
+  | { ok: false; status: 400 | 500; error: string };
 
 function cleanRegnr(value: unknown): string {
   return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
@@ -19,6 +39,18 @@ function cleanFileName(value: unknown): string {
 function cleanDocumentType(value: unknown): string {
   const documentType = typeof value === 'string' ? value.trim().toUpperCase() : '';
   return documentType.replace(/[^A-Z0-9_-]+/g, '_').slice(0, 80) || 'OVRIGT';
+}
+
+function cleanContextType(value: unknown): ContextType | null {
+  const contextType = typeof value === 'string' ? value.trim().toUpperCase() : 'VEHICLE';
+  return ['VEHICLE', 'DAMAGE', 'SALU_CHECKPOINT', 'SALU_CHILD_PROCESS'].includes(contextType)
+    ? contextType as ContextType
+    : null;
+}
+
+function cleanContextId(value: unknown): string | null {
+  const contextId = typeof value === 'string' ? value.trim() : '';
+  return UUID_RE.test(contextId) ? contextId : null;
 }
 
 function createAdminClient() {
@@ -40,6 +72,139 @@ async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr:
   const failed = [vehicle, nybil, checkin, salu].find((response) => response.error);
   if (failed?.error) throw failed.error;
   return [vehicle, nybil, checkin, salu].some((response) => (response.data?.length ?? 0) > 0);
+}
+
+async function resolveDocumentContext(
+  admin: ReturnType<typeof createAdminClient>,
+  regnr: string,
+  rawType: unknown,
+  rawId: unknown,
+): Promise<ContextResolution> {
+  const contextType = cleanContextType(rawType);
+  if (!contextType) return { ok: false, status: 400, error: 'Invalid document context type' };
+
+  const emptyLinks = {
+    damage_id: null,
+    salu_flag_id: null,
+    salu_checkpoint_id: null,
+    salu_child_process_id: null,
+  };
+
+  if (contextType === 'VEHICLE') {
+    return {
+      ok: true,
+      links: emptyLinks,
+      payload: { type: 'VEHICLE', id: null, label: 'Bilen' },
+    };
+  }
+
+  const contextId = cleanContextId(rawId);
+  if (!contextId) return { ok: false, status: 400, error: 'Invalid document context id' };
+
+  if (contextType === 'DAMAGE') {
+    const { data: damage, error } = await admin
+      .from('damages')
+      .select('id,damage_type_raw,legacy_damage_source_text,damage_date,source')
+      .eq('id', contextId)
+      .eq('regnr', regnr)
+      .maybeSingle();
+    if (error) {
+      console.error('[vehicle-documents] Could not verify damage context:', error);
+      return { ok: false, status: 500, error: 'Could not verify document context' };
+    }
+    if (!damage) return { ok: false, status: 400, error: 'Damage does not belong to vehicle' };
+
+    const damageName = damage.damage_type_raw || damage.legacy_damage_source_text || 'Skada';
+    const damageDate = damage.damage_date ? ` ${damage.damage_date}` : '';
+    return {
+      ok: true,
+      links: { ...emptyLinks, damage_id: damage.id },
+      payload: {
+        type: 'DAMAGE',
+        id: damage.id,
+        label: `${damageName}${damageDate}`,
+      },
+    };
+  }
+
+  if (contextType === 'SALU_CHECKPOINT') {
+    const { data: checkpoint, error } = await admin
+      .from('salu_checkpoints')
+      .select('checkpoint_id,flag_id,checkpoint_code,status')
+      .eq('checkpoint_id', contextId)
+      .maybeSingle();
+    if (error) {
+      console.error('[vehicle-documents] Could not verify SALU checkpoint context:', error);
+      return { ok: false, status: 500, error: 'Could not verify document context' };
+    }
+    if (!checkpoint) return { ok: false, status: 400, error: 'SALU checkpoint not found' };
+
+    const { data: flag, error: flagError } = await admin
+      .from('salu_flags')
+      .select('flag_id,regnr')
+      .eq('flag_id', checkpoint.flag_id)
+      .maybeSingle();
+    if (flagError) {
+      console.error('[vehicle-documents] Could not verify SALU flag:', flagError);
+      return { ok: false, status: 500, error: 'Could not verify document context' };
+    }
+    if (!flag || flag.regnr !== regnr) {
+      return { ok: false, status: 400, error: 'SALU checkpoint does not belong to vehicle' };
+    }
+
+    return {
+      ok: true,
+      links: {
+        ...emptyLinks,
+        salu_flag_id: flag.flag_id,
+        salu_checkpoint_id: checkpoint.checkpoint_id,
+      },
+      payload: {
+        type: 'SALU_CHECKPOINT',
+        id: checkpoint.checkpoint_id,
+        label: `SALU ${checkpoint.checkpoint_code} · ${checkpoint.status}`,
+      },
+    };
+  }
+
+  const { data: childProcess, error } = await admin
+    .from('salu_child_processes')
+    .select('child_process_id,flag_id,process_type,source_checkpoint,status')
+    .eq('child_process_id', contextId)
+    .maybeSingle();
+  if (error) {
+    console.error('[vehicle-documents] Could not verify SALU child process context:', error);
+    return { ok: false, status: 500, error: 'Could not verify document context' };
+  }
+  if (!childProcess) return { ok: false, status: 400, error: 'SALU action not found' };
+
+  const { data: flag, error: flagError } = await admin
+    .from('salu_flags')
+    .select('flag_id,regnr')
+    .eq('flag_id', childProcess.flag_id)
+    .maybeSingle();
+  if (flagError) {
+    console.error('[vehicle-documents] Could not verify SALU child-process flag:', flagError);
+    return { ok: false, status: 500, error: 'Could not verify document context' };
+  }
+  if (!flag || flag.regnr !== regnr) {
+    return { ok: false, status: 400, error: 'SALU action does not belong to vehicle' };
+  }
+
+  const checkpointLabel = childProcess.source_checkpoint ? ` · ${childProcess.source_checkpoint}` : '';
+  return {
+    ok: true,
+    links: {
+      ...emptyLinks,
+      salu_flag_id: flag.flag_id,
+      salu_child_process_id: childProcess.child_process_id,
+    },
+    payload: {
+      type: 'SALU_CHILD_PROCESS',
+      id: childProcess.child_process_id,
+      label: `${childProcess.process_type}${checkpointLabel} · ${childProcess.status}`,
+    },
+  };
 }
 
 export async function POST(request: Request) {
@@ -101,6 +266,10 @@ export async function POST(request: Request) {
       const title = typeof body.title === 'string' && body.title.trim() ? body.title.trim().slice(0, 200) : null;
       const mimeType = typeof body.mimeType === 'string' && body.mimeType.trim() ? body.mimeType.trim().slice(0, 200) : null;
       const expectedSize = Number(body.sizeBytes);
+      const context = await resolveDocumentContext(admin, regnr, body.contextType, body.contextId);
+      if (!context.ok) {
+        return NextResponse.json({ error: context.error }, { status: context.status });
+      }
 
       if (!path.startsWith(`${regnr}/`) || path.includes('..')) {
         return NextResponse.json({ error: 'Invalid storage path' }, { status: 400 });
@@ -137,13 +306,17 @@ export async function POST(request: Request) {
           file_name: fileName,
           mime_type: mimeType,
           size_bytes: Number.isFinite(storedSize) ? storedSize : null,
+          ...context.links,
           source_system: 'VAGNKORT',
           source_record_id: path,
-          metadata: { uploadedVia: 'VAGNKORT' },
+          metadata: {
+            uploadedVia: 'VAGNKORT',
+            context: context.payload,
+          },
           uploaded_by: verification.user.id,
           uploaded_by_email: verification.user.email,
         })
-        .select('document_id,document_type,title,file_name,mime_type,size_bytes,storage_bucket,storage_path,uploaded_at')
+        .select('document_id,document_type,title,file_name,mime_type,size_bytes,storage_bucket,storage_path,damage_id,salu_flag_id,salu_checkpoint_id,salu_child_process_id,metadata,uploaded_at')
         .single();
 
       if (documentError || !document) {
@@ -173,6 +346,7 @@ export async function POST(request: Request) {
             fileName,
             mimeType,
             sizeBytes: document.size_bytes,
+            context: context.payload,
           },
         })
         .select('event_id')

--- a/app/vagnkort/document-upload.tsx
+++ b/app/vagnkort/document-upload.tsx
@@ -16,8 +16,16 @@ const DOCUMENT_TYPES = [
   ['OVRIGT', 'Övrigt'],
 ] as const;
 
+type ContextOption = {
+  value: string;
+  label: string;
+};
+
 type Props = {
   regnr: string;
+  damageOptions: ContextOption[];
+  checkpointOptions: ContextOption[];
+  childProcessOptions: ContextOption[];
   onUploaded: () => void;
 };
 
@@ -28,16 +36,42 @@ type PrepareResponse = {
 
 type CompleteResponse = { data?: { document_id: string }; error?: string };
 
-export default function DocumentUpload({ regnr, onUploaded }: Props) {
+export default function DocumentUpload({
+  regnr,
+  damageOptions,
+  checkpointOptions,
+  childProcessOptions,
+  onUploaded,
+}: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [documentType, setDocumentType] = useState('OVRIGT');
   const [title, setTitle] = useState('');
+  const [contextType, setContextType] = useState('VEHICLE');
+  const [contextId, setContextId] = useState('');
   const [uploading, setUploading] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [message, setMessage] = useState('');
 
+  const contextOptions = contextType === 'DAMAGE'
+    ? damageOptions
+    : contextType === 'SALU_CHECKPOINT'
+      ? checkpointOptions
+      : contextType === 'SALU_CHILD_PROCESS'
+        ? childProcessOptions
+        : [];
+
+  function changeContextType(nextType: string) {
+    setContextType(nextType);
+    setContextId('');
+  }
+
   async function uploadFiles(files: File[]) {
     if (!files.length || uploading) return;
+    if (contextType !== 'VEHICLE' && !contextId) {
+      setMessage('Välj vilken skada eller SALU-post dokumentet ska kopplas till.');
+      return;
+    }
+
     setUploading(true);
     setMessage('');
 
@@ -81,6 +115,8 @@ export default function DocumentUpload({ regnr, onUploaded }: Props) {
             sizeBytes: file.size,
             documentType,
             title: title.trim() || null,
+            contextType,
+            contextId: contextType === 'VEHICLE' ? null : contextId,
           }),
         });
         const completed = (await completeResponse.json()) as CompleteResponse;
@@ -121,6 +157,24 @@ export default function DocumentUpload({ regnr, onUploaded }: Props) {
           </select>
         </label>
         <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+          Koppla till
+          <select value={contextType} onChange={(event) => changeContextType(event.target.value)} disabled={uploading} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
+            <option value="VEHICLE">Bilen generellt</option>
+            <option value="DAMAGE">Skada</option>
+            <option value="SALU_CHECKPOINT">SALU-checkpoint</option>
+            <option value="SALU_CHILD_PROCESS">SALU-åtgärd</option>
+          </select>
+        </label>
+        {contextType !== 'VEHICLE' && (
+          <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+            Välj post
+            <select value={contextId} onChange={(event) => setContextId(event.target.value)} disabled={uploading} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
+              <option value="">Välj…</option>
+              {contextOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+          </label>
+        )}
+        <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
           Rubrik (valfri)
           <input value={title} onChange={(event) => setTitle(event.target.value)} disabled={uploading} placeholder="T.ex. Faktura Werksta 20/8" style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
         </label>
@@ -149,7 +203,7 @@ export default function DocumentUpload({ regnr, onUploaded }: Props) {
         <input ref={inputRef} type="file" multiple onChange={onFileInput} disabled={uploading} style={{ display: 'none' }} />
       </div>
 
-      {message && <div style={{ fontSize: 13, color: message.includes('misslyck') || message.includes('Kunde') || message.includes('större') ? '#a00' : '#176b2c' }}>{message}</div>}
+      {message && <div style={{ fontSize: 13, color: message.includes('misslyck') || message.includes('Kunde') || message.includes('större') || message.includes('Välj') ? '#a00' : '#176b2c' }}>{message}</div>}
     </div>
   );
 }

--- a/app/vagnkort/document-upload.tsx
+++ b/app/vagnkort/document-upload.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, DragEvent, useRef, useState } from 'react';
+import { ChangeEvent, DragEvent, useEffect, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabase';
 
 const DOCUMENT_TYPES = [
@@ -23,9 +23,6 @@ type ContextOption = {
 
 type Props = {
   regnr: string;
-  damageOptions: ContextOption[];
-  checkpointOptions: ContextOption[];
-  childProcessOptions: ContextOption[];
   onUploaded: () => void;
 };
 
@@ -36,21 +33,71 @@ type PrepareResponse = {
 
 type CompleteResponse = { data?: { document_id: string }; error?: string };
 
-export default function DocumentUpload({
-  regnr,
-  damageOptions,
-  checkpointOptions,
-  childProcessOptions,
-  onUploaded,
-}: Props) {
+type JourneyContextResponse = {
+  data?: {
+    damages?: Array<{
+      id: string;
+      damage_type_raw?: string | null;
+      legacy_damage_source_text?: string | null;
+      damage_date?: string | null;
+      source?: string | null;
+    }>;
+    salu?: {
+      checkpoints?: Array<Record<string, unknown>>;
+      childProcesses?: Array<Record<string, unknown>>;
+    };
+  };
+};
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+export default function DocumentUpload({ regnr, onUploaded }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [documentType, setDocumentType] = useState('OVRIGT');
   const [title, setTitle] = useState('');
   const [contextType, setContextType] = useState('VEHICLE');
   const [contextId, setContextId] = useState('');
+  const [damageOptions, setDamageOptions] = useState<ContextOption[]>([]);
+  const [checkpointOptions, setCheckpointOptions] = useState<ContextOption[]>([]);
+  const [childProcessOptions, setChildProcessOptions] = useState<ContextOption[]>([]);
   const [uploading, setUploading] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadContexts() {
+      try {
+        const response = await fetch(`/api/vehicle-journey?reg=${encodeURIComponent(regnr)}`);
+        if (!response.ok) return;
+        const body = (await response.json()) as JourneyContextResponse;
+        if (cancelled) return;
+
+        setDamageOptions((body.data?.damages ?? []).map((damage) => ({
+          value: damage.id,
+          label: `${damage.damage_type_raw || damage.legacy_damage_source_text || 'Skada'}${damage.damage_date ? ` · ${damage.damage_date}` : ''}${damage.source ? ` · ${damage.source}` : ''}`,
+        })));
+
+        setCheckpointOptions((body.data?.salu?.checkpoints ?? []).map((checkpoint) => ({
+          value: text(checkpoint.checkpoint_id),
+          label: `${text(checkpoint.checkpoint_code) || 'Checkpoint'} · ${text(checkpoint.status) || 'okänd status'}`,
+        })).filter((option) => option.value));
+
+        setChildProcessOptions((body.data?.salu?.childProcesses ?? []).map((process) => ({
+          value: text(process.child_process_id),
+          label: `${text(process.process_type) || 'SALU-åtgärd'}${text(process.source_checkpoint) ? ` · ${text(process.source_checkpoint)}` : ''} · ${text(process.status) || 'okänd status'}`,
+        })).filter((option) => option.value));
+      } catch {
+        // Vagnkortet fungerar fortfarande med bilnivå även om kontextlistan inte kan laddas.
+      }
+    }
+
+    void loadContexts();
+    return () => { cancelled = true; };
+  }, [regnr]);
 
   const contextOptions = contextType === 'DAMAGE'
     ? damageOptions

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -39,6 +39,21 @@ test('Vagnkort document upload uses authenticated prepare/complete and signed St
   assert.match(upload, /Skadebild/);
 });
 
+test('Vagnkort document upload can bind evidence to vehicle, damage and SALU context', () => {
+  assert.match(upload, /Bilen generellt/);
+  assert.match(upload, /SALU-checkpoint/);
+  assert.match(upload, /SALU-åtgärd/);
+  assert.match(upload, /contextType/);
+  assert.match(upload, /contextId/);
+  assert.match(uploadApi, /resolveDocumentContext/);
+  assert.match(uploadApi, /Damage does not belong to vehicle/);
+  assert.match(uploadApi, /SALU checkpoint does not belong to vehicle/);
+  assert.match(uploadApi, /SALU action does not belong to vehicle/);
+  assert.match(uploadApi, /damage_id/);
+  assert.match(uploadApi, /salu_checkpoint_id/);
+  assert.match(uploadApi, /salu_child_process_id/);
+});
+
 test('document server API verifies identity, keeps private storage server controlled and appends a journey event', () => {
   assert.match(uploadApi, /verifyApiUser\(request\)/);
   assert.match(uploadApi, /createSignedUploadUrl/);


### PR DESCRIPTION
## Sammanfattning
- låter dokumentuppladdning kopplas till bilen generellt, en specifik skada, SALU-checkpoint eller SALU-åtgärd
- servern verifierar att vald skada/SALU-post faktiskt tillhör rätt regnr innan dokumentet registreras
- sparar FK-kopplingarna i befintliga `vehicle_documents`-fält
- lägger vald kontext även i dokumentmetadata och `DOCUMENT_UPLOADED`-händelsen
- Vagnkortet hämtar valbara skador/checkpoints/barnprocesser från befintlig fordonsresa

## Säkerhet
- ingen klientstyrd FK accepteras utan server-side ägarskapskontroll
- dokumentflödet ligger fortsatt bakom `verifyApiUser`
- inga nya direkta browser-grants eller RLS-policyer

## Databas
Ingen schemaändring behövs. `vehicle_documents` har redan FK-fälten `damage_id`, `salu_flag_id`, `salu_checkpoint_id` och `salu_child_process_id`.

## Test
Utökat Vagnkort-kontraktstest täcker kontextval och servervalidering.