### PR TITLE
Vagnkort: visa livscykelmått i arbetsytan

### DIFF
--- a/app/vagnkort/journey-metrics-panel.tsx
+++ b/app/vagnkort/journey-metrics-panel.tsx
@@ -96,9 +96,12 @@ export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
       }
     };
 
-    setLoading(true);
-    setError('');
-    void load();
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setLoading(true);
+      setError('');
+      void load();
+    });
 
     return () => { cancelled = true; };
   }, [regnr, refreshNonce]);

--- a/app/vagnkort/journey-metrics-panel.tsx
+++ b/app/vagnkort/journey-metrics-panel.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type JourneyMetrics = {
+  lifecycleStartAt: string | null;
+  lifecycleEndAt: string | null;
+  lifecycleOngoing: boolean;
+  lifecycleHours: number | null;
+  rentalCount: number;
+  rentalHours: number;
+  downtimeHours: number;
+  workshopHours: number;
+  availableHours: number;
+  transportHours: number;
+  measuredOperationalHours: number;
+  utilizationPct: number | null;
+  overlappingOperationalPeriods: boolean;
+  downtimeHoursByReason: Record<string, number>;
+  firstRentalAt: string | null;
+  nybilToFirstRentalHours: number | null;
+  lastRentalReturnAt: string | null;
+  saluAt: string | null;
+  lastRentalToSaluHours: number | null;
+  betweenRentalGapCount: number;
+  averageHoursBetweenRentals: number | null;
+  longestHoursBetweenRentals: number | null;
+};
+
+type MetricsResponse = {
+  data?: {
+    regnr: string;
+    metrics: JourneyMetrics;
+    coverage: {
+      periodCount: number;
+      hasLifecycleStart: boolean;
+      hasLifecycleEnd: boolean;
+      hasSaluDate: boolean;
+    };
+  };
+  error?: string;
+};
+
+type Props = {
+  regnr: string;
+  refreshNonce: number;
+};
+
+const reasonLabels: Record<string, string> = {
+  DAMAGE: 'Skada',
+  WORKSHOP: 'Verkstad',
+  SERVICE: 'Service',
+  WAITING_PARTS: 'Väntar reservdelar',
+  MISSING_EQUIPMENT: 'Saknad utrustning',
+  TRANSPORT: 'Transport',
+  ADMINISTRATION: 'Administration',
+  OTHER: 'Övrigt',
+  UNSPECIFIED: 'Ej angiven',
+};
+
+function formatHours(value: number | null | undefined) {
+  if (value === null || value === undefined) return '—';
+  if (value >= 24) return `${Math.round((value / 24) * 10) / 10} dygn`;
+  return `${value} h`;
+}
+
+function formatPercent(value: number | null | undefined) {
+  return value === null || value === undefined ? '—' : `${value} %`;
+}
+
+export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
+  const [metrics, setMetrics] = useState<JourneyMetrics | null>(null);
+  const [periodCount, setPeriodCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const response = await fetch(`/api/vehicle-journey/metrics?reg=${encodeURIComponent(regnr)}`);
+        const body = await response.json() as MetricsResponse;
+        if (!response.ok || !body.data) throw new Error(body.error || 'Kunde inte hämta resans nyckeltal');
+        if (!cancelled) {
+          setMetrics(body.data.metrics);
+          setPeriodCount(body.data.coverage.periodCount);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setMetrics(null);
+          setError(err instanceof Error ? err.message : 'Kunde inte hämta resans nyckeltal');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    setLoading(true);
+    setError('');
+    void load();
+
+    return () => { cancelled = true; };
+  }, [regnr, refreshNonce]);
+
+  if (loading) return <p style={{ color: '#666' }}>Räknar resans nyckeltal…</p>;
+  if (error) return <p style={{ color: '#a00' }}>{error}</p>;
+  if (!metrics) return null;
+
+  const downtimeReasons = Object.entries(metrics.downtimeHoursByReason)
+    .sort((left, right) => right[1] - left[1]);
+
+  const stats: Array<[string, string]> = [
+    ['Livscykel', formatHours(metrics.lifecycleHours)],
+    ['Uthyrningar', String(metrics.rentalCount)],
+    ['Uthyrd tid', formatHours(metrics.rentalHours)],
+    ['Nyttjandegrad', formatPercent(metrics.utilizationPct)],
+    ['Stillestånd', formatHours(metrics.downtimeHours)],
+    ['Verkstad', formatHours(metrics.workshopHours)],
+    ['Nybil → första uthyrning', formatHours(metrics.nybilToFirstRentalHours)],
+    ['Snitt mellan uthyrningar', formatHours(metrics.averageHoursBetweenRentals)],
+    ['Sista retur → SALU', formatHours(metrics.lastRentalToSaluHours)],
+  ];
+
+  return (
+    <div style={{ marginTop: '1rem' }}>
+      <div style={{ fontWeight: 700, marginBottom: '.55rem' }}>Resans nyckeltal</div>
+      {periodCount === 0 && (
+        <div style={{ background: '#f6f6f6', borderRadius: 8, padding: '.65rem .75rem', marginBottom: '.7rem', color: '#555' }}>
+          Ingen periodhistorik ännu. Nyckeltalen fylls på när uthyrning, stillestånd, verkstad och andra perioder registreras.
+        </div>
+      )}
+      {metrics.overlappingOperationalPeriods && (
+        <div style={{ background: '#fff2db', borderRadius: 8, padding: '.65rem .75rem', marginBottom: '.7rem' }}>
+          Operativa perioder överlappar. Nyttjandegrad visas därför inte förrän tidslinjen är entydig.
+        </div>
+      )}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '.55rem' }}>
+        {stats.map(([label, value]) => (
+          <div key={label} style={{ border: '1px solid #e4e4e4', borderRadius: 8, padding: '.65rem' }}>
+            <div style={{ fontSize: 12, color: '#666', marginBottom: '.2rem' }}>{label}</div>
+            <strong>{value}</strong>
+          </div>
+        ))}
+      </div>
+      {downtimeReasons.length > 0 && (
+        <div style={{ marginTop: '.8rem' }}>
+          <div style={{ fontSize: 13, fontWeight: 700, marginBottom: '.25rem' }}>Stillestånd per orsak</div>
+          {downtimeReasons.map(([reason, total]) => (
+            <div key={reason} style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', padding: '.3rem 0', borderTop: '1px solid #eee' }}>
+              <span>{reasonLabels[reason] ?? reason}</span>
+              <strong>{formatHours(total)}</strong>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/vagnkort/vagnkort-client.tsx
+++ b/app/vagnkort/vagnkort-client.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import DocumentUpload from './document-upload';
 import EquipmentChangeControls from './equipment-change-controls';
+import JourneyMetricsPanel from './journey-metrics-panel';
 import JourneyPeriodControls from './journey-period-controls';
 
 type JourneyPeriod = {
@@ -260,6 +261,7 @@ export default function VagnkortClient() {
               <section style={card}>
                 <h2 style={{ marginTop: 0 }}>Tid i resan</h2>
                 <JourneyPeriodControls regnr={data.regnr} openPeriods={data.journey.openPeriods} onChanged={() => setRefreshNonce((value) => value + 1)} />
+                <JourneyMetricsPanel regnr={data.regnr} refreshNonce={refreshNonce} />
                 <div style={{ marginTop: '1rem' }}>
                   {Object.keys(data.journey.totalHoursByType).length === 0 ? <p>Inga avslutade perioder ännu.</p> : Object.entries(data.journey.totalHoursByType).map(([type, total]) => <div key={type} style={{ display: 'flex', justifyContent: 'space-between', padding: '.45rem 0', borderBottom: '1px solid #eee' }}><span>{type}</span><strong>{hours(total)}</strong></div>)}
                 </div>

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -21,6 +21,7 @@ const protectedApiPaths = [
   '/api/vehicle-edits',
   '/api/vehicle-info?reg=GEU29F',
   '/api/vehicle-journey?reg=GEU29F',
+  '/api/vehicle-journey/metrics?reg=GEU29F',
 ]
 
 test('all central protected API paths reject unauthenticated requests', async (t) => {

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -10,6 +10,8 @@ const uploadApi = readFileSync(join(process.cwd(), 'app/api/vehicle-documents/ro
 const documentApi = readFileSync(join(process.cwd(), 'app/api/vehicle-documents/[id]/route.ts'), 'utf8');
 const periodControls = readFileSync(join(process.cwd(), 'app/vagnkort/journey-period-controls.tsx'), 'utf8');
 const periodApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/periods/route.ts'), 'utf8');
+const metricsPanel = readFileSync(join(process.cwd(), 'app/vagnkort/journey-metrics-panel.tsx'), 'utf8');
+const metricsApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/metrics/route.ts'), 'utf8');
 const equipmentControls = readFileSync(join(process.cwd(), 'app/vagnkort/equipment-change-controls.tsx'), 'utf8');
 const equipmentApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/equipment/route.ts'), 'utf8');
 const journeyApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/route.ts'), 'utf8');
@@ -27,6 +29,19 @@ test('Vagnkort reads the authenticated vehicle journey API', () => {
   assert.match(client, /Tid i resan/);
   assert.match(client, /Dokument/);
   assert.match(client, /Tidslinje/);
+});
+
+test('Vagnkort surfaces lifecycle metrics and refreshes them with period changes', () => {
+  assert.match(client, /<JourneyMetricsPanel regnr=\{data\.regnr\} refreshNonce=\{refreshNonce\} \/>/);
+  assert.match(metricsPanel, /\/api\/vehicle-journey\/metrics\?reg=/);
+  assert.match(metricsPanel, /Resans nyckeltal/);
+  assert.match(metricsPanel, /Nyttjandegrad/);
+  assert.match(metricsPanel, /Nybil → första uthyrning/);
+  assert.match(metricsPanel, /Sista retur → SALU/);
+  assert.match(metricsPanel, /Stillestånd per orsak/);
+  assert.match(metricsPanel, /Operativa perioder överlappar/);
+  assert.match(metricsApi, /verifyApiUser\(request\)/);
+  assert.match(metricsApi, /computeJourneyLifecycleMetrics/);
 });
 
 test('Vagnkort surfaces baseline/current equipment changes', () => {


### PR DESCRIPTION
## Sammanfattning
- kopplar in befintliga livscykelmått direkt i Vagnkortets arbetsyta
- visar livscykel, antal uthyrningar, uthyrd tid, nyttjandegrad, stillestånd, verkstad, Nybil→första uthyrning, tid mellan uthyrningar och sista retur→SALU
- visar stilleståndstid per orsak
- visar tydlig varning om operativa perioder överlappar och KPI därför inte är tillförlitlig
- panelen uppdateras automatiskt när perioder startas eller avslutas

## Säkerhet
- metrics-routen ligger kvar bakom `verifyApiUser`
- security regression omfattar nu `/api/vehicle-journey/metrics`
- ingen schemaändring eller Production-write

## Test
- utökat Vagnkort-kontraktstest för metrics-panel och server-route
- befintliga rena livscykeltester ligger kvar från föregående release.