### PR TITLE
Vagnkort: gör SALU till slutdelen av bilens resa

### DIFF
--- a/app/vagnkort/salu-journey-panel.tsx
+++ b/app/vagnkort/salu-journey-panel.tsx
@@ -136,6 +136,9 @@ export default function SaluJourneyPanel({ state, latestFlag, checkpoints, child
           <div style={{ fontWeight: 700, marginBottom: '.35rem' }}>Hantering</div>
           {childProcesses.map((process) => {
             const evidenceCount = documentCountForChildProcess(documents, process.child_process_id);
+            const hasSourceReason = Boolean(process.source_reason);
+            const hasOutcome = Boolean(process.outcome);
+            const hasDeadline = Boolean(process.deadline_at);
             return (
               <div key={String(process.child_process_id)} style={{ borderTop: '1px solid #eee', padding: '.55rem 0' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
@@ -146,11 +149,11 @@ export default function SaluJourneyPanel({ state, latestFlag, checkpoints, child
                   {process.source_checkpoint ? `Från ${text(process.source_checkpoint)} · ` : ''}
                   Ägare {text(process.owner_ref)} · {text(process.execution_system)}
                 </div>
-                {(process.source_reason || process.outcome || process.deadline_at) && (
+                {(hasSourceReason || hasOutcome || hasDeadline) && (
                   <div style={{ marginTop: '.2rem', fontSize: 13 }}>
-                    {process.source_reason ? <span>{text(process.source_reason)}</span> : null}
-                    {process.outcome ? <span>{process.source_reason ? ' · ' : ''}{text(process.outcome)}</span> : null}
-                    {process.deadline_at ? <span>{process.source_reason || process.outcome ? ' · ' : ''}Deadline {date(process.deadline_at)}</span> : null}
+                    {hasSourceReason ? <span>{text(process.source_reason)}</span> : null}
+                    {hasOutcome ? <span>{hasSourceReason ? ' · ' : ''}{text(process.outcome)}</span> : null}
+                    {hasDeadline ? <span>{hasSourceReason || hasOutcome ? ' · ' : ''}Deadline {date(process.deadline_at)}</span> : null}
                   </div>
                 )}
               </div>

--- a/app/vagnkort/salu-journey-panel.tsx
+++ b/app/vagnkort/salu-journey-panel.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+type VehicleDocument = {
+  document_id: string;
+  document_type: string;
+  title: string | null;
+  file_name: string;
+  uploaded_at: string;
+  salu_flag_id?: string | null;
+  salu_checkpoint_id?: string | null;
+  salu_child_process_id?: string | null;
+};
+
+type Props = {
+  state: Record<string, unknown> | null;
+  latestFlag: Record<string, unknown> | null;
+  checkpoints: Array<Record<string, unknown>>;
+  childProcesses: Array<Record<string, unknown>>;
+  documents: VehicleDocument[];
+};
+
+function text(value: unknown) {
+  if (value === null || value === undefined || value === '') return '—';
+  return String(value);
+}
+
+function date(value: unknown) {
+  if (typeof value !== 'string' || !value) return '—';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString('sv-SE');
+}
+
+function statusLabel(value: unknown) {
+  const status = typeof value === 'string' ? value : '';
+  const labels: Record<string, string> = {
+    'GODKÄND': 'Godkänd',
+    'AVVIKELSE': 'Avvikelse',
+    'EJ RELEVANT': 'Ej relevant',
+    'VÄNTAR': 'Väntar',
+    'CREATED': 'Skapad',
+    'ACCEPTED': 'Accepterad',
+    'IN_PROGRESS': 'Pågår',
+    'READY_FOR_VERIFICATION': 'Redo för verifiering',
+    'VERIFIED': 'Verifierad',
+    'CANCELLED': 'Avbruten',
+  };
+  return labels[status] ?? text(value);
+}
+
+function documentCountForCheckpoint(documents: VehicleDocument[], checkpointId: unknown) {
+  return typeof checkpointId === 'string'
+    ? documents.filter((document) => document.salu_checkpoint_id === checkpointId).length
+    : 0;
+}
+
+function documentCountForChildProcess(documents: VehicleDocument[], childProcessId: unknown) {
+  return typeof childProcessId === 'string'
+    ? documents.filter((document) => document.salu_child_process_id === childProcessId).length
+    : 0;
+}
+
+function differenceDays(original: unknown, current: unknown) {
+  if (typeof original !== 'string' || typeof current !== 'string') return null;
+  const originalMs = new Date(original).getTime();
+  const currentMs = new Date(current).getTime();
+  if (!Number.isFinite(originalMs) || !Number.isFinite(currentMs)) return null;
+  return Math.round((currentMs - originalMs) / 86_400_000);
+}
+
+export default function SaluJourneyPanel({ state, latestFlag, checkpoints, childProcesses, documents }: Props) {
+  if (!state && !latestFlag && checkpoints.length === 0 && childProcesses.length === 0) {
+    return <p style={{ color: '#666' }}>Ingen aktiv eller historisk SALU-process finns för bilen.</p>;
+  }
+
+  const originalDate = state?.original_saludatum;
+  const currentDate = state?.current_saludatum ?? latestFlag?.current_saludatum;
+  const deltaDays = differenceDays(originalDate, currentDate);
+  const deviations = checkpoints.filter((checkpoint) => checkpoint.status === 'AVVIKELSE');
+  const waiting = checkpoints.filter((checkpoint) => checkpoint.status === 'VÄNTAR');
+  const openActions = childProcesses.filter((process) => !['VERIFIED', 'CANCELLED'].includes(String(process.status ?? '')));
+  const flagId = typeof latestFlag?.flag_id === 'string' ? latestFlag.flag_id : null;
+  const flagEvidence = flagId
+    ? documents.filter((document) => document.salu_flag_id === flagId).length
+    : 0;
+
+  return (
+    <div style={{ display: 'grid', gap: '.8rem' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(145px, 1fr))', gap: '.55rem' }}>
+        <div style={{ border: '1px solid #e6e6e6', borderRadius: 8, padding: '.65rem' }}>
+          <div style={{ color: '#666', fontSize: 12 }}>Status</div>
+          <strong>{text(latestFlag?.status)}</strong>
+        </div>
+        <div style={{ border: '1px solid #e6e6e6', borderRadius: 8, padding: '.65rem' }}>
+          <div style={{ color: '#666', fontSize: 12 }}>Ursprungligt SALU-datum</div>
+          <strong>{text(originalDate)}</strong>
+        </div>
+        <div style={{ border: '1px solid #e6e6e6', borderRadius: 8, padding: '.65rem' }}>
+          <div style={{ color: '#666', fontSize: 12 }}>Aktuellt SALU-datum</div>
+          <strong>{text(currentDate)}</strong>
+        </div>
+        <div style={{ border: '1px solid #e6e6e6', borderRadius: 8, padding: '.65rem' }}>
+          <div style={{ color: '#666', fontSize: 12 }}>Förskjutning</div>
+          <strong>{deltaDays === null ? '—' : `${deltaDays > 0 ? '+' : ''}${deltaDays} dagar`}</strong>
+        </div>
+        <div style={{ border: '1px solid #e6e6e6', borderRadius: 8, padding: '.65rem' }}>
+          <div style={{ color: '#666', fontSize: 12 }}>Avvikelser</div>
+          <strong>{deviations.length}</strong>
+        </div>
+        <div style={{ border: '1px solid #e6e6e6', borderRadius: 8, padding: '.65rem' }}>
+          <div style={{ color: '#666', fontSize: 12 }}>Öppna åtgärder</div>
+          <strong>{openActions.length}</strong>
+        </div>
+      </div>
+
+      {(deviations.length > 0 || waiting.length > 0) && (
+        <div>
+          <div style={{ fontWeight: 700, marginBottom: '.35rem' }}>Kontrollpunkter som kräver uppmärksamhet</div>
+          {[...deviations, ...waiting].map((checkpoint) => {
+            const evidenceCount = documentCountForCheckpoint(documents, checkpoint.checkpoint_id);
+            return (
+              <div key={String(checkpoint.checkpoint_id)} style={{ borderTop: '1px solid #eee', padding: '.55rem 0', display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'start' }}>
+                <div>
+                  <strong>{text(checkpoint.checkpoint_code)} · {statusLabel(checkpoint.status)}</strong>
+                  <div style={{ fontSize: 13, color: '#666' }}>Senast uppdaterad {date(checkpoint.updated_at)}</div>
+                </div>
+                <span style={{ whiteSpace: 'nowrap', fontSize: 13 }}>{evidenceCount} underlag</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {childProcesses.length > 0 && (
+        <div>
+          <div style={{ fontWeight: 700, marginBottom: '.35rem' }}>Hantering</div>
+          {childProcesses.map((process) => {
+            const evidenceCount = documentCountForChildProcess(documents, process.child_process_id);
+            return (
+              <div key={String(process.child_process_id)} style={{ borderTop: '1px solid #eee', padding: '.55rem 0' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap' }}>
+                  <strong>{text(process.process_type)} · {statusLabel(process.status)}</strong>
+                  <span style={{ fontSize: 13 }}>{evidenceCount} underlag</span>
+                </div>
+                <div style={{ fontSize: 13, color: '#666' }}>
+                  {process.source_checkpoint ? `Från ${text(process.source_checkpoint)} · ` : ''}
+                  Ägare {text(process.owner_ref)} · {text(process.execution_system)}
+                </div>
+                {(process.source_reason || process.outcome || process.deadline_at) && (
+                  <div style={{ marginTop: '.2rem', fontSize: 13 }}>
+                    {process.source_reason ? <span>{text(process.source_reason)}</span> : null}
+                    {process.outcome ? <span>{process.source_reason ? ' · ' : ''}{text(process.outcome)}</span> : null}
+                    {process.deadline_at ? <span>{process.source_reason || process.outcome ? ' · ' : ''}Deadline {date(process.deadline_at)}</span> : null}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div style={{ background: '#f6f6f6', borderRadius: 8, padding: '.65rem .75rem', fontSize: 13 }}>
+        <strong>Underlag:</strong> {flagEvidence} dokument kopplade till aktuell SALU-flagga. Dokument som är direkt kopplade till checkpoint eller åtgärd visas även på respektive rad.
+      </div>
+    </div>
+  );
+}

--- a/app/vagnkort/vagnkort-client.tsx
+++ b/app/vagnkort/vagnkort-client.tsx
@@ -6,6 +6,7 @@ import DocumentUpload from './document-upload';
 import EquipmentChangeControls from './equipment-change-controls';
 import JourneyMetricsPanel from './journey-metrics-panel';
 import JourneyPeriodControls from './journey-period-controls';
+import SaluJourneyPanel from './salu-journey-panel';
 
 type JourneyPeriod = {
   period_id: string;
@@ -32,6 +33,9 @@ type VehicleDocument = {
   file_name: string;
   external_url: string | null;
   uploaded_at: string;
+  salu_flag_id?: string | null;
+  salu_checkpoint_id?: string | null;
+  salu_child_process_id?: string | null;
   sourceKind?: 'vehicle_document' | 'legacy_receipt';
 };
 
@@ -267,12 +271,14 @@ export default function VagnkortClient() {
                 </div>
               </section>
               <section style={card}>
-                <h2 style={{ marginTop: 0 }}>SALU</h2>
-                <div><strong>Status:</strong> {present(data.salu.latestFlag?.status)}</div>
-                <div><strong>SALU-datum:</strong> {present(data.salu.state?.current_saludatum)}</div>
-                <div><strong>Eskalering:</strong> {present(data.salu.latestFlag?.escalation_status)}</div>
-                <div><strong>Checkpoints:</strong> {data.salu.checkpoints.length}</div>
-                <div><strong>Barnprocesser:</strong> {data.salu.childProcesses.length}</div>
+                <h2 style={{ marginTop: 0 }}>SALU – slutdelen av bilens resa</h2>
+                <SaluJourneyPanel
+                  state={data.salu.state}
+                  latestFlag={data.salu.latestFlag}
+                  checkpoints={data.salu.checkpoints}
+                  childProcesses={data.salu.childProcesses}
+                  documents={data.documents}
+                />
               </section>
             </div>
 

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -12,6 +12,7 @@ const periodControls = readFileSync(join(process.cwd(), 'app/vagnkort/journey-pe
 const periodApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/periods/route.ts'), 'utf8');
 const metricsPanel = readFileSync(join(process.cwd(), 'app/vagnkort/journey-metrics-panel.tsx'), 'utf8');
 const metricsApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/metrics/route.ts'), 'utf8');
+const saluPanel = readFileSync(join(process.cwd(), 'app/vagnkort/salu-journey-panel.tsx'), 'utf8');
 const equipmentControls = readFileSync(join(process.cwd(), 'app/vagnkort/equipment-change-controls.tsx'), 'utf8');
 const equipmentApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/equipment/route.ts'), 'utf8');
 const journeyApi = readFileSync(join(process.cwd(), 'app/api/vehicle-journey/route.ts'), 'utf8');
@@ -42,6 +43,20 @@ test('Vagnkort surfaces lifecycle metrics and refreshes them with period changes
   assert.match(metricsPanel, /Operativa perioder överlappar/);
   assert.match(metricsApi, /verifyApiUser\(request\)/);
   assert.match(metricsApi, /computeJourneyLifecycleMetrics/);
+});
+
+test('Vagnkort presents SALU as the endpoint of the vehicle journey with deviations, handling and evidence', () => {
+  assert.match(client, /SALU – slutdelen av bilens resa/);
+  assert.match(client, /<SaluJourneyPanel/);
+  assert.match(client, /documents=\{data\.documents\}/);
+  assert.match(saluPanel, /Ursprungligt SALU-datum/);
+  assert.match(saluPanel, /Aktuellt SALU-datum/);
+  assert.match(saluPanel, /Förskjutning/);
+  assert.match(saluPanel, /Kontrollpunkter som kräver uppmärksamhet/);
+  assert.match(saluPanel, /Hantering/);
+  assert.match(saluPanel, /salu_checkpoint_id/);
+  assert.match(saluPanel, /salu_child_process_id/);
+  assert.match(saluPanel, /underlag/);
 });
 
 test('Vagnkort surfaces baseline/current equipment changes', () => {


### PR DESCRIPTION
## Sammanfattning
- ersätter den tidigare kompakta SALU-rutan med en faktisk SALU-läsvy i Vagnkortet
- visar ursprungligt och aktuellt SALU-datum samt förskjutning i dagar
- visar avvikelser och väntande checkpoints som kräver uppmärksamhet
- visar öppna och historiska SALU-barnprocesser som hantering
- räknar kopplat Vagnkort-underlag per SALU-checkpoint och barnprocess
- behåller SALU som del av samma fordonsresa i stället för ett separat formulär

## Datamodell
- återanvänder befintliga `salu_vehicle_state`, `salu_flags`, `salu_checkpoints`, `salu_child_processes` och `vehicle_documents`
- inga nya tabeller, policies, grants eller Production-skrivningar

## Test
- utökar Vagnkortets kontraktstest med SALU endpoint/deviation/handling/evidence-vyn
- befintlig read model och dokumentkoppling används oförändrat.