### PR TITLE
Kontrollpunktsmotor: första grundkontraktet

### DIFF
--- a/app/api/vehicle-checkpoints/route.ts
+++ b/app/api/vehicle-checkpoints/route.ts
@@ -1,0 +1,262 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+import { CHECKPOINT_STATUSES, validateCheckpointCode } from '@/lib/checkpoint-engine';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function cleanRegnr(value: unknown): string {
+  return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
+}
+
+function cleanOptionalText(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  return value.trim().slice(0, maxLength);
+}
+
+function cleanTimestamp(value: unknown): string | null | undefined {
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value !== 'string') return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}
+
+function cleanEvidenceRefs(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value) || value.length > 50) return undefined;
+
+  const refs = value.map((entry) => {
+    if (typeof entry !== 'string') return null;
+    const cleaned = entry.trim().slice(0, 200);
+    return cleaned || null;
+  });
+
+  return refs.some((entry) => entry === null) ? undefined : refs as string[];
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr: string) {
+  const [vehicle, nybil, checkin, salu] = await Promise.all([
+    admin.from('vehicles').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('nybil_inventering').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('checkins').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('salu_vehicle_state').select('regnr').eq('regnr', regnr).limit(1),
+  ]);
+
+  const failed = [vehicle, nybil, checkin, salu].find((response) => response.error);
+  if (failed?.error) throw failed.error;
+  return [vehicle, nybil, checkin, salu].some((response) => (response.data?.length ?? 0) > 0);
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const regnr = cleanRegnr(new URL(request.url).searchParams.get('reg'));
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-checkpoints] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Checkpoint engine unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    const { data: checkpoints, error } = await admin
+      .from('vehicle_checkpoints')
+      .select('checkpoint_id,checkpoint_code,definition_version,cycle_key,status,due_at,source_journey_event_id,source_context,created_at,updated_at')
+      .eq('regnr', regnr)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+
+    const codes = [...new Set((checkpoints ?? []).map((row) => row.checkpoint_code as string))];
+    const { data: definitions, error: definitionError } = codes.length === 0
+      ? { data: [], error: null }
+      : await admin
+          .from('checkpoint_definitions')
+          .select('checkpoint_code,definition_version,domain,title,description,owner_function,verification_mode,blocking')
+          .in('checkpoint_code', codes);
+
+    if (definitionError) throw definitionError;
+
+    const definitionMap = new Map(
+      (definitions ?? []).map((definition) => [
+        `${definition.checkpoint_code}:${definition.definition_version}`,
+        definition,
+      ]),
+    );
+
+    return NextResponse.json({
+      data: (checkpoints ?? []).map((checkpoint) => ({
+        ...checkpoint,
+        definition: definitionMap.get(`${checkpoint.checkpoint_code}:${checkpoint.definition_version}`) ?? null,
+      })),
+    });
+  } catch (error) {
+    console.error('[vehicle-checkpoints] Read failed:', error);
+    return NextResponse.json({ error: 'Could not load checkpoints' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const action = typeof body.action === 'string' ? body.action.trim().toUpperCase() : '';
+  const regnr = cleanRegnr(body.regnr);
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-checkpoints] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Checkpoint engine unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    if (action === 'ENSURE') {
+      let checkpointCode: string;
+      try {
+        checkpointCode = validateCheckpointCode(typeof body.checkpointCode === 'string' ? body.checkpointCode : '');
+      } catch {
+        return NextResponse.json({ error: 'Invalid checkpoint code' }, { status: 400 });
+      }
+
+      const cycleKey = cleanOptionalText(body.cycleKey, 120) ?? 'default';
+      const dueAt = cleanTimestamp(body.dueAt);
+      if (dueAt === undefined) {
+        return NextResponse.json({ error: 'Invalid due time' }, { status: 400 });
+      }
+
+      const sourceJourneyEventId = typeof body.sourceJourneyEventId === 'string'
+        && UUID_RE.test(body.sourceJourneyEventId.trim())
+        ? body.sourceJourneyEventId.trim()
+        : null;
+      if (body.sourceJourneyEventId && !sourceJourneyEventId) {
+        return NextResponse.json({ error: 'Invalid source journey event id' }, { status: 400 });
+      }
+
+      const sourceContext = body.sourceContext && typeof body.sourceContext === 'object' && !Array.isArray(body.sourceContext)
+        ? body.sourceContext
+        : {};
+
+      const { data, error } = await admin.rpc('ensure_vehicle_checkpoint', {
+        p_regnr: regnr,
+        p_checkpoint_code: checkpointCode,
+        p_cycle_key: cycleKey,
+        p_due_at: dueAt,
+        p_source_journey_event_id: sourceJourneyEventId,
+        p_source_context: sourceContext,
+        p_actor_id: verification.user.id,
+        p_actor_email: verification.user.email,
+      });
+
+      if (error) {
+        if (error.code === 'P0002') {
+          return NextResponse.json({ error: 'Active checkpoint definition not found' }, { status: 404 });
+        }
+        throw error;
+      }
+
+      return NextResponse.json({ data }, { status: data?.created ? 201 : 200 });
+    }
+
+    if (action === 'ASSESS') {
+      const checkpointId = typeof body.checkpointId === 'string' && UUID_RE.test(body.checkpointId.trim())
+        ? body.checkpointId.trim()
+        : null;
+      if (!checkpointId) {
+        return NextResponse.json({ error: 'Invalid checkpoint id' }, { status: 400 });
+      }
+
+      const status = typeof body.status === 'string' ? body.status.trim().toUpperCase() : '';
+      if (!CHECKPOINT_STATUSES.includes(status as (typeof CHECKPOINT_STATUSES)[number]) || status === 'VANTAR') {
+        return NextResponse.json({ error: 'Invalid assessment status' }, { status: 400 });
+      }
+
+      const comment = cleanOptionalText(body.comment, 1000);
+      if (status === 'AVVIKELSE' && !comment) {
+        return NextResponse.json({ error: 'Deviation requires a comment' }, { status: 400 });
+      }
+
+      const evidenceRefs = cleanEvidenceRefs(body.evidenceRefs);
+      if (evidenceRefs === undefined) {
+        return NextResponse.json({ error: 'Invalid evidence refs' }, { status: 400 });
+      }
+
+      const { data: checkpoint, error: checkpointError } = await admin
+        .from('vehicle_checkpoints')
+        .select('checkpoint_id')
+        .eq('checkpoint_id', checkpointId)
+        .eq('regnr', regnr)
+        .maybeSingle();
+      if (checkpointError) throw checkpointError;
+      if (!checkpoint) {
+        return NextResponse.json({ error: 'Checkpoint not found for vehicle' }, { status: 404 });
+      }
+
+      const { data, error } = await admin.rpc('assess_vehicle_checkpoint', {
+        p_checkpoint_id: checkpointId,
+        p_status: status,
+        p_comment: comment,
+        p_evidence_refs: evidenceRefs,
+        p_actor_id: verification.user.id,
+        p_actor_email: verification.user.email,
+        p_actor_source: 'MANUELL',
+      });
+
+      if (error) {
+        if (error.code === '22023') {
+          return NextResponse.json({ error: error.message }, { status: 400 });
+        }
+        if (error.code === 'P0002') {
+          return NextResponse.json({ error: 'Checkpoint not found' }, { status: 404 });
+        }
+        throw error;
+      }
+
+      return NextResponse.json({ data });
+    }
+
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+  } catch (error) {
+    console.error('[vehicle-checkpoints] Write failed:', error);
+    return NextResponse.json({ error: 'Checkpoint operation failed' }, { status: 500 });
+  }
+}

--- a/lib/checkpoint-engine.ts
+++ b/lib/checkpoint-engine.ts
@@ -1,0 +1,91 @@
+export const CHECKPOINT_DOMAINS = [
+  'NYBIL',
+  'DRIFT',
+  'CHECKIN',
+  'SERVICE',
+  'SALU',
+  'PLANERING',
+  'INKOP',
+  'OTHER',
+] as const;
+
+export type CheckpointDomain = (typeof CHECKPOINT_DOMAINS)[number];
+
+export const CHECKPOINT_STATUSES = [
+  'VANTAR',
+  'GODKAND',
+  'AVVIKELSE',
+  'EJ_RELEVANT',
+] as const;
+
+export type CheckpointStatus = (typeof CHECKPOINT_STATUSES)[number];
+
+export const CHECKPOINT_VERIFICATION_MODES = [
+  'MANUELL',
+  'SYSTEM',
+  'EVIDENCE_REQUIRED',
+] as const;
+
+export type CheckpointVerificationMode = (typeof CHECKPOINT_VERIFICATION_MODES)[number];
+
+export type CheckpointDefinition = {
+  code: string;
+  version: number;
+  domain: CheckpointDomain;
+  title: string;
+  ownerFunction: string;
+  verificationMode: CheckpointVerificationMode;
+  blocking: boolean;
+};
+
+export type CheckpointAssessmentInput = {
+  status: Exclude<CheckpointStatus, 'VANTAR'>;
+  comment?: string | null;
+  evidenceRefs?: string[];
+};
+
+export type CheckpointReadiness = {
+  ready: boolean;
+  reasons: string[];
+};
+
+export function validateCheckpointCode(code: string): string {
+  const normalized = code.trim().toUpperCase();
+  if (!/^[A-Z0-9][A-Z0-9_-]{1,79}$/.test(normalized)) {
+    throw new Error('Invalid checkpoint code');
+  }
+  return normalized;
+}
+
+export function validateCheckpointAssessment(
+  input: CheckpointAssessmentInput,
+  verificationMode: CheckpointVerificationMode,
+): void {
+  if (input.status === 'AVVIKELSE' && !input.comment?.trim()) {
+    throw new Error('Deviation requires a comment');
+  }
+
+  if (
+    verificationMode === 'EVIDENCE_REQUIRED' &&
+    input.status === 'GODKAND' &&
+    (input.evidenceRefs?.length ?? 0) === 0
+  ) {
+    throw new Error('Approved checkpoint requires evidence');
+  }
+}
+
+export function assessCheckpointReadiness(
+  checkpoints: Array<{ status: CheckpointStatus; blocking: boolean }>,
+): CheckpointReadiness {
+  const reasons: string[] = [];
+
+  if (checkpoints.some((checkpoint) => checkpoint.blocking && checkpoint.status === 'VANTAR')) {
+    reasons.push('BLOCKING_CHECKPOINT_VANTAR');
+  }
+
+  if (checkpoints.some((checkpoint) => checkpoint.blocking && checkpoint.status === 'AVVIKELSE')) {
+    reasons.push('BLOCKING_CHECKPOINT_AVVIKELSE');
+  }
+
+  return { ready: reasons.length === 0, reasons };
+}

--- a/migrations/20260821004000_create_checkpoint_engine_foundation.sql
+++ b/migrations/20260821004000_create_checkpoint_engine_foundation.sql
@@ -1,0 +1,248 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Generic checkpoint definitions. Definitions are versioned so historical vehicle
+-- outcomes remain tied to the rule that was active when the checkpoint was created.
+create table public.checkpoint_definitions (
+  checkpoint_code text not null,
+  definition_version integer not null check (definition_version > 0),
+  domain text not null check (domain in (
+    'NYBIL', 'DRIFT', 'CHECKIN', 'SERVICE', 'SALU', 'PLANERING', 'INKOP', 'OTHER'
+  )),
+  title text not null check (length(trim(title)) > 0),
+  description text,
+  owner_function text not null check (length(trim(owner_function)) > 0),
+  verification_mode text not null default 'MANUELL'
+    check (verification_mode in ('MANUELL', 'SYSTEM', 'EVIDENCE_REQUIRED')),
+  blocking boolean not null default false,
+  trigger_type text,
+  trigger_config jsonb not null default '{}'::jsonb,
+  active boolean not null default true,
+  valid_from timestamptz not null default now(),
+  changed_by uuid,
+  changed_at timestamptz not null default now(),
+  primary key (checkpoint_code, definition_version),
+  check (checkpoint_code ~ '^[A-Z0-9][A-Z0-9_-]{1,79}$')
+);
+
+create unique index checkpoint_definitions_one_active_version_uidx
+  on public.checkpoint_definitions (checkpoint_code)
+  where active;
+
+-- No FK on regnr for the same reason as vehicle_journey_events: Production has
+-- legitimate Nybil/Check/SALU source vehicles that are not present in vehicles.
+create table public.vehicle_checkpoints (
+  checkpoint_id uuid primary key default gen_random_uuid(),
+  regnr text not null check (length(trim(regnr)) > 0),
+  checkpoint_code text not null,
+  definition_version integer not null,
+  cycle_key text not null default 'default' check (length(trim(cycle_key)) > 0),
+  status text not null default 'VANTAR'
+    check (status in ('VANTAR', 'GODKAND', 'AVVIKELSE', 'EJ_RELEVANT')),
+  due_at timestamptz,
+  source_journey_event_id uuid references public.vehicle_journey_events(event_id) on delete restrict,
+  source_context jsonb not null default '{}'::jsonb,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_by uuid,
+  updated_at timestamptz not null default now(),
+  foreign key (checkpoint_code, definition_version)
+    references public.checkpoint_definitions(checkpoint_code, definition_version) on delete restrict,
+  unique (regnr, checkpoint_code, cycle_key)
+);
+
+create index vehicle_checkpoints_regnr_status_idx
+  on public.vehicle_checkpoints (regnr, status, due_at);
+create index vehicle_checkpoints_definition_idx
+  on public.vehicle_checkpoints (checkpoint_code, definition_version);
+create index vehicle_checkpoints_source_event_idx
+  on public.vehicle_checkpoints (source_journey_event_id)
+  where source_journey_event_id is not null;
+
+-- Assessments are the immutable outcome ledger for a checkpoint. The mutable
+-- vehicle_checkpoints.status row is only the current projection.
+create table public.checkpoint_assessments (
+  assessment_id uuid primary key default gen_random_uuid(),
+  checkpoint_id uuid not null references public.vehicle_checkpoints(checkpoint_id) on delete restrict,
+  previous_status text not null
+    check (previous_status in ('VANTAR', 'GODKAND', 'AVVIKELSE', 'EJ_RELEVANT')),
+  status text not null
+    check (status in ('GODKAND', 'AVVIKELSE', 'EJ_RELEVANT')),
+  comment text,
+  evidence_refs jsonb not null default '[]'::jsonb,
+  actor_id uuid,
+  actor_email text,
+  actor_source text not null default 'MANUELL'
+    check (actor_source in ('SYSTEM', 'MANUELL', 'EXTERNAL')),
+  assessed_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  check (status <> 'AVVIKELSE' or length(trim(coalesce(comment, ''))) > 0),
+  check (jsonb_typeof(evidence_refs) = 'array')
+);
+
+create index checkpoint_assessments_checkpoint_time_idx
+  on public.checkpoint_assessments (checkpoint_id, assessed_at desc);
+
+create or replace function public.reject_checkpoint_assessment_mutation()
+returns trigger
+language plpgsql
+security invoker
+set search_path = pg_catalog
+as $$
+begin
+  raise exception 'checkpoint_assessments is append-only; write a new assessment instead';
+end;
+$$;
+
+create trigger checkpoint_assessments_append_only_update
+before update on public.checkpoint_assessments
+for each row execute function public.reject_checkpoint_assessment_mutation();
+
+create trigger checkpoint_assessments_append_only_delete
+before delete on public.checkpoint_assessments
+for each row execute function public.reject_checkpoint_assessment_mutation();
+
+-- Atomic assessment: lock current checkpoint, validate evidence semantics,
+-- append immutable assessment, update projection and append journey event.
+create or replace function public.assess_vehicle_checkpoint(
+  p_checkpoint_id uuid,
+  p_status text,
+  p_comment text,
+  p_evidence_refs jsonb,
+  p_actor_id uuid,
+  p_actor_email text,
+  p_actor_source text default 'MANUELL'
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_checkpoint public.vehicle_checkpoints%rowtype;
+  v_definition public.checkpoint_definitions%rowtype;
+  v_assessment_id uuid;
+begin
+  if p_status not in ('GODKAND', 'AVVIKELSE', 'EJ_RELEVANT') then
+    raise exception 'Invalid checkpoint status' using errcode = '22023';
+  end if;
+
+  if p_status = 'AVVIKELSE' and length(trim(coalesce(p_comment, ''))) = 0 then
+    raise exception 'Deviation requires a comment' using errcode = '22023';
+  end if;
+
+  if pg_catalog.jsonb_typeof(coalesce(p_evidence_refs, '[]'::jsonb)) <> 'array' then
+    raise exception 'Evidence refs must be an array' using errcode = '22023';
+  end if;
+
+  select * into v_checkpoint
+  from public.vehicle_checkpoints
+  where checkpoint_id = p_checkpoint_id
+  for update;
+
+  if not found then
+    raise exception 'Checkpoint not found' using errcode = 'P0002';
+  end if;
+
+  select * into v_definition
+  from public.checkpoint_definitions
+  where checkpoint_code = v_checkpoint.checkpoint_code
+    and definition_version = v_checkpoint.definition_version;
+
+  if v_definition.verification_mode = 'EVIDENCE_REQUIRED'
+     and p_status = 'GODKAND'
+     and pg_catalog.jsonb_array_length(coalesce(p_evidence_refs, '[]'::jsonb)) = 0 then
+    raise exception 'Approved checkpoint requires evidence' using errcode = '22023';
+  end if;
+
+  insert into public.checkpoint_assessments (
+    checkpoint_id,
+    previous_status,
+    status,
+    comment,
+    evidence_refs,
+    actor_id,
+    actor_email,
+    actor_source
+  ) values (
+    p_checkpoint_id,
+    v_checkpoint.status,
+    p_status,
+    nullif(trim(coalesce(p_comment, '')), ''),
+    coalesce(p_evidence_refs, '[]'::jsonb),
+    p_actor_id,
+    p_actor_email,
+    p_actor_source
+  ) returning assessment_id into v_assessment_id;
+
+  update public.vehicle_checkpoints
+  set status = p_status,
+      updated_by = p_actor_id,
+      updated_at = pg_catalog.now()
+  where checkpoint_id = p_checkpoint_id;
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    v_checkpoint.regnr,
+    'CHECKPOINT_ASSESSED',
+    'checkpoint-assessment:' || v_assessment_id::text,
+    pg_catalog.now(),
+    'CHECKPOINT_ENGINE',
+    'checkpoint_assessments',
+    v_assessment_id::text,
+    p_actor_id,
+    p_actor_source,
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'checkpointId', p_checkpoint_id,
+      'checkpointCode', v_checkpoint.checkpoint_code,
+      'definitionVersion', v_checkpoint.definition_version,
+      'previousStatus', v_checkpoint.status,
+      'status', p_status,
+      'comment', nullif(trim(coalesce(p_comment, '')), ''),
+      'evidenceRefs', coalesce(p_evidence_refs, '[]'::jsonb),
+      'blocking', v_definition.blocking
+    )
+  );
+
+  return pg_catalog.jsonb_build_object(
+    'assessment_id', v_assessment_id,
+    'checkpoint_id', p_checkpoint_id,
+    'previous_status', v_checkpoint.status,
+    'status', p_status
+  );
+end;
+$$;
+
+alter table public.checkpoint_definitions enable row level security;
+alter table public.vehicle_checkpoints enable row level security;
+alter table public.checkpoint_assessments enable row level security;
+
+revoke all on public.checkpoint_definitions from public, anon, authenticated;
+revoke all on public.vehicle_checkpoints from public, anon, authenticated;
+revoke all on public.checkpoint_assessments from public, anon, authenticated;
+revoke all on function public.reject_checkpoint_assessment_mutation() from public, anon, authenticated;
+revoke all on function public.assess_vehicle_checkpoint(uuid, text, text, jsonb, uuid, text, text)
+  from public, anon, authenticated;
+
+grant select, insert, update, delete on public.checkpoint_definitions to service_role;
+grant select, insert, update on public.vehicle_checkpoints to service_role;
+grant select, insert on public.checkpoint_assessments to service_role;
+grant execute on function public.reject_checkpoint_assessment_mutation() to service_role;
+grant execute on function public.assess_vehicle_checkpoint(uuid, text, text, jsonb, uuid, text, text)
+  to service_role;
+
+commit;

--- a/migrations/20260821004500_add_checkpoint_instance_rpc.sql
+++ b/migrations/20260821004500_add_checkpoint_instance_rpc.sql
@@ -1,0 +1,127 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Idempotently materialize the currently active definition for one vehicle/cycle
+-- and append the creation fact to the vehicle journey in the same transaction.
+create or replace function public.ensure_vehicle_checkpoint(
+  p_regnr text,
+  p_checkpoint_code text,
+  p_cycle_key text,
+  p_due_at timestamptz,
+  p_source_journey_event_id uuid,
+  p_source_context jsonb,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_definition public.checkpoint_definitions%rowtype;
+  v_checkpoint public.vehicle_checkpoints%rowtype;
+  v_created boolean := false;
+begin
+  select * into v_definition
+  from public.checkpoint_definitions
+  where checkpoint_code = upper(trim(p_checkpoint_code))
+    and active
+  order by definition_version desc
+  limit 1;
+
+  if not found then
+    raise exception 'Active checkpoint definition not found' using errcode = 'P0002';
+  end if;
+
+  select * into v_checkpoint
+  from public.vehicle_checkpoints
+  where regnr = upper(regexp_replace(p_regnr, '\s+', '', 'g'))
+    and checkpoint_code = v_definition.checkpoint_code
+    and cycle_key = coalesce(nullif(trim(p_cycle_key), ''), 'default')
+  for update;
+
+  if not found then
+    insert into public.vehicle_checkpoints (
+      regnr,
+      checkpoint_code,
+      definition_version,
+      cycle_key,
+      due_at,
+      source_journey_event_id,
+      source_context,
+      created_by,
+      updated_by
+    ) values (
+      upper(regexp_replace(p_regnr, '\s+', '', 'g')),
+      v_definition.checkpoint_code,
+      v_definition.definition_version,
+      coalesce(nullif(trim(p_cycle_key), ''), 'default'),
+      p_due_at,
+      p_source_journey_event_id,
+      coalesce(p_source_context, '{}'::jsonb),
+      p_actor_id,
+      p_actor_id
+    )
+    returning * into v_checkpoint;
+
+    v_created := true;
+
+    insert into public.vehicle_journey_events (
+      regnr,
+      event_type,
+      event_key,
+      occurred_at,
+      source_system,
+      source_entity,
+      source_record_id,
+      actor_id,
+      actor_source,
+      actor_email,
+      payload
+    ) values (
+      v_checkpoint.regnr,
+      'CHECKPOINT_CREATED',
+      'checkpoint-created:' || v_checkpoint.checkpoint_id::text,
+      pg_catalog.now(),
+      'CHECKPOINT_ENGINE',
+      'vehicle_checkpoints',
+      v_checkpoint.checkpoint_id::text,
+      p_actor_id,
+      'MANUELL',
+      p_actor_email,
+      pg_catalog.jsonb_build_object(
+        'checkpointId', v_checkpoint.checkpoint_id,
+        'checkpointCode', v_checkpoint.checkpoint_code,
+        'definitionVersion', v_checkpoint.definition_version,
+        'cycleKey', v_checkpoint.cycle_key,
+        'dueAt', v_checkpoint.due_at,
+        'blocking', v_definition.blocking,
+        'verificationMode', v_definition.verification_mode
+      )
+    );
+  end if;
+
+  return pg_catalog.jsonb_build_object(
+    'checkpoint_id', v_checkpoint.checkpoint_id,
+    'regnr', v_checkpoint.regnr,
+    'checkpoint_code', v_checkpoint.checkpoint_code,
+    'definition_version', v_checkpoint.definition_version,
+    'cycle_key', v_checkpoint.cycle_key,
+    'status', v_checkpoint.status,
+    'due_at', v_checkpoint.due_at,
+    'blocking', v_definition.blocking,
+    'verification_mode', v_definition.verification_mode,
+    'created', v_created
+  );
+end;
+$$;
+
+revoke all on function public.ensure_vehicle_checkpoint(text, text, text, timestamptz, uuid, jsonb, uuid, text)
+  from public, anon, authenticated;
+grant execute on function public.ensure_vehicle_checkpoint(text, text, text, timestamptz, uuid, jsonb, uuid, text)
+  to service_role;
+
+commit;

--- a/tests/checkpoint-engine.test.ts
+++ b/tests/checkpoint-engine.test.ts
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  assessCheckpointReadiness,
+  validateCheckpointAssessment,
+  validateCheckpointCode,
+} from '../lib/checkpoint-engine';
+
+const foundation = readFileSync(
+  join(process.cwd(), 'migrations/20260821004000_create_checkpoint_engine_foundation.sql'),
+  'utf8',
+);
+const instanceRpc = readFileSync(
+  join(process.cwd(), 'migrations/20260821004500_add_checkpoint_instance_rpc.sql'),
+  'utf8',
+);
+const api = readFileSync(
+  join(process.cwd(), 'app/api/vehicle-checkpoints/route.ts'),
+  'utf8',
+);
+
+test('checkpoint codes are normalized and reject unsafe values', () => {
+  assert.equal(validateCheckpointCode(' salu_return_01 '), 'SALU_RETURN_01');
+  assert.throws(() => validateCheckpointCode('x'), /Invalid checkpoint code/);
+  assert.throws(() => validateCheckpointCode('bad code'), /Invalid checkpoint code/);
+});
+
+test('deviations require comment and evidence-required approval requires evidence', () => {
+  assert.throws(
+    () => validateCheckpointAssessment({ status: 'AVVIKELSE' }, 'MANUELL'),
+    /Deviation requires a comment/,
+  );
+  assert.throws(
+    () => validateCheckpointAssessment({ status: 'GODKAND', evidenceRefs: [] }, 'EVIDENCE_REQUIRED'),
+    /Approved checkpoint requires evidence/,
+  );
+  assert.doesNotThrow(() => validateCheckpointAssessment(
+    { status: 'GODKAND', evidenceRefs: ['document:123'] },
+    'EVIDENCE_REQUIRED',
+  ));
+});
+
+test('blocking readiness treats waiting and deviation as unresolved', () => {
+  assert.deepEqual(
+    assessCheckpointReadiness([
+      { status: 'VANTAR', blocking: true },
+      { status: 'GODKAND', blocking: true },
+    ]),
+    { ready: false, reasons: ['BLOCKING_CHECKPOINT_VANTAR'] },
+  );
+  assert.deepEqual(
+    assessCheckpointReadiness([{ status: 'AVVIKELSE', blocking: true }]),
+    { ready: false, reasons: ['BLOCKING_CHECKPOINT_AVVIKELSE'] },
+  );
+  assert.deepEqual(
+    assessCheckpointReadiness([{ status: 'AVVIKELSE', blocking: false }]),
+    { ready: true, reasons: [] },
+  );
+});
+
+test('checkpoint persistence is versioned, server-only and keeps assessment history append-only', () => {
+  assert.match(foundation, /primary key \(checkpoint_code, definition_version\)/i);
+  assert.match(foundation, /unique \(regnr, checkpoint_code, cycle_key\)/i);
+  assert.match(foundation, /checkpoint_assessments is append-only/i);
+  assert.match(foundation, /before update on public\.checkpoint_assessments/i);
+  assert.match(foundation, /before delete on public\.checkpoint_assessments/i);
+  assert.match(foundation, /enable row level security/i);
+  assert.match(foundation, /revoke all on public\.checkpoint_definitions from public, anon, authenticated/i);
+  assert.match(foundation, /revoke all on public\.vehicle_checkpoints from public, anon, authenticated/i);
+  assert.match(foundation, /revoke all on public\.checkpoint_assessments from public, anon, authenticated/i);
+});
+
+test('checkpoint assessment is atomic with current projection and journey event', () => {
+  assert.match(foundation, /function public\.assess_vehicle_checkpoint/i);
+  assert.match(foundation, /for update/i);
+  assert.match(foundation, /insert into public\.checkpoint_assessments/i);
+  assert.match(foundation, /update public\.vehicle_checkpoints/i);
+  assert.match(foundation, /insert into public\.vehicle_journey_events/i);
+  assert.match(foundation, /'CHECKPOINT_ASSESSED'/);
+  assert.match(foundation, /to service_role/i);
+});
+
+test('checkpoint materialization is idempotent and appends creation to the vehicle journey', () => {
+  assert.match(instanceRpc, /function public\.ensure_vehicle_checkpoint/i);
+  assert.match(instanceRpc, /where checkpoint_code = upper\(trim\(p_checkpoint_code\)\)[\s\S]*and active/i);
+  assert.match(instanceRpc, /insert into public\.vehicle_checkpoints/i);
+  assert.match(instanceRpc, /'CHECKPOINT_CREATED'/);
+  assert.match(instanceRpc, /to service_role/i);
+});
+
+test('checkpoint API is authenticated and delegates writes to server-only RPCs', () => {
+  assert.match(api, /verifyApiUser\(request\)/);
+  assert.match(api, /vehicleExists/);
+  assert.match(api, /rpc\('ensure_vehicle_checkpoint'/);
+  assert.match(api, /rpc\('assess_vehicle_checkpoint'/);
+  assert.match(api, /Checkpoint not found for vehicle/);
+  assert.match(api, /Deviation requires a comment/);
+});

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -16,6 +16,7 @@ const protectedApiPaths = [
   '/api/notify',
   '/api/notify-arrival',
   '/api/notify-nybil',
+  '/api/vehicle-checkpoints?reg=GEU29F',
   '/api/vehicle-documents',
   '/api/vehicle-documents/00000000-0000-4000-8000-000000000000',
   '/api/vehicle-edits',


### PR DESCRIPTION
## Sammanfattning
- lägger ett generiskt kontrollpunktslager ovanpå befintlig fordonsresa och SALU
- versionsstyrda checkpoint-definitioner med domän, ägare, verifieringsläge och blockerande semantik
- materialiserar checkpoints per bil/cykel utan hård FK till `vehicles`
- append-only `checkpoint_assessments` för verifierade utfall
- atomisk bedömning: assessment + aktuell projection + `CHECKPOINT_ASSESSED` i fordonsresan
- idempotent materialisering med `CHECKPOINT_CREATED`
- autentiserat server-API `/api/vehicle-checkpoints`
- avvikelse kräver kommentar, `EVIDENCE_REQUIRED` kräver evidens vid godkännande
- server-only: RLS, inga browser-grants, RPC endast `service_role`

## Arkitektur
Detta duplicerar inte SALU-processen. SALU:s befintliga checkpoints ligger kvar; detta är det generiska kontraktet som senare kan användas av Nybil, Drift, Check-in, Service, SALU, Planering och Inköp. Bilens resa fortsätter vara faktalagret och checkpoint-assessments är verifierade utfall ovanpå den.

## Production
Migrationerna är applicerade. Inga definitioner, checkpoint-instanser eller assessments seedades: 0/0/0 efter migration. Behörigheterna är verifierade: `anon`/`authenticated` saknar execute, `service_role` har execute på båda RPC:erna.

## Test
- domänkontrakt och valideringsregler
- blockerande readiness
- versionsstyrning och append-only assessment-history
- atomiska assessment-writes
- idempotent checkpoint-materialisering
- API-auth boundary och RPC-delegering