### PR TITLE
Vagnkort: starta och avsluta fordonsperioder

### DIFF
--- a/app/api/vehicle-journey/periods/route.ts
+++ b/app/api/vehicle-journey/periods/route.ts
@@ -1,0 +1,311 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const PERIOD_TYPES = [
+  'PREPARATION',
+  'AVAILABLE',
+  'RENTAL',
+  'DOWNTIME',
+  'WORKSHOP',
+  'TRANSPORT',
+  'SALU',
+  'OTHER',
+] as const;
+
+type PeriodType = (typeof PERIOD_TYPES)[number];
+
+const DOWNTIME_REASONS = [
+  'DAMAGE',
+  'WORKSHOP',
+  'SERVICE',
+  'WAITING_PARTS',
+  'MISSING_EQUIPMENT',
+  'TRANSPORT',
+  'ADMINISTRATION',
+  'OTHER',
+] as const;
+
+type DowntimeReason = (typeof DOWNTIME_REASONS)[number];
+
+function cleanRegnr(value: unknown): string {
+  return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
+}
+
+function cleanPeriodType(value: unknown): PeriodType | null {
+  const periodType = typeof value === 'string' ? value.trim().toUpperCase() : '';
+  return PERIOD_TYPES.includes(periodType as PeriodType) ? periodType as PeriodType : null;
+}
+
+function cleanReasonCode(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  return value.trim().toUpperCase().replace(/[^A-Z0-9_-]+/g, '_').slice(0, 80) || null;
+}
+
+function cleanReasonText(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  return value.trim().slice(0, 500);
+}
+
+function parseTimestamp(value: unknown, fallbackToNow: boolean): string | null {
+  if ((value === null || value === undefined || value === '') && fallbackToNow) {
+    return new Date().toISOString();
+  }
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr: string) {
+  const [vehicle, nybil, checkin, salu] = await Promise.all([
+    admin.from('vehicles').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('nybil_inventering').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('checkins').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('salu_vehicle_state').select('regnr').eq('regnr', regnr).limit(1),
+  ]);
+
+  const failed = [vehicle, nybil, checkin, salu].find((response) => response.error);
+  if (failed?.error) throw failed.error;
+  return [vehicle, nybil, checkin, salu].some((response) => (response.data?.length ?? 0) > 0);
+}
+
+async function appendPeriodEvent(
+  admin: ReturnType<typeof createAdminClient>,
+  input: {
+    eventType: 'PERIOD_STARTED' | 'PERIOD_ENDED';
+    regnr: string;
+    periodId: string;
+    occurredAt: string;
+    actorId: string;
+    actorEmail: string;
+    payload: Record<string, unknown>;
+  },
+) {
+  const { data: event, error } = await admin
+    .from('vehicle_journey_events')
+    .insert({
+      regnr: input.regnr,
+      event_type: input.eventType,
+      event_key: `vehicle-period:${input.periodId}:${input.eventType}`,
+      occurred_at: input.occurredAt,
+      source_system: 'VAGNKORT',
+      source_entity: 'vehicle_journey_periods',
+      source_record_id: input.periodId,
+      actor_id: input.actorId,
+      actor_source: 'MANUELL',
+      actor_email: input.actorEmail,
+      payload: input.payload,
+    })
+    .select('event_id')
+    .single();
+
+  if (error || !event) {
+    console.error(`[vehicle-journey-periods] Could not append ${input.eventType}:`, error);
+    return null;
+  }
+  return event.event_id as string;
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const action = typeof body.action === 'string' ? body.action.trim().toUpperCase() : '';
+  const regnr = cleanRegnr(body.regnr);
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-journey-periods] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Vehicle journey unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    if (action === 'START') {
+      const periodType = cleanPeriodType(body.periodType);
+      if (!periodType) {
+        return NextResponse.json({ error: 'Invalid period type' }, { status: 400 });
+      }
+
+      const startedAt = parseTimestamp(body.startedAt, true);
+      if (!startedAt) {
+        return NextResponse.json({ error: 'Invalid start time' }, { status: 400 });
+      }
+
+      const reasonCode = cleanReasonCode(body.reasonCode);
+      const reasonText = cleanReasonText(body.reasonText);
+      if (periodType === 'DOWNTIME') {
+        if (!reasonCode || !DOWNTIME_REASONS.includes(reasonCode as DowntimeReason)) {
+          return NextResponse.json({ error: 'Downtime requires a valid reason' }, { status: 400 });
+        }
+        if (reasonCode === 'OTHER' && !reasonText) {
+          return NextResponse.json({ error: 'Other downtime requires a comment' }, { status: 400 });
+        }
+      }
+
+      const { data: existingOpen, error: existingError } = await admin
+        .from('vehicle_journey_periods')
+        .select('period_id')
+        .eq('regnr', regnr)
+        .eq('period_type', periodType)
+        .is('ended_at', null)
+        .limit(1);
+      if (existingError) throw existingError;
+      if ((existingOpen?.length ?? 0) > 0) {
+        return NextResponse.json({ error: `${periodType} is already open for vehicle` }, { status: 409 });
+      }
+
+      const periodId = crypto.randomUUID();
+      const { data: period, error: periodError } = await admin
+        .from('vehicle_journey_periods')
+        .insert({
+          period_id: periodId,
+          regnr,
+          period_type: periodType,
+          started_at: startedAt,
+          reason_code: reasonCode,
+          reason_text: reasonText,
+          source_system: 'VAGNKORT',
+          source_entity: 'vehicle_journey_periods',
+          source_record_id: periodId,
+          metadata: { createdVia: 'VAGNKORT' },
+          created_by: verification.user.id,
+        })
+        .select('period_id,period_type,started_at,ended_at,reason_code,reason_text,source_system,source_event_id,metadata,created_at,updated_at')
+        .single();
+
+      if (periodError || !period) {
+        console.error('[vehicle-journey-periods] Could not create period:', periodError);
+        return NextResponse.json({ error: 'Could not start period' }, { status: 500 });
+      }
+
+      const sourceEventId = await appendPeriodEvent(admin, {
+        eventType: 'PERIOD_STARTED',
+        regnr,
+        periodId,
+        occurredAt: startedAt,
+        actorId: verification.user.id,
+        actorEmail: verification.user.email,
+        payload: {
+          periodType,
+          startedAt,
+          reasonCode,
+          reasonText,
+        },
+      });
+
+      if (sourceEventId) {
+        const { error: linkError } = await admin
+          .from('vehicle_journey_periods')
+          .update({ source_event_id: sourceEventId, updated_at: new Date().toISOString() })
+          .eq('period_id', periodId);
+        if (linkError) console.error('[vehicle-journey-periods] Could not link start event:', linkError);
+      }
+
+      return NextResponse.json({ data: { ...period, source_event_id: sourceEventId } }, { status: 201 });
+    }
+
+    if (action === 'CLOSE') {
+      const periodId = typeof body.periodId === 'string' && UUID_RE.test(body.periodId.trim())
+        ? body.periodId.trim()
+        : null;
+      if (!periodId) {
+        return NextResponse.json({ error: 'Invalid period id' }, { status: 400 });
+      }
+
+      const endedAt = parseTimestamp(body.endedAt, true);
+      if (!endedAt) {
+        return NextResponse.json({ error: 'Invalid end time' }, { status: 400 });
+      }
+
+      const { data: current, error: currentError } = await admin
+        .from('vehicle_journey_periods')
+        .select('period_id,period_type,started_at,ended_at,reason_code,reason_text,source_event_id')
+        .eq('period_id', periodId)
+        .eq('regnr', regnr)
+        .maybeSingle();
+      if (currentError) throw currentError;
+      if (!current) {
+        return NextResponse.json({ error: 'Period not found for vehicle' }, { status: 404 });
+      }
+      if (current.ended_at) {
+        return NextResponse.json({ error: 'Period is already closed' }, { status: 409 });
+      }
+      if (new Date(endedAt).getTime() < new Date(current.started_at).getTime()) {
+        return NextResponse.json({ error: 'End time cannot be before start time' }, { status: 400 });
+      }
+
+      const updatedAt = new Date().toISOString();
+      const { data: period, error: updateError } = await admin
+        .from('vehicle_journey_periods')
+        .update({ ended_at: endedAt, updated_at: updatedAt })
+        .eq('period_id', periodId)
+        .eq('regnr', regnr)
+        .is('ended_at', null)
+        .select('period_id,period_type,started_at,ended_at,reason_code,reason_text,source_system,source_event_id,metadata,created_at,updated_at')
+        .maybeSingle();
+
+      if (updateError) throw updateError;
+      if (!period) {
+        return NextResponse.json({ error: 'Period changed before it could be closed' }, { status: 409 });
+      }
+
+      const durationHours = Math.round(
+        ((new Date(endedAt).getTime() - new Date(current.started_at).getTime()) / 3_600_000) * 10,
+      ) / 10;
+
+      await appendPeriodEvent(admin, {
+        eventType: 'PERIOD_ENDED',
+        regnr,
+        periodId,
+        occurredAt: endedAt,
+        actorId: verification.user.id,
+        actorEmail: verification.user.email,
+        payload: {
+          periodType: current.period_type,
+          startedAt: current.started_at,
+          endedAt,
+          durationHours,
+          reasonCode: current.reason_code,
+          reasonText: current.reason_text,
+        },
+      });
+
+      return NextResponse.json({ data: { ...period, durationHours } });
+    }
+
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+  } catch (error) {
+    console.error('[vehicle-journey-periods] Unexpected error:', error);
+    return NextResponse.json({ error: 'Period operation failed' }, { status: 500 });
+  }
+}

--- a/app/vagnkort/journey-period-controls.tsx
+++ b/app/vagnkort/journey-period-controls.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { FormEvent, useMemo, useState } from 'react';
+
+type JourneyPeriod = {
+  period_id: string;
+  period_type: string;
+  started_at: string;
+  ended_at: string | null;
+  reason_code: string | null;
+  reason_text: string | null;
+  durationHours: number | null;
+};
+
+type Props = {
+  regnr: string;
+  openPeriods: JourneyPeriod[];
+  onChanged: () => void;
+};
+
+const PERIOD_TYPES = [
+  ['AVAILABLE', 'Tillgänglig'],
+  ['RENTAL', 'Uthyrd'],
+  ['DOWNTIME', 'Stillestånd'],
+  ['WORKSHOP', 'Verkstad'],
+  ['TRANSPORT', 'Transport'],
+  ['PREPARATION', 'Förberedelse'],
+  ['SALU', 'SALU'],
+  ['OTHER', 'Övrigt'],
+] as const;
+
+const DOWNTIME_REASONS = [
+  ['DAMAGE', 'Skada'],
+  ['WORKSHOP', 'Verkstad'],
+  ['SERVICE', 'Service'],
+  ['WAITING_PARTS', 'Väntar reservdelar'],
+  ['MISSING_EQUIPMENT', 'Saknad utrustning'],
+  ['TRANSPORT', 'Transport'],
+  ['ADMINISTRATION', 'Administration'],
+  ['OTHER', 'Övrigt'],
+] as const;
+
+function localDateTimeValue(date = new Date()) {
+  const shifted = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return shifted.toISOString().slice(0, 16);
+}
+
+export default function JourneyPeriodControls({ regnr, openPeriods, onChanged }: Props) {
+  const [periodType, setPeriodType] = useState('RENTAL');
+  const [startedAt, setStartedAt] = useState(localDateTimeValue);
+  const [reasonCode, setReasonCode] = useState('DAMAGE');
+  const [reasonText, setReasonText] = useState('');
+  const [busy, setBusy] = useState<string | null>(null);
+  const [message, setMessage] = useState('');
+
+  const openByType = useMemo(
+    () => new Map(openPeriods.map((period) => [period.period_type, period])),
+    [openPeriods],
+  );
+
+  async function startPeriod(event: FormEvent) {
+    event.preventDefault();
+    setBusy('start');
+    setMessage('');
+    try {
+      const response = await fetch('/api/vehicle-journey/periods', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'START',
+          regnr,
+          periodType,
+          startedAt: new Date(startedAt).toISOString(),
+          reasonCode: periodType === 'DOWNTIME' ? reasonCode : null,
+          reasonText: periodType === 'DOWNTIME' ? reasonText.trim() || null : null,
+        }),
+      });
+      const body = await response.json() as { error?: string };
+      if (!response.ok) throw new Error(body.error || 'Kunde inte starta perioden');
+      setMessage('Perioden är startad.');
+      setStartedAt(localDateTimeValue());
+      setReasonText('');
+      onChanged();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Kunde inte starta perioden.');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function closePeriod(period: JourneyPeriod) {
+    setBusy(period.period_id);
+    setMessage('');
+    try {
+      const response = await fetch('/api/vehicle-journey/periods', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'CLOSE',
+          regnr,
+          periodId: period.period_id,
+          endedAt: new Date().toISOString(),
+        }),
+      });
+      const body = await response.json() as { error?: string };
+      if (!response.ok) throw new Error(body.error || 'Kunde inte avsluta perioden');
+      setMessage('Perioden är avslutad.');
+      onChanged();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Kunde inte avsluta perioden.');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: '.9rem' }}>
+      {openPeriods.length > 0 && (
+        <div style={{ display: 'grid', gap: '.45rem' }}>
+          <strong>Pågående perioder</strong>
+          {openPeriods.map((period) => (
+            <div key={period.period_id} style={{ display: 'flex', justifyContent: 'space-between', gap: '.75rem', alignItems: 'center', borderTop: '1px solid #eee', paddingTop: '.5rem' }}>
+              <div>
+                <div><strong>{period.period_type}</strong></div>
+                <div style={{ fontSize: 13, color: '#666' }}>{new Date(period.started_at).toLocaleString('sv-SE')}{period.reason_text ? ` · ${period.reason_text}` : period.reason_code ? ` · ${period.reason_code}` : ''}</div>
+              </div>
+              <button type="button" onClick={() => void closePeriod(period)} disabled={Boolean(busy)} style={{ border: 0, borderRadius: 8, background: '#111', color: '#fff', padding: '.55rem .75rem', fontWeight: 700 }}>
+                {busy === period.period_id ? 'Avslutar…' : 'Avsluta nu'}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <form onSubmit={startPeriod} style={{ display: 'grid', gap: '.65rem' }}>
+        <strong>Starta ny period</strong>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '.6rem' }}>
+          <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+            Typ
+            <select value={periodType} onChange={(event) => setPeriodType(event.target.value)} disabled={Boolean(busy)} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
+              {PERIOD_TYPES.map(([value, label]) => (
+                <option key={value} value={value} disabled={openByType.has(value)}>{label}{openByType.has(value) ? ' · pågår' : ''}</option>
+              ))}
+            </select>
+          </label>
+          <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+            Starttid
+            <input type="datetime-local" value={startedAt} onChange={(event) => setStartedAt(event.target.value)} disabled={Boolean(busy)} required style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
+          </label>
+        </div>
+
+        {periodType === 'DOWNTIME' && (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '.6rem' }}>
+            <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+              Orsak
+              <select value={reasonCode} onChange={(event) => setReasonCode(event.target.value)} disabled={Boolean(busy)} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
+                {DOWNTIME_REASONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              </select>
+            </label>
+            <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+              Kommentar {reasonCode === 'OTHER' ? '(krävs)' : '(valfri)'}
+              <input value={reasonText} onChange={(event) => setReasonText(event.target.value)} required={reasonCode === 'OTHER'} disabled={Boolean(busy)} placeholder="T.ex. väntar delar från leverantör" style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
+            </label>
+          </div>
+        )}
+
+        <button type="submit" disabled={Boolean(busy) || openByType.has(periodType)} style={{ justifySelf: 'start', border: 0, borderRadius: 8, background: '#111', color: '#fff', padding: '.65rem 1rem', fontWeight: 700 }}>
+          {busy === 'start' ? 'Startar…' : 'Starta period'}
+        </button>
+      </form>
+
+      {message && <div style={{ fontSize: 13, color: message.includes('Kunde') || message.includes('Invalid') || message.includes('already') ? '#a00' : '#176b2c' }}>{message}</div>}
+    </div>
+  );
+}

--- a/app/vagnkort/vagnkort-client.tsx
+++ b/app/vagnkort/vagnkort-client.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import DocumentUpload from './document-upload';
+import JourneyPeriodControls from './journey-period-controls';
 
 type JourneyPeriod = {
   period_id: string;
@@ -243,7 +244,10 @@ export default function VagnkortClient() {
             <div style={grid}>
               <section style={card}>
                 <h2 style={{ marginTop: 0 }}>Tid i resan</h2>
-                {Object.keys(data.journey.totalHoursByType).length === 0 ? <p>Inga perioder registrerade ännu.</p> : Object.entries(data.journey.totalHoursByType).map(([type, total]) => <div key={type} style={{ display: 'flex', justifyContent: 'space-between', padding: '.45rem 0', borderBottom: '1px solid #eee' }}><span>{type}</span><strong>{hours(total)}</strong></div>)}
+                <JourneyPeriodControls regnr={data.regnr} openPeriods={data.journey.openPeriods} onChanged={() => setRefreshNonce((value) => value + 1)} />
+                <div style={{ marginTop: '1rem' }}>
+                  {Object.keys(data.journey.totalHoursByType).length === 0 ? <p>Inga avslutade perioder ännu.</p> : Object.entries(data.journey.totalHoursByType).map(([type, total]) => <div key={type} style={{ display: 'flex', justifyContent: 'space-between', padding: '.45rem 0', borderBottom: '1px solid #eee' }}><span>{type}</span><strong>{hours(total)}</strong></div>)}
+                </div>
               </section>
               <section style={card}>
                 <h2 style={{ marginTop: 0 }}>SALU</h2>

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -8,6 +8,8 @@ const client = readFileSync(join(process.cwd(), 'app/vagnkort/vagnkort-client.ts
 const upload = readFileSync(join(process.cwd(), 'app/vagnkort/document-upload.tsx'), 'utf8');
 const uploadApi = readFileSync(join(process.cwd(), 'app/api/vehicle-documents/route.ts'), 'utf8');
 const documentApi = readFileSync(join(process.cwd(), 'app/api/vehicle-documents/[id]/route.ts'), 'utf8');
+const periodControls = readFileSync(join(process.cwd(), 'app/vagnkort/journey-period-controls.tsx'), 'utf8');
+const periodApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/periods/route.ts'), 'utf8');
 const home = readFileSync(join(process.cwd(), 'app/page.tsx'), 'utf8');
 
 test('Vagnkort page stays behind the existing LoginGate', () => {
@@ -63,6 +65,30 @@ test('document server API verifies identity, keeps private storage server contro
   assert.match(documentApi, /verifyApiUser\(request\)/);
   assert.match(documentApi, /createSignedUrl/);
   assert.match(documentApi, /300/);
+});
+
+test('Vagnkort can start and close vehicle journey periods', () => {
+  assert.match(client, /<JourneyPeriodControls regnr=/);
+  assert.match(periodControls, /Tillgänglig/);
+  assert.match(periodControls, /Uthyrd/);
+  assert.match(periodControls, /Stillestånd/);
+  assert.match(periodControls, /Verkstad/);
+  assert.match(periodControls, /Väntar reservdelar/);
+  assert.match(periodControls, /action:\s*'START'/);
+  assert.match(periodControls, /action:\s*'CLOSE'/);
+  assert.match(periodControls, /\/api\/vehicle-journey\/periods/);
+});
+
+test('journey period API validates vehicle, downtime reason and appends timeline events', () => {
+  assert.match(periodApi, /verifyApiUser\(request\)/);
+  assert.match(periodApi, /vehicleExists/);
+  assert.match(periodApi, /DOWNTIME_REASONS/);
+  assert.match(periodApi, /Downtime requires a valid reason/);
+  assert.match(periodApi, /PERIOD_STARTED/);
+  assert.match(periodApi, /PERIOD_ENDED/);
+  assert.match(periodApi, /vehicle_journey_periods/);
+  assert.match(periodApi, /vehicle_journey_events/);
+  assert.match(periodApi, /created_by:\s*verification\.user\.id/);
 });
 
 test('start page links to Vagnkort', () => {


### PR DESCRIPTION
## Sammanfattning
- lägger till server-API för att starta och avsluta perioder i `vehicle_journey_periods`
- stöd för Tillgänglig, Uthyrd, Stillestånd, Verkstad, Transport, Förberedelse, SALU och Övrigt
- Stillestånd kräver strukturerad orsak; `OTHER` kräver kommentar
- skapar append-only `PERIOD_STARTED` och `PERIOD_ENDED` i `vehicle_journey_events`
- Vagnkortet får kontroller för att starta/avsluta perioder och visar pågående perioder

## Säkerhet
- alla writes går via autentiserad server-route och service role
- browser får inga nya grants till `vehicle_journey_periods`
- vald bil verifieras mot befintliga fordonskällor
- ingen schemaändring i Production

## Test
- utökat Vagnkort-kontraktstest för periodflöde, orsaker och händelselogg
- Production-tabellen är fortsatt server-only med RLS och saknar idag riktiga periodrader, så ingen historik påverkas av ändringen.