### PR TITLE
Vagnkort: livscykelmått för bilens resa

### DIFF
--- a/app/api/vehicle-journey/metrics/route.ts
+++ b/app/api/vehicle-journey/metrics/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+import { computeJourneyLifecycleMetrics } from '@/lib/vehicle-journey-metrics';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+
+type QueryError = { message?: string } | null;
+
+function cleanRegnr(value: string): string {
+  return value.toUpperCase().replace(/\s+/g, '');
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+function firstError(errors: Array<[string, QueryError]>): string | null {
+  for (const [label, error] of errors) {
+    if (error) {
+      console.error(`[vehicle-journey-metrics] ${label} query failed:`, error);
+      return label;
+    }
+  }
+  return null;
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const regnr = cleanRegnr(searchParams.get('reg') ?? searchParams.get('regnr') ?? '');
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-journey-metrics] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Vehicle journey unavailable' }, { status: 503 });
+  }
+
+  const [periodsResponse, nybilResponse, vehicleResponse, saluResponse] = await Promise.all([
+    admin
+      .from('vehicle_journey_periods')
+      .select('period_type,started_at,ended_at,reason_code')
+      .eq('regnr', regnr)
+      .order('started_at', { ascending: true }),
+    admin
+      .from('nybil_inventering')
+      .select('registreringsdatum,created_at,saludatum,saludatum_planerat,sold_date')
+      .eq('regnr', regnr)
+      .order('created_at', { ascending: false })
+      .limit(1),
+    admin
+      .from('vehicles')
+      .select('datum_ankomst_mabi,sold_date')
+      .eq('regnr', regnr)
+      .limit(1),
+    admin
+      .from('salu_vehicle_state')
+      .select('ny_date,current_saludatum,final_closed_at')
+      .eq('regnr', regnr)
+      .limit(1),
+  ]);
+
+  const failedSource = firstError([
+    ['periods', periodsResponse.error],
+    ['nybil', nybilResponse.error],
+    ['vehicle', vehicleResponse.error],
+    ['SALU', saluResponse.error],
+  ]);
+  if (failedSource) {
+    return NextResponse.json({ error: `Failed to load ${failedSource}` }, { status: 500 });
+  }
+
+  const nybil = nybilResponse.data?.[0] ?? null;
+  const vehicle = vehicleResponse.data?.[0] ?? null;
+  const salu = saluResponse.data?.[0] ?? null;
+
+  const lifecycleStartAt = salu?.ny_date
+    ?? nybil?.registreringsdatum
+    ?? vehicle?.datum_ankomst_mabi
+    ?? nybil?.created_at
+    ?? null;
+  const lifecycleEndAt = vehicle?.sold_date
+    ?? nybil?.sold_date
+    ?? salu?.final_closed_at
+    ?? null;
+  const saluAt = salu?.current_saludatum
+    ?? nybil?.saludatum
+    ?? nybil?.saludatum_planerat
+    ?? null;
+
+  const metrics = computeJourneyLifecycleMetrics({
+    periods: periodsResponse.data ?? [],
+    lifecycleStartAt,
+    lifecycleEndAt,
+    saluAt,
+  });
+
+  return NextResponse.json({
+    data: {
+      regnr,
+      metrics,
+      coverage: {
+        periodCount: periodsResponse.data?.length ?? 0,
+        hasLifecycleStart: Boolean(lifecycleStartAt),
+        hasLifecycleEnd: Boolean(lifecycleEndAt),
+        hasSaluDate: Boolean(saluAt),
+      },
+    },
+  });
+}

--- a/lib/vehicle-journey-metrics.ts
+++ b/lib/vehicle-journey-metrics.ts
@@ -1,0 +1,172 @@
+export type JourneyMetricPeriod = {
+  period_type: string;
+  started_at: string;
+  ended_at: string | null;
+  reason_code?: string | null;
+};
+
+export type JourneyLifecycleMetrics = {
+  lifecycleStartAt: string | null;
+  lifecycleEndAt: string | null;
+  lifecycleOngoing: boolean;
+  lifecycleHours: number | null;
+  rentalCount: number;
+  rentalHours: number;
+  downtimeHours: number;
+  workshopHours: number;
+  availableHours: number;
+  transportHours: number;
+  measuredOperationalHours: number;
+  utilizationPct: number | null;
+  overlappingOperationalPeriods: boolean;
+  downtimeHoursByReason: Record<string, number>;
+  firstRentalAt: string | null;
+  nybilToFirstRentalHours: number | null;
+  lastRentalReturnAt: string | null;
+  saluAt: string | null;
+  lastRentalToSaluHours: number | null;
+  betweenRentalGapCount: number;
+  averageHoursBetweenRentals: number | null;
+  longestHoursBetweenRentals: number | null;
+};
+
+type MetricInput = {
+  periods: JourneyMetricPeriod[];
+  lifecycleStartAt?: string | null;
+  lifecycleEndAt?: string | null;
+  saluAt?: string | null;
+  now?: string;
+};
+
+const OPERATIONAL_TYPES = new Set(['AVAILABLE', 'RENTAL', 'DOWNTIME', 'WORKSHOP', 'TRANSPORT']);
+
+function parseMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function roundHours(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function roundPct(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function hoursBetween(start: string | null | undefined, end: string | null | undefined): number | null {
+  const startMs = parseMs(start);
+  const endMs = parseMs(end);
+  if (startMs === null || endMs === null || endMs < startMs) return null;
+  return roundHours((endMs - startMs) / 3_600_000);
+}
+
+function effectivePeriod(period: JourneyMetricPeriod, nowMs: number) {
+  const startMs = parseMs(period.started_at);
+  const endMs = period.ended_at ? parseMs(period.ended_at) : nowMs;
+  if (startMs === null || endMs === null || endMs < startMs) return null;
+  return {
+    ...period,
+    startMs,
+    endMs,
+    hours: roundHours((endMs - startMs) / 3_600_000),
+  };
+}
+
+function hasOverlap(periods: Array<{ startMs: number; endMs: number }>): boolean {
+  const ordered = [...periods].sort((left, right) => left.startMs - right.startMs || left.endMs - right.endMs);
+  let latestEnd = -Infinity;
+  for (const period of ordered) {
+    if (period.startMs < latestEnd) return true;
+    latestEnd = Math.max(latestEnd, period.endMs);
+  }
+  return false;
+}
+
+export function computeJourneyLifecycleMetrics(input: MetricInput): JourneyLifecycleMetrics {
+  const now = input.now ?? new Date().toISOString();
+  const nowMs = parseMs(now) ?? Date.now();
+  const effective = input.periods
+    .map((period) => effectivePeriod(period, nowMs))
+    .filter((period): period is NonNullable<ReturnType<typeof effectivePeriod>> => period !== null);
+
+  const hoursByType = effective.reduce<Record<string, number>>((totals, period) => {
+    totals[period.period_type] = roundHours((totals[period.period_type] ?? 0) + period.hours);
+    return totals;
+  }, {});
+
+  const downtimeHoursByReason = effective
+    .filter((period) => period.period_type === 'DOWNTIME')
+    .reduce<Record<string, number>>((totals, period) => {
+      const reason = period.reason_code?.trim() || 'UNSPECIFIED';
+      totals[reason] = roundHours((totals[reason] ?? 0) + period.hours);
+      return totals;
+    }, {});
+
+  const rentals = effective
+    .filter((period) => period.period_type === 'RENTAL')
+    .sort((left, right) => left.startMs - right.startMs);
+
+  const rentalHours = hoursByType.RENTAL ?? 0;
+  const downtimeHours = hoursByType.DOWNTIME ?? 0;
+  const workshopHours = hoursByType.WORKSHOP ?? 0;
+  const availableHours = hoursByType.AVAILABLE ?? 0;
+  const transportHours = hoursByType.TRANSPORT ?? 0;
+  const measuredOperationalHours = roundHours(
+    rentalHours + downtimeHours + workshopHours + availableHours + transportHours,
+  );
+
+  const operationalPeriods = effective.filter((period) => OPERATIONAL_TYPES.has(period.period_type));
+  const overlappingOperationalPeriods = hasOverlap(operationalPeriods);
+  const utilizationPct = measuredOperationalHours > 0 && !overlappingOperationalPeriods
+    ? roundPct((rentalHours / measuredOperationalHours) * 100)
+    : null;
+
+  const firstRentalAt = rentals[0]?.started_at ?? null;
+  const closedRentalReturns = rentals
+    .filter((period) => period.ended_at)
+    .sort((left, right) => right.endMs - left.endMs);
+  const lastRentalReturnAt = closedRentalReturns[0]?.ended_at ?? null;
+
+  const rentalGaps: number[] = [];
+  for (let index = 0; index < rentals.length - 1; index += 1) {
+    const current = rentals[index];
+    const next = rentals[index + 1];
+    if (!current.ended_at || current.endMs > next.startMs) continue;
+    rentalGaps.push(roundHours((next.startMs - current.endMs) / 3_600_000));
+  }
+
+  const averageHoursBetweenRentals = rentalGaps.length > 0
+    ? roundHours(rentalGaps.reduce((total, gap) => total + gap, 0) / rentalGaps.length)
+    : null;
+  const longestHoursBetweenRentals = rentalGaps.length > 0 ? Math.max(...rentalGaps) : null;
+
+  const lifecycleStartAt = input.lifecycleStartAt ?? null;
+  const explicitLifecycleEndAt = input.lifecycleEndAt ?? null;
+  const lifecycleEndAt = explicitLifecycleEndAt ?? (lifecycleStartAt ? now : null);
+
+  return {
+    lifecycleStartAt,
+    lifecycleEndAt,
+    lifecycleOngoing: Boolean(lifecycleStartAt && !explicitLifecycleEndAt),
+    lifecycleHours: hoursBetween(lifecycleStartAt, lifecycleEndAt),
+    rentalCount: rentals.length,
+    rentalHours,
+    downtimeHours,
+    workshopHours,
+    availableHours,
+    transportHours,
+    measuredOperationalHours,
+    utilizationPct,
+    overlappingOperationalPeriods,
+    downtimeHoursByReason,
+    firstRentalAt,
+    nybilToFirstRentalHours: hoursBetween(lifecycleStartAt, firstRentalAt),
+    lastRentalReturnAt,
+    saluAt: input.saluAt ?? null,
+    lastRentalToSaluHours: hoursBetween(lastRentalReturnAt, input.saluAt),
+    betweenRentalGapCount: rentalGaps.length,
+    averageHoursBetweenRentals,
+    longestHoursBetweenRentals,
+  };
+}

--- a/tests/vehicle-journey-metrics.test.ts
+++ b/tests/vehicle-journey-metrics.test.ts
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { computeJourneyLifecycleMetrics } from '../lib/vehicle-journey-metrics';
+
+test('journey lifecycle metrics summarize rental, downtime and workshop time', () => {
+  const metrics = computeJourneyLifecycleMetrics({
+    now: '2026-01-10T00:00:00.000Z',
+    lifecycleStartAt: '2026-01-01T00:00:00.000Z',
+    lifecycleEndAt: '2026-01-10T00:00:00.000Z',
+    saluAt: '2026-01-09T00:00:00.000Z',
+    periods: [
+      { period_type: 'AVAILABLE', started_at: '2026-01-01T00:00:00.000Z', ended_at: '2026-01-02T00:00:00.000Z' },
+      { period_type: 'RENTAL', started_at: '2026-01-02T00:00:00.000Z', ended_at: '2026-01-04T00:00:00.000Z' },
+      { period_type: 'DOWNTIME', started_at: '2026-01-04T00:00:00.000Z', ended_at: '2026-01-05T00:00:00.000Z', reason_code: 'DAMAGE' },
+      { period_type: 'WORKSHOP', started_at: '2026-01-05T00:00:00.000Z', ended_at: '2026-01-06T00:00:00.000Z' },
+      { period_type: 'RENTAL', started_at: '2026-01-07T00:00:00.000Z', ended_at: '2026-01-08T00:00:00.000Z' },
+    ],
+  });
+
+  assert.equal(metrics.lifecycleHours, 216);
+  assert.equal(metrics.rentalCount, 2);
+  assert.equal(metrics.rentalHours, 72);
+  assert.equal(metrics.downtimeHours, 24);
+  assert.equal(metrics.workshopHours, 24);
+  assert.equal(metrics.availableHours, 24);
+  assert.equal(metrics.downtimeHoursByReason.DAMAGE, 24);
+  assert.equal(metrics.firstRentalAt, '2026-01-02T00:00:00.000Z');
+  assert.equal(metrics.nybilToFirstRentalHours, 24);
+  assert.equal(metrics.lastRentalReturnAt, '2026-01-08T00:00:00.000Z');
+  assert.equal(metrics.lastRentalToSaluHours, 24);
+  assert.equal(metrics.betweenRentalGapCount, 1);
+  assert.equal(metrics.averageHoursBetweenRentals, 72);
+  assert.equal(metrics.longestHoursBetweenRentals, 72);
+  assert.equal(metrics.overlappingOperationalPeriods, false);
+  assert.equal(metrics.utilizationPct, 50);
+});
+
+test('journey lifecycle metrics include an open period up to now', () => {
+  const metrics = computeJourneyLifecycleMetrics({
+    now: '2026-01-03T00:00:00.000Z',
+    lifecycleStartAt: '2026-01-01T00:00:00.000Z',
+    periods: [
+      { period_type: 'RENTAL', started_at: '2026-01-02T00:00:00.000Z', ended_at: null },
+    ],
+  });
+
+  assert.equal(metrics.lifecycleOngoing, true);
+  assert.equal(metrics.lifecycleHours, 48);
+  assert.equal(metrics.rentalHours, 24);
+  assert.equal(metrics.rentalCount, 1);
+});
+
+test('journey lifecycle metrics avoid misleading utilization when periods overlap', () => {
+  const metrics = computeJourneyLifecycleMetrics({
+    now: '2026-01-03T00:00:00.000Z',
+    periods: [
+      { period_type: 'RENTAL', started_at: '2026-01-01T00:00:00.000Z', ended_at: '2026-01-02T00:00:00.000Z' },
+      { period_type: 'DOWNTIME', started_at: '2026-01-01T12:00:00.000Z', ended_at: '2026-01-02T12:00:00.000Z', reason_code: 'WORKSHOP' },
+    ],
+  });
+
+  assert.equal(metrics.overlappingOperationalPeriods, true);
+  assert.equal(metrics.utilizationPct, null);
+});


### PR DESCRIPTION
## Sammanfattning
- lägger till ren beräkning av livscykelmått ovanpå `vehicle_journey_periods`
- nytt autentiserat server-API: `/api/vehicle-journey/metrics`
- summerar uthyrning, stillestånd, verkstad, tillgänglig och transport
- räknar antal uthyrningar, nyttjandegrad, tid Nybil→första uthyrning, sista retur→SALU och tid mellan uthyrningar
- summerar stillestånd per orsak
- öppna perioder räknas fram till nu
- nyttjandegrad returneras inte om operativa perioder överlappar, för att undvika missvisande KPI

## Säkerhet
- endast autentiserad server-route
- `service_role` stannar server-side
- ingen ny browser-grant, RLS-policy eller Production-schemaändring

## Test
- rena enhetstester för summering, öppna perioder och överlappande perioder
- inga Production-data skrivs eller migreras.