### PR TITLE
Vagnkort: dokumentera utrustningsförändringar

### DIFF
--- a/app/api/vehicle-journey/equipment/route.ts
+++ b/app/api/vehicle-journey/equipment/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+
+const EQUIPMENT_FIELDS = [
+  'keys',
+  'chargingCables',
+  'privacyCovers',
+  'instructionBook',
+  'coc',
+  'wheelLocks',
+  'towbar',
+  'rubberMats',
+  'tireCompressor',
+  'mountedWheels',
+  'looseWheels',
+] as const;
+
+type EquipmentField = (typeof EQUIPMENT_FIELDS)[number];
+
+type EquipmentValue = string | number | boolean | null;
+
+function cleanRegnr(value: unknown): string {
+  return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
+}
+
+function cleanField(value: unknown): EquipmentField | null {
+  return typeof value === 'string' && EQUIPMENT_FIELDS.includes(value as EquipmentField)
+    ? value as EquipmentField
+    : null;
+}
+
+function cleanComment(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  return value.trim().slice(0, 500);
+}
+
+function cleanValue(field: EquipmentField, value: unknown): EquipmentValue | undefined {
+  if (value === null) return null;
+
+  if (field === 'keys' || field === 'chargingCables' || field === 'privacyCovers') {
+    const numberValue = typeof value === 'number' ? value : Number(value);
+    if (!Number.isInteger(numberValue) || numberValue < 0 || numberValue > 20) return undefined;
+    return numberValue;
+  }
+
+  if (
+    field === 'instructionBook' ||
+    field === 'coc' ||
+    field === 'wheelLocks' ||
+    field === 'towbar' ||
+    field === 'rubberMats' ||
+    field === 'tireCompressor'
+  ) {
+    if (typeof value === 'boolean') return value;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return undefined;
+  }
+
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim().slice(0, 120);
+  return normalized || null;
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr: string) {
+  const [vehicle, nybil, checkin, salu] = await Promise.all([
+    admin.from('vehicles').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('nybil_inventering').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('checkins').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('salu_vehicle_state').select('regnr').eq('regnr', regnr).limit(1),
+  ]);
+
+  const failed = [vehicle, nybil, checkin, salu].find((response) => response.error);
+  if (failed?.error) throw failed.error;
+  return [vehicle, nybil, checkin, salu].some((response) => (response.data?.length ?? 0) > 0);
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const regnr = cleanRegnr(body.regnr);
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  const field = cleanField(body.field);
+  if (!field) {
+    return NextResponse.json({ error: 'Invalid equipment field' }, { status: 400 });
+  }
+
+  const value = cleanValue(field, body.value);
+  if (value === undefined) {
+    return NextResponse.json({ error: 'Invalid equipment value' }, { status: 400 });
+  }
+
+  const comment = cleanComment(body.comment);
+  if (!comment) {
+    return NextResponse.json({ error: 'Equipment change requires a comment' }, { status: 400 });
+  }
+
+  const occurredAtInput = typeof body.occurredAt === 'string' && body.occurredAt.trim()
+    ? new Date(body.occurredAt)
+    : new Date();
+  if (Number.isNaN(occurredAtInput.getTime())) {
+    return NextResponse.json({ error: 'Invalid occurrence time' }, { status: 400 });
+  }
+  const occurredAt = occurredAtInput.toISOString();
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-equipment] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Vehicle journey unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    const eventId = crypto.randomUUID();
+    const { data: event, error } = await admin
+      .from('vehicle_journey_events')
+      .insert({
+        event_id: eventId,
+        regnr,
+        event_type: 'EQUIPMENT_CHANGED',
+        event_key: `equipment-change:${eventId}`,
+        occurred_at: occurredAt,
+        source_system: 'VAGNKORT',
+        source_entity: 'vehicle_equipment',
+        source_record_id: eventId,
+        actor_id: verification.user.id,
+        actor_source: 'MANUELL',
+        actor_email: verification.user.email,
+        payload: {
+          field,
+          value,
+          comment,
+        },
+      })
+      .select('event_id,event_type,occurred_at,actor_id,actor_email,payload')
+      .single();
+
+    if (error || !event) {
+      console.error('[vehicle-equipment] Could not append equipment event:', error);
+      return NextResponse.json({ error: 'Could not register equipment change' }, { status: 500 });
+    }
+
+    return NextResponse.json({ data: event }, { status: 201 });
+  } catch (error) {
+    console.error('[vehicle-equipment] Unexpected error:', error);
+    return NextResponse.json({ error: 'Equipment change failed' }, { status: 500 });
+  }
+}

--- a/app/api/vehicle-journey/route.ts
+++ b/app/api/vehicle-journey/route.ts
@@ -5,6 +5,22 @@ import { verifyApiUser } from '@/lib/server-auth';
 const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
 const HOUR_MS = 60 * 60 * 1000;
 
+const EQUIPMENT_FIELDS = [
+  'keys',
+  'chargingCables',
+  'privacyCovers',
+  'instructionBook',
+  'coc',
+  'wheelLocks',
+  'towbar',
+  'rubberMats',
+  'tireCompressor',
+  'mountedWheels',
+  'looseWheels',
+] as const;
+
+type EquipmentField = (typeof EQUIPMENT_FIELDS)[number];
+type EquipmentValue = string | number | boolean | null;
 type QueryError = { message?: string } | null;
 
 function cleanRegnr(value: string): string {
@@ -39,6 +55,28 @@ function firstError(errors: Array<[string, QueryError]>): string | null {
     }
   }
   return null;
+}
+
+function equipmentChangeFromEvent(event: { event_id: string; occurred_at: string; actor_name: string | null; actor_email: string | null; payload: unknown }) {
+  if (!event.payload || typeof event.payload !== 'object' || Array.isArray(event.payload)) return null;
+  const payload = event.payload as Record<string, unknown>;
+  const field = typeof payload.field === 'string' && EQUIPMENT_FIELDS.includes(payload.field as EquipmentField)
+    ? payload.field as EquipmentField
+    : null;
+  if (!field) return null;
+
+  const value = payload.value;
+  if (value !== null && typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') return null;
+
+  return {
+    eventId: event.event_id,
+    field,
+    value: value as EquipmentValue,
+    comment: typeof payload.comment === 'string' ? payload.comment : null,
+    occurredAt: event.occurred_at,
+    actorName: event.actor_name,
+    actorEmail: event.actor_email,
+  };
 }
 
 export async function GET(request: Request) {
@@ -205,20 +243,31 @@ export async function GET(request: Request) {
       }
     : null;
 
-  const equipmentCurrent = vehicle
-    ? {
-        keys: vehicle.antal_nycklar,
-        chargingCables: vehicle.antal_laddkablar,
-        privacyCovers: vehicle.antal_insynsskydd,
-        instructionBookLocation: vehicle.instruktionsbok_location,
-        cocLocation: vehicle.coc_location,
-        rubberMats: vehicle.har_gummimattor,
-        tireCompressor: vehicle.har_kompressor,
-        mountedWheels: vehicle.hjul_pa_bilen,
-        hasWinterWheels: vehicle.har_vinterdack,
-        hasSummerWheels: vehicle.har_sommarhjul,
-      }
-    : null;
+  const equipmentCurrent: Record<EquipmentField, EquipmentValue> = {
+    keys: vehicle?.antal_nycklar ?? nybil?.antal_nycklar ?? null,
+    chargingCables: vehicle?.antal_laddkablar ?? nybil?.antal_laddkablar ?? null,
+    privacyCovers: vehicle?.antal_insynsskydd ?? nybil?.antal_insynsskydd ?? null,
+    instructionBook: vehicle?.instruktionsbok_location ? true : (nybil?.instruktionsbok ?? null),
+    coc: vehicle?.coc_location ? true : (nybil?.coc ?? null),
+    wheelLocks: nybil?.lasbultar_med ?? null,
+    towbar: nybil?.dragkrok ?? null,
+    rubberMats: vehicle?.har_gummimattor ?? nybil?.gummimattor ?? null,
+    tireCompressor: vehicle?.har_kompressor ?? nybil?.dackkompressor ?? null,
+    mountedWheels: vehicle?.hjul_pa_bilen ?? nybil?.hjultyp ?? null,
+    looseWheels: nybil?.hjul_ej_monterade ?? null,
+  };
+
+  const equipmentChanges = (eventsResponse.data ?? [])
+    .filter((event) => event.event_type === 'EQUIPMENT_CHANGED')
+    .map(equipmentChangeFromEvent)
+    .filter((change): change is NonNullable<ReturnType<typeof equipmentChangeFromEvent>> => change !== null);
+
+  const fieldsOverlaid = new Set<EquipmentField>();
+  for (const change of equipmentChanges) {
+    if (fieldsOverlaid.has(change.field)) continue;
+    equipmentCurrent[change.field] = change.value;
+    fieldsOverlaid.add(change.field);
+  }
 
   const documents = [
     ...(documentsResponse.data ?? []).map((document) => ({
@@ -281,6 +330,7 @@ export async function GET(request: Request) {
       equipment: {
         baseline: equipmentBaseline,
         current: equipmentCurrent,
+        changes: equipmentChanges,
       },
       damages: damagesResponse.data ?? [],
       journey: {

--- a/app/vagnkort/equipment-change-controls.tsx
+++ b/app/vagnkort/equipment-change-controls.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { FormEvent, useMemo, useState } from 'react';
+
+type EquipmentState = {
+  keys?: number | null;
+  chargingCables?: number | null;
+  privacyCovers?: number | null;
+  instructionBook?: boolean | null;
+  coc?: boolean | null;
+  wheelLocks?: boolean | null;
+  towbar?: boolean | null;
+  rubberMats?: boolean | null;
+  tireCompressor?: boolean | null;
+  mountedWheels?: string | null;
+  looseWheels?: string | null;
+};
+
+type Props = {
+  regnr: string;
+  current: EquipmentState | null;
+  onChanged: () => void;
+};
+
+type FieldName = keyof EquipmentState;
+
+type FieldDefinition = {
+  field: FieldName;
+  label: string;
+  kind: 'number' | 'boolean' | 'text';
+};
+
+const fields: FieldDefinition[] = [
+  { field: 'keys', label: 'Nycklar', kind: 'number' },
+  { field: 'chargingCables', label: 'Laddkablar', kind: 'number' },
+  { field: 'privacyCovers', label: 'Insynsskydd / hatthylla', kind: 'number' },
+  { field: 'instructionBook', label: 'Instruktionsbok', kind: 'boolean' },
+  { field: 'coc', label: 'COC', kind: 'boolean' },
+  { field: 'wheelLocks', label: 'Låsbultar', kind: 'boolean' },
+  { field: 'towbar', label: 'Dragkrok', kind: 'boolean' },
+  { field: 'rubberMats', label: 'Gummimattor', kind: 'boolean' },
+  { field: 'tireCompressor', label: 'Däckkompressor', kind: 'boolean' },
+  { field: 'mountedWheels', label: 'Monterade hjul', kind: 'text' },
+  { field: 'looseWheels', label: 'Lösa hjul', kind: 'text' },
+];
+
+function present(value: unknown) {
+  if (value === null || value === undefined || value === '') return '—';
+  if (typeof value === 'boolean') return value ? 'Ja' : 'Nej';
+  return String(value);
+}
+
+export default function EquipmentChangeControls({ regnr, current, onChanged }: Props) {
+  const [field, setField] = useState<FieldName>('keys');
+  const [rawValue, setRawValue] = useState('');
+  const [comment, setComment] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const definition = useMemo(() => fields.find((item) => item.field === field) ?? fields[0], [field]);
+  const currentValue = current?.[field];
+
+  function parseValue() {
+    if (definition.kind === 'number') return Number(rawValue);
+    if (definition.kind === 'boolean') return rawValue === 'true';
+    return rawValue.trim();
+  }
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    setError('');
+
+    if (!comment.trim()) {
+      setError('Kommentar krävs för att dokumentera förändringen.');
+      return;
+    }
+    if (definition.kind !== 'boolean' && !rawValue.trim()) {
+      setError('Ange det nya värdet.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const response = await fetch('/api/vehicle-journey/equipment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          regnr,
+          field,
+          value: parseValue(),
+          comment: comment.trim(),
+        }),
+      });
+      const body = await response.json() as { error?: string };
+      if (!response.ok) throw new Error(body.error || 'Kunde inte registrera förändringen');
+
+      setRawValue('');
+      setComment('');
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Kunde inte registrera förändringen');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} style={{ borderTop: '1px solid #e5e5e5', marginTop: '1rem', paddingTop: '1rem' }}>
+      <div style={{ fontWeight: 700, marginBottom: '.65rem' }}>Dokumentera utrustningsförändring</div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '.6rem' }}>
+        <label>
+          <div style={{ fontSize: 12, color: '#666', marginBottom: '.25rem' }}>Attribut</div>
+          <select
+            value={field}
+            onChange={(event) => {
+              const next = event.target.value as FieldName;
+              setField(next);
+              setRawValue('');
+            }}
+            style={{ width: '100%', padding: '.65rem', borderRadius: 7, border: '1px solid #bbb' }}
+          >
+            {fields.map((item) => <option key={item.field} value={item.field}>{item.label}</option>)}
+          </select>
+        </label>
+
+        <label>
+          <div style={{ fontSize: 12, color: '#666', marginBottom: '.25rem' }}>Nu registrerat: {present(currentValue)}</div>
+          {definition.kind === 'boolean' ? (
+            <select value={rawValue} onChange={(event) => setRawValue(event.target.value)} required style={{ width: '100%', padding: '.65rem', borderRadius: 7, border: '1px solid #bbb' }}>
+              <option value="">Välj nytt värde</option>
+              <option value="true">Ja</option>
+              <option value="false">Nej</option>
+            </select>
+          ) : (
+            <input
+              type={definition.kind === 'number' ? 'number' : 'text'}
+              min={definition.kind === 'number' ? 0 : undefined}
+              max={definition.kind === 'number' ? 20 : undefined}
+              value={rawValue}
+              onChange={(event) => setRawValue(event.target.value)}
+              placeholder="Nytt värde"
+              required
+              style={{ width: '100%', boxSizing: 'border-box', padding: '.65rem', borderRadius: 7, border: '1px solid #bbb' }}
+            />
+          )}
+        </label>
+      </div>
+
+      <textarea
+        value={comment}
+        onChange={(event) => setComment(event.target.value)}
+        placeholder="Vad har ändrats och varför?"
+        maxLength={500}
+        required
+        rows={2}
+        style={{ width: '100%', boxSizing: 'border-box', marginTop: '.6rem', padding: '.65rem', borderRadius: 7, border: '1px solid #bbb', resize: 'vertical' }}
+      />
+
+      {error && <div style={{ color: '#a00', fontSize: 13, marginTop: '.45rem' }}>{error}</div>}
+      <button type="submit" disabled={saving} style={{ marginTop: '.6rem', border: 0, borderRadius: 7, background: '#111', color: '#fff', padding: '.65rem .9rem', fontWeight: 700, cursor: 'pointer' }}>
+        {saving ? 'Sparar…' : 'Registrera förändring'}
+      </button>
+    </form>
+  );
+}

--- a/app/vagnkort/vagnkort-client.tsx
+++ b/app/vagnkort/vagnkort-client.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import DocumentUpload from './document-upload';
+import EquipmentChangeControls from './equipment-change-controls';
 import JourneyPeriodControls from './journey-period-controls';
 
 type JourneyPeriod = {
@@ -55,11 +56,21 @@ type EquipmentState = {
   looseWheels?: string | null;
 };
 
+type EquipmentChange = {
+  eventId: string;
+  field: keyof EquipmentState;
+  value: string | number | boolean | null;
+  comment: string | null;
+  occurredAt: string;
+  actorName: string | null;
+  actorEmail: string | null;
+};
+
 type JourneyResponse = {
   found: boolean;
   regnr: string;
   identity: { brand: string | null; model: string | null };
-  equipment: { baseline: EquipmentState | null; current: EquipmentState | null };
+  equipment: { baseline: EquipmentState | null; current: EquipmentState | null; changes: EquipmentChange[] };
   damages: Damage[];
   journey: {
     events: JourneyEvent[];
@@ -127,6 +138,10 @@ function present(value: unknown) {
   if (value === null || value === undefined || value === '') return '—';
   if (typeof value === 'boolean') return value ? 'Ja' : 'Nej';
   return String(value);
+}
+
+function equipmentLabel(field: keyof EquipmentState) {
+  return equipmentRows.find(([key]) => key === field)?.[1] ?? String(field);
 }
 
 export default function VagnkortClient() {
@@ -262,6 +277,21 @@ export default function VagnkortClient() {
             <section style={card}>
               <h2 style={{ marginTop: 0 }}>Utrustning – Nybil mot nu</h2>
               {!equipmentDiffs.length ? <p>Jämförelseunderlag saknas.</p> : <div style={{ overflowX: 'auto' }}><table style={{ width: '100%', borderCollapse: 'collapse' }}><thead><tr><th style={{ textAlign: 'left', padding: '.5rem' }}>Attribut</th><th style={{ textAlign: 'left', padding: '.5rem' }}>Nybil</th><th style={{ textAlign: 'left', padding: '.5rem' }}>Nu</th><th style={{ textAlign: 'left', padding: '.5rem' }}>Status</th></tr></thead><tbody>{equipmentDiffs.map((row) => <tr key={String(row.key)} style={{ background: row.changed ? '#fff2db' : undefined }}><td style={{ padding: '.55rem', borderTop: '1px solid #eee' }}>{row.label}</td><td style={{ padding: '.55rem', borderTop: '1px solid #eee' }}>{present(row.baseline)}</td><td style={{ padding: '.55rem', borderTop: '1px solid #eee' }}>{present(row.current)}</td><td style={{ padding: '.55rem', borderTop: '1px solid #eee', fontWeight: row.changed ? 700 : 400 }}>{row.changed ? 'Förändrat' : 'Oförändrat'}</td></tr>)}</tbody></table></div>}
+
+              <EquipmentChangeControls regnr={data.regnr} current={data.equipment.current} onChanged={() => setRefreshNonce((value) => value + 1)} />
+
+              {data.equipment.changes.length > 0 && (
+                <div style={{ marginTop: '1rem' }}>
+                  <div style={{ fontWeight: 700, marginBottom: '.35rem' }}>Senaste dokumenterade förändringar</div>
+                  {data.equipment.changes.slice(0, 8).map((change) => (
+                    <div key={change.eventId} style={{ padding: '.5rem 0', borderTop: '1px solid #eee' }}>
+                      <strong>{equipmentLabel(change.field)} → {present(change.value)}</strong>
+                      <div style={{ fontSize: 13, color: '#666' }}>{formatDate(change.occurredAt)}{change.actorName || change.actorEmail ? ` · ${change.actorName || change.actorEmail}` : ''}</div>
+                      {change.comment && <div>{change.comment}</div>}
+                    </div>
+                  ))}
+                </div>
+              )}
             </section>
 
             <div style={grid}>

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -10,6 +10,9 @@ const uploadApi = readFileSync(join(process.cwd(), 'app/api/vehicle-documents/ro
 const documentApi = readFileSync(join(process.cwd(), 'app/api/vehicle-documents/[id]/route.ts'), 'utf8');
 const periodControls = readFileSync(join(process.cwd(), 'app/vagnkort/journey-period-controls.tsx'), 'utf8');
 const periodApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/periods/route.ts'), 'utf8');
+const equipmentControls = readFileSync(join(process.cwd(), 'app/vagnkort/equipment-change-controls.tsx'), 'utf8');
+const equipmentApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/equipment/route.ts'), 'utf8');
+const journeyApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/route.ts'), 'utf8');
 const home = readFileSync(join(process.cwd(), 'app/page.tsx'), 'utf8');
 
 test('Vagnkort page stays behind the existing LoginGate', () => {
@@ -89,6 +92,27 @@ test('journey period API validates vehicle, downtime reason and appends timeline
   assert.match(periodApi, /vehicle_journey_periods/);
   assert.match(periodApi, /vehicle_journey_events/);
   assert.match(periodApi, /created_by:\s*verification\.user\.id/);
+});
+
+test('Vagnkort can document equipment changes as append-only journey events', () => {
+  assert.match(client, /<EquipmentChangeControls regnr=/);
+  assert.match(client, /Senaste dokumenterade förändringar/);
+  assert.match(equipmentControls, /Dokumentera utrustningsförändring/);
+  assert.match(equipmentControls, /Kommentar krävs/);
+  assert.match(equipmentControls, /\/api\/vehicle-journey\/equipment/);
+  assert.match(equipmentApi, /verifyApiUser\(request\)/);
+  assert.match(equipmentApi, /EQUIPMENT_CHANGED/);
+  assert.match(equipmentApi, /Equipment change requires a comment/);
+  assert.match(equipmentApi, /actor_id:\s*verification\.user\.id/);
+  assert.match(equipmentApi, /vehicle_journey_events/);
+});
+
+test('vehicle journey read model overlays latest equipment event without overwriting Nybil baseline', () => {
+  assert.match(journeyApi, /equipmentBaseline/);
+  assert.match(journeyApi, /equipmentChanges/);
+  assert.match(journeyApi, /fieldsOverlaid/);
+  assert.match(journeyApi, /equipmentCurrent\[change\.field\] = change\.value/);
+  assert.match(journeyApi, /event_type === 'EQUIPMENT_CHANGED'/);
 });
 
 test('start page links to Vagnkort', () => {


### PR DESCRIPTION
## Sammanfattning
- lägger till ett autentiserat server-API för utrustningsförändringar i bilens resa
- förändringar skrivs som append-only `EQUIPMENT_CHANGED` i `vehicle_journey_events`
- Nybil-baseline skrivs aldrig över
- read-modellen projicerar senaste dokumenterade förändring per attribut ovanpå aktuell fordonsdata
- Vagnkortet får formulär för nytt värde + obligatorisk kommentar och visar senaste förändringar

## Attribut
Nycklar, laddkablar, insynsskydd/hatthylla, instruktionsbok, COC, låsbultar, dragkrok, gummimattor, däckkompressor, monterade hjul och lösa hjul.

## Säkerhet
- alla writes går genom `verifyApiUser`
- `service_role` används endast server-side
- ingen ny browser-access eller RLS-policy
- ingen schemaändring i Production

## Test
- utökat Vagnkort-kontraktstest för append-only utrustningshändelser och read-model overlay
- Production har ännu inga `vehicle_journey_events`, så inga befintliga resedata förändras av denna release.