### PR TITLE
Vagnkort: återanvänd dokumentkontext utan extra API-anrop

### DIFF
--- a/app/vagnkort/document-upload.tsx
+++ b/app/vagnkort/document-upload.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, DragEvent, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, DragEvent, useMemo, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabase';
 
 const DOCUMENT_TYPES = [
@@ -21,8 +21,19 @@ type ContextOption = {
   label: string;
 };
 
+type DamageContext = {
+  id: string;
+  damage_type_raw?: string | null;
+  legacy_damage_source_text?: string | null;
+  damage_date?: string | null;
+  source?: string | null;
+};
+
 type Props = {
   regnr: string;
+  damages: DamageContext[];
+  checkpoints: Array<Record<string, unknown>>;
+  childProcesses: Array<Record<string, unknown>>;
   onUploaded: () => void;
 };
 
@@ -33,71 +44,34 @@ type PrepareResponse = {
 
 type CompleteResponse = { data?: { document_id: string }; error?: string };
 
-type JourneyContextResponse = {
-  data?: {
-    damages?: Array<{
-      id: string;
-      damage_type_raw?: string | null;
-      legacy_damage_source_text?: string | null;
-      damage_date?: string | null;
-      source?: string | null;
-    }>;
-    salu?: {
-      checkpoints?: Array<Record<string, unknown>>;
-      childProcesses?: Array<Record<string, unknown>>;
-    };
-  };
-};
-
 function text(value: unknown): string {
   return typeof value === 'string' ? value : '';
 }
 
-export default function DocumentUpload({ regnr, onUploaded }: Props) {
+export default function DocumentUpload({ regnr, damages, checkpoints, childProcesses, onUploaded }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [documentType, setDocumentType] = useState('OVRIGT');
   const [title, setTitle] = useState('');
   const [contextType, setContextType] = useState('VEHICLE');
   const [contextId, setContextId] = useState('');
-  const [damageOptions, setDamageOptions] = useState<ContextOption[]>([]);
-  const [checkpointOptions, setCheckpointOptions] = useState<ContextOption[]>([]);
-  const [childProcessOptions, setChildProcessOptions] = useState<ContextOption[]>([]);
   const [uploading, setUploading] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [message, setMessage] = useState('');
 
-  useEffect(() => {
-    let cancelled = false;
+  const damageOptions = useMemo<ContextOption[]>(() => damages.map((damage) => ({
+    value: damage.id,
+    label: `${damage.damage_type_raw || damage.legacy_damage_source_text || 'Skada'}${damage.damage_date ? ` · ${damage.damage_date}` : ''}${damage.source ? ` · ${damage.source}` : ''}`,
+  })), [damages]);
 
-    async function loadContexts() {
-      try {
-        const response = await fetch(`/api/vehicle-journey?reg=${encodeURIComponent(regnr)}`);
-        if (!response.ok) return;
-        const body = (await response.json()) as JourneyContextResponse;
-        if (cancelled) return;
+  const checkpointOptions = useMemo<ContextOption[]>(() => checkpoints.map((checkpoint) => ({
+    value: text(checkpoint.checkpoint_id),
+    label: `${text(checkpoint.checkpoint_code) || 'Checkpoint'} · ${text(checkpoint.status) || 'okänd status'}`,
+  })).filter((option) => option.value), [checkpoints]);
 
-        setDamageOptions((body.data?.damages ?? []).map((damage) => ({
-          value: damage.id,
-          label: `${damage.damage_type_raw || damage.legacy_damage_source_text || 'Skada'}${damage.damage_date ? ` · ${damage.damage_date}` : ''}${damage.source ? ` · ${damage.source}` : ''}`,
-        })));
-
-        setCheckpointOptions((body.data?.salu?.checkpoints ?? []).map((checkpoint) => ({
-          value: text(checkpoint.checkpoint_id),
-          label: `${text(checkpoint.checkpoint_code) || 'Checkpoint'} · ${text(checkpoint.status) || 'okänd status'}`,
-        })).filter((option) => option.value));
-
-        setChildProcessOptions((body.data?.salu?.childProcesses ?? []).map((process) => ({
-          value: text(process.child_process_id),
-          label: `${text(process.process_type) || 'SALU-åtgärd'}${text(process.source_checkpoint) ? ` · ${text(process.source_checkpoint)}` : ''} · ${text(process.status) || 'okänd status'}`,
-        })).filter((option) => option.value));
-      } catch {
-        // Vagnkortet fungerar fortfarande med bilnivå även om kontextlistan inte kan laddas.
-      }
-    }
-
-    void loadContexts();
-    return () => { cancelled = true; };
-  }, [regnr]);
+  const childProcessOptions = useMemo<ContextOption[]>(() => childProcesses.map((process) => ({
+    value: text(process.child_process_id),
+    label: `${text(process.process_type) || 'SALU-åtgärd'}${text(process.source_checkpoint) ? ` · ${text(process.source_checkpoint)}` : ''} · ${text(process.status) || 'okänd status'}`,
+  })).filter((option) => option.value), [childProcesses]);
 
   const contextOptions = contextType === 'DAMAGE'
     ? damageOptions
@@ -215,8 +189,8 @@ export default function DocumentUpload({ regnr, onUploaded }: Props) {
         {contextType !== 'VEHICLE' && (
           <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
             Välj post
-            <select value={contextId} onChange={(event) => setContextId(event.target.value)} disabled={uploading} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
-              <option value="">Välj…</option>
+            <select value={contextId} onChange={(event) => setContextId(event.target.value)} disabled={uploading || contextOptions.length === 0} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
+              <option value="">{contextOptions.length === 0 ? 'Inga valbara poster' : 'Välj…'}</option>
               {contextOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
             </select>
           </label>

--- a/app/vagnkort/vagnkort-client.tsx
+++ b/app/vagnkort/vagnkort-client.tsx
@@ -309,7 +309,13 @@ export default function VagnkortClient() {
               </section>
               <section style={card}>
                 <h2 style={{ marginTop: 0 }}>Dokument</h2>
-                <DocumentUpload regnr={data.regnr} onUploaded={() => setRefreshNonce((value) => value + 1)} />
+                <DocumentUpload
+                  regnr={data.regnr}
+                  damages={data.damages}
+                  checkpoints={data.salu.checkpoints}
+                  childProcesses={data.salu.childProcesses}
+                  onUploaded={() => setRefreshNonce((value) => value + 1)}
+                />
                 <div style={{ marginTop: '1rem' }}>
                   {data.documents.length === 0 ? <p>Inga dokument registrerade ännu.</p> : data.documents.slice(0, 20).map((document) => (
                     <div key={document.document_id} style={{ padding: '.55rem 0', borderBottom: '1px solid #eee', display: 'flex', gap: '.7rem', justifyContent: 'space-between', alignItems: 'center' }}>

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -68,13 +68,21 @@ test('Vagnkort surfaces baseline/current equipment changes', () => {
 });
 
 test('Vagnkort document upload uses authenticated prepare/complete and signed Storage upload', () => {
-  assert.match(client, /<DocumentUpload regnr=/);
+  assert.match(client, /<DocumentUpload/);
   assert.match(upload, /action:\s*'prepare'/);
   assert.match(upload, /uploadToSignedUrl/);
   assert.match(upload, /action:\s*'complete'/);
   assert.match(upload, /Släpp filer här/);
   assert.match(upload, /Leverantörsfaktura/);
   assert.match(upload, /Skadebild/);
+});
+
+test('Vagnkort reuses already loaded journey context for document upload', () => {
+  assert.match(client, /damages=\{data\.damages\}/);
+  assert.match(client, /checkpoints=\{data\.salu\.checkpoints\}/);
+  assert.match(client, /childProcesses=\{data\.salu\.childProcesses\}/);
+  assert.doesNotMatch(upload, /\/api\/vehicle-journey\?reg=/);
+  assert.match(upload, /Inga valbara poster/);
 });
 
 test('Vagnkort document upload can bind evidence to vehicle, damage and SALU context', () => {


### PR DESCRIPTION
## Sammanfattning
- tar bort DocumentUploads separata hämtning av `/api/vehicle-journey`
- återanvänder skador, SALU-checkpoints och SALU-åtgärder som Vagnkortet redan har laddat
- visar tydligt när vald kontext saknar valbara poster
- lämnar prepare/complete-uppladdning och servervalidering oförändrad

## Effekt
- ett färre journey-API-anrop per öppnat Vagnkort
- mindre duplicerad klientstate och färre möjliga race mellan två läsningar
- samma server-side kontroll av att dokumentkontext tillhör rätt bil

## Säkerhet och data
- ingen service role exponeras i klienten
- inga schema-, policy- eller Production-dataändringar

## Test
- utökar Vagnkortets kontraktstest för att verifiera att kontexten skickas från parent och att upload-komponenten inte längre gör ett eget journey-anrop.