### PR TITLE
Kontrollpunktsmotor: koppla Nybil, Check-in och SALU-källor

### DIFF
--- a/app/api/vehicle-checkpoints/sync/route.ts
+++ b/app/api/vehicle-checkpoints/sync/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+
+function cleanRegnr(value: unknown): string {
+  return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr: string) {
+  const [vehicle, nybil, checkin, salu] = await Promise.all([
+    admin.from('vehicles').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('nybil_inventering').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('checkins').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('salu_vehicle_state').select('regnr').eq('regnr', regnr).limit(1),
+  ]);
+
+  const failed = [vehicle, nybil, checkin, salu].find((response) => response.error);
+  if (failed?.error) throw failed.error;
+  return [vehicle, nybil, checkin, salu].some((response) => (response.data?.length ?? 0) > 0);
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const regnr = cleanRegnr(body.regnr ?? body.reg);
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-checkpoint-sync] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Checkpoint engine unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    const { data, error } = await admin.rpc('sync_vehicle_source_checkpoints', {
+      p_regnr: regnr,
+      p_actor_id: verification.user.id,
+      p_actor_email: verification.user.email,
+    });
+
+    if (error) {
+      if (error.code === '22023') {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+      if (error.code === 'P0002') {
+        return NextResponse.json({ error: 'Checkpoint source definitions unavailable' }, { status: 503 });
+      }
+      throw error;
+    }
+
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error('[vehicle-checkpoint-sync] Source synchronization failed:', error);
+    return NextResponse.json({ error: 'Could not synchronize source checkpoints' }, { status: 500 });
+  }
+}

--- a/migrations/20260820225411_seed_checkpoint_source_definitions_v1.sql
+++ b/migrations/20260820225411_seed_checkpoint_source_definitions_v1.sql
@@ -1,0 +1,64 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- First real source-backed checkpoints. These are deliberately narrow boundary
+-- facts: a source record exists and has reached the stated source status.
+-- They do not replace detailed SALU checkpoints or infer business quality.
+insert into public.checkpoint_definitions (
+  checkpoint_code,
+  definition_version,
+  domain,
+  title,
+  description,
+  owner_function,
+  verification_mode,
+  blocking,
+  trigger_type,
+  trigger_config,
+  active
+)
+values
+  (
+    'NYBIL_BASELINE_CAPTURED',
+    1,
+    'NYBIL',
+    'Nybil-baseline registrerad',
+    'Systemverifierad kontrollpunkt som visar att bilen har ett registrerat Nybil-startläge. Den bedömer inte om alla enskilda baselinefält är fullständiga.',
+    'BILKONTROLL',
+    'SYSTEM',
+    false,
+    'SOURCE_RECORD',
+    '{"sourceEntity":"nybil_inventering"}'::jsonb,
+    true
+  ),
+  (
+    'CHECKIN_COMPLETED',
+    1,
+    'CHECKIN',
+    'Check-in slutförd',
+    'Systemverifierad kontrollpunkt per slutförd Check-in. Varje Check-in behåller en egen cykel och källa.',
+    'BILKONTROLL',
+    'SYSTEM',
+    false,
+    'SOURCE_RECORD',
+    '{"sourceEntity":"checkins","requiredStatus":"COMPLETED"}'::jsonb,
+    true
+  ),
+  (
+    'SALU_CYCLE_CREATED',
+    1,
+    'SALU',
+    'SALU-cykel skapad',
+    'Systemverifierad gränskontrollpunkt för en skapad SALU-cykel. Den ersätter eller duplicerar inte SALU-checkpoints S00-S28.',
+    'BILKONTROLL',
+    'SYSTEM',
+    false,
+    'SOURCE_RECORD',
+    '{"sourceEntity":"salu_flags"}'::jsonb,
+    true
+  )
+on conflict (checkpoint_code, definition_version) do nothing;
+
+commit;

--- a/migrations/20260820225623_add_verified_checkpoint_source_adapter_v1.sql
+++ b/migrations/20260820225623_add_verified_checkpoint_source_adapter_v1.sql
@@ -1,0 +1,248 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Atomically materialize and verify one SYSTEM checkpoint from a concrete
+-- source record. Repeating the same source cycle is idempotent.
+create or replace function public.record_verified_source_checkpoint(
+  p_regnr text,
+  p_checkpoint_code text,
+  p_cycle_key text,
+  p_occurred_at timestamptz,
+  p_source_entity text,
+  p_source_record_id text,
+  p_source_journey_event_id uuid,
+  p_source_context jsonb,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_definition public.checkpoint_definitions%rowtype;
+  v_checkpoint public.vehicle_checkpoints%rowtype;
+  v_assessment_id uuid;
+  v_regnr text;
+  v_cycle_key text;
+  v_source_entity text;
+  v_source_record_id text;
+  v_source_context jsonb;
+  v_created boolean := false;
+  v_assessed boolean := false;
+begin
+  v_regnr := upper(regexp_replace(coalesce(p_regnr, ''), '\s+', '', 'g'));
+  v_cycle_key := coalesce(nullif(trim(p_cycle_key), ''), 'default');
+  v_source_entity := nullif(trim(p_source_entity), '');
+  v_source_record_id := nullif(trim(p_source_record_id), '');
+
+  if length(v_regnr) = 0 then
+    raise exception 'Invalid regnr' using errcode = '22023';
+  end if;
+
+  if p_occurred_at is null then
+    raise exception 'Source occurrence time is required' using errcode = '22023';
+  end if;
+
+  if v_source_entity is null or v_source_record_id is null then
+    raise exception 'Source identity is required' using errcode = '22023';
+  end if;
+
+  if pg_catalog.jsonb_typeof(coalesce(p_source_context, '{}'::jsonb)) <> 'object' then
+    raise exception 'Source context must be an object' using errcode = '22023';
+  end if;
+
+  select * into v_definition
+  from public.checkpoint_definitions
+  where checkpoint_code = upper(trim(p_checkpoint_code))
+    and active
+  order by definition_version desc
+  limit 1;
+
+  if not found then
+    raise exception 'Active checkpoint definition not found' using errcode = 'P0002';
+  end if;
+
+  if v_definition.verification_mode <> 'SYSTEM' then
+    raise exception 'Source adapter requires a SYSTEM checkpoint definition' using errcode = '22023';
+  end if;
+
+  v_source_context := coalesce(p_source_context, '{}'::jsonb)
+    || pg_catalog.jsonb_build_object(
+      'sourceEntity', v_source_entity,
+      'sourceRecordId', v_source_record_id,
+      'occurredAt', p_occurred_at
+    );
+
+  select * into v_checkpoint
+  from public.vehicle_checkpoints
+  where regnr = v_regnr
+    and checkpoint_code = v_definition.checkpoint_code
+    and cycle_key = v_cycle_key
+  for update;
+
+  if not found then
+    insert into public.vehicle_checkpoints (
+      regnr,
+      checkpoint_code,
+      definition_version,
+      cycle_key,
+      status,
+      source_journey_event_id,
+      source_context,
+      created_by,
+      updated_by
+    ) values (
+      v_regnr,
+      v_definition.checkpoint_code,
+      v_definition.definition_version,
+      v_cycle_key,
+      'VANTAR',
+      p_source_journey_event_id,
+      v_source_context,
+      p_actor_id,
+      p_actor_id
+    )
+    returning * into v_checkpoint;
+
+    v_created := true;
+
+    insert into public.vehicle_journey_events (
+      regnr,
+      event_type,
+      event_key,
+      occurred_at,
+      source_system,
+      source_entity,
+      source_record_id,
+      actor_id,
+      actor_source,
+      actor_email,
+      payload
+    ) values (
+      v_checkpoint.regnr,
+      'CHECKPOINT_CREATED',
+      'checkpoint-created:' || v_checkpoint.checkpoint_id::text,
+      p_occurred_at,
+      'CHECKPOINT_ENGINE',
+      v_source_entity,
+      v_source_record_id,
+      p_actor_id,
+      'SYSTEM',
+      p_actor_email,
+      pg_catalog.jsonb_build_object(
+        'checkpointId', v_checkpoint.checkpoint_id,
+        'checkpointCode', v_checkpoint.checkpoint_code,
+        'definitionVersion', v_checkpoint.definition_version,
+        'cycleKey', v_checkpoint.cycle_key,
+        'blocking', v_definition.blocking,
+        'verificationMode', v_definition.verification_mode,
+        'sourceContext', v_source_context
+      )
+    );
+  else
+    update public.vehicle_checkpoints
+    set source_journey_event_id = coalesce(source_journey_event_id, p_source_journey_event_id),
+        source_context = v_source_context,
+        updated_by = p_actor_id,
+        updated_at = pg_catalog.now()
+    where checkpoint_id = v_checkpoint.checkpoint_id
+    returning * into v_checkpoint;
+  end if;
+
+  if v_checkpoint.status <> 'GODKAND' then
+    insert into public.checkpoint_assessments (
+      checkpoint_id,
+      previous_status,
+      status,
+      comment,
+      evidence_refs,
+      actor_id,
+      actor_email,
+      actor_source,
+      assessed_at,
+      metadata
+    ) values (
+      v_checkpoint.checkpoint_id,
+      v_checkpoint.status,
+      'GODKAND',
+      null,
+      pg_catalog.jsonb_build_array(v_source_entity || ':' || v_source_record_id),
+      p_actor_id,
+      p_actor_email,
+      'SYSTEM',
+      p_occurred_at,
+      pg_catalog.jsonb_build_object('sourceContext', v_source_context)
+    )
+    returning assessment_id into v_assessment_id;
+
+    update public.vehicle_checkpoints
+    set status = 'GODKAND',
+        updated_by = p_actor_id,
+        updated_at = pg_catalog.now()
+    where checkpoint_id = v_checkpoint.checkpoint_id
+    returning * into v_checkpoint;
+
+    insert into public.vehicle_journey_events (
+      regnr,
+      event_type,
+      event_key,
+      occurred_at,
+      source_system,
+      source_entity,
+      source_record_id,
+      actor_id,
+      actor_source,
+      actor_email,
+      payload
+    ) values (
+      v_checkpoint.regnr,
+      'CHECKPOINT_ASSESSED',
+      'checkpoint-assessment:' || v_assessment_id::text,
+      p_occurred_at,
+      'CHECKPOINT_ENGINE',
+      v_source_entity,
+      v_source_record_id,
+      p_actor_id,
+      'SYSTEM',
+      p_actor_email,
+      pg_catalog.jsonb_build_object(
+        'assessmentId', v_assessment_id,
+        'checkpointId', v_checkpoint.checkpoint_id,
+        'checkpointCode', v_checkpoint.checkpoint_code,
+        'definitionVersion', v_checkpoint.definition_version,
+        'cycleKey', v_checkpoint.cycle_key,
+        'previousStatus', 'VANTAR',
+        'status', 'GODKAND',
+        'blocking', v_definition.blocking,
+        'verificationMode', v_definition.verification_mode,
+        'sourceContext', v_source_context
+      )
+    );
+
+    v_assessed := true;
+  end if;
+
+  return pg_catalog.jsonb_build_object(
+    'checkpoint_id', v_checkpoint.checkpoint_id,
+    'checkpoint_code', v_checkpoint.checkpoint_code,
+    'definition_version', v_checkpoint.definition_version,
+    'cycle_key', v_checkpoint.cycle_key,
+    'status', v_checkpoint.status,
+    'created', v_created,
+    'assessed', v_assessed,
+    'source_entity', v_source_entity,
+    'source_record_id', v_source_record_id
+  );
+end;
+$$;
+
+revoke all on function public.record_verified_source_checkpoint(text, text, text, timestamptz, text, text, uuid, jsonb, uuid, text)
+  from public, anon, authenticated;
+grant execute on function public.record_verified_source_checkpoint(text, text, text, timestamptz, text, text, uuid, jsonb, uuid, text)
+  to service_role;
+
+commit;

--- a/migrations/20260820230052_sync_and_harden_checkpoint_sources_v1.sql
+++ b/migrations/20260820230052_sync_and_harden_checkpoint_sources_v1.sql
@@ -1,0 +1,195 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Enforce verification semantics even for direct service-role inserts. A
+-- SYSTEM checkpoint may only be assessed from a verified system source.
+create or replace function public.enforce_checkpoint_assessment_verification_mode()
+returns trigger
+language plpgsql
+security invoker
+set search_path = pg_catalog
+as $$
+declare
+  v_verification_mode text;
+begin
+  select definition.verification_mode
+  into v_verification_mode
+  from public.vehicle_checkpoints checkpoint
+  join public.checkpoint_definitions definition
+    on definition.checkpoint_code = checkpoint.checkpoint_code
+   and definition.definition_version = checkpoint.definition_version
+  where checkpoint.checkpoint_id = new.checkpoint_id;
+
+  if not found then
+    raise exception 'Checkpoint definition not found for assessment' using errcode = 'P0002';
+  end if;
+
+  if v_verification_mode = 'SYSTEM' and new.actor_source <> 'SYSTEM' then
+    raise exception 'System checkpoint can only be assessed by a system source' using errcode = '22023';
+  end if;
+
+  if v_verification_mode = 'EVIDENCE_REQUIRED'
+     and new.status = 'GODKAND'
+     and pg_catalog.jsonb_array_length(coalesce(new.evidence_refs, '[]'::jsonb)) = 0 then
+    raise exception 'Approved checkpoint requires evidence' using errcode = '22023';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists checkpoint_assessments_verification_mode_insert
+  on public.checkpoint_assessments;
+create trigger checkpoint_assessments_verification_mode_insert
+before insert on public.checkpoint_assessments
+for each row execute function public.enforce_checkpoint_assessment_verification_mode();
+
+-- Synchronize all supported source facts for one vehicle in one database
+-- transaction. No source data is altered and no checkpoint is inferred without
+-- a concrete Nybil, completed Check-in or SALU flag record.
+create or replace function public.sync_vehicle_source_checkpoints(
+  p_regnr text,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_regnr text;
+  v_result jsonb;
+  v_total integer := 0;
+  v_created integer := 0;
+  v_assessed integer := 0;
+  v_nybil integer := 0;
+  v_checkins integer := 0;
+  v_salu_cycles integer := 0;
+  v_row record;
+begin
+  v_regnr := upper(regexp_replace(coalesce(p_regnr, ''), '\s+', '', 'g'));
+  if v_regnr !~ '^[A-Z]{3}[0-9]{2}[0-9A-Z]$' then
+    raise exception 'Invalid regnr' using errcode = '22023';
+  end if;
+
+  for v_row in
+    select id, created_at, updated_at
+    from public.nybil_inventering
+    where upper(regexp_replace(regnr, '\s+', '', 'g')) = v_regnr
+    order by created_at, id
+  loop
+    v_result := public.record_verified_source_checkpoint(
+      v_regnr,
+      'NYBIL_BASELINE_CAPTURED',
+      'nybil:' || v_row.id::text,
+      coalesce(v_row.created_at, v_row.updated_at, pg_catalog.now()),
+      'nybil_inventering',
+      v_row.id::text,
+      null,
+      pg_catalog.jsonb_build_object(
+        'sourceKind', 'NYBIL_BASELINE',
+        'sourceStatus', 'RECORDED'
+      ),
+      p_actor_id,
+      p_actor_email
+    );
+
+    v_total := v_total + 1;
+    v_nybil := v_nybil + 1;
+    if coalesce((v_result ->> 'created')::boolean, false) then v_created := v_created + 1; end if;
+    if coalesce((v_result ->> 'assessed')::boolean, false) then v_assessed := v_assessed + 1; end if;
+  end loop;
+
+  for v_row in
+    select id, completed_at, checker_name, checker_email, completed_by
+    from public.checkins
+    where upper(regexp_replace(regnr, '\s+', '', 'g')) = v_regnr
+      and status = 'COMPLETED'
+      and completed_at is not null
+    order by completed_at, id
+  loop
+    v_result := public.record_verified_source_checkpoint(
+      v_regnr,
+      'CHECKIN_COMPLETED',
+      'checkin:' || v_row.id::text,
+      v_row.completed_at,
+      'checkins',
+      v_row.id::text,
+      null,
+      pg_catalog.jsonb_build_object(
+        'sourceKind', 'CHECKIN',
+        'sourceStatus', 'COMPLETED',
+        'completedBy', v_row.completed_by,
+        'checkerName', v_row.checker_name,
+        'checkerEmail', v_row.checker_email
+      ),
+      p_actor_id,
+      p_actor_email
+    );
+
+    v_total := v_total + 1;
+    v_checkins := v_checkins + 1;
+    if coalesce((v_result ->> 'created')::boolean, false) then v_created := v_created + 1; end if;
+    if coalesce((v_result ->> 'assessed')::boolean, false) then v_assessed := v_assessed + 1; end if;
+  end loop;
+
+  for v_row in
+    select flag_id, cycle_saludatum, current_saludatum, status, owner_function, created_at
+    from public.salu_flags
+    where upper(regexp_replace(regnr, '\s+', '', 'g')) = v_regnr
+    order by created_at, flag_id
+  loop
+    v_result := public.record_verified_source_checkpoint(
+      v_regnr,
+      'SALU_CYCLE_CREATED',
+      'salu:' || v_row.flag_id::text,
+      v_row.created_at,
+      'salu_flags',
+      v_row.flag_id::text,
+      null,
+      pg_catalog.jsonb_build_object(
+        'sourceKind', 'SALU_CYCLE',
+        'sourceStatus', v_row.status,
+        'cycleSaludatum', v_row.cycle_saludatum,
+        'currentSaludatum', v_row.current_saludatum,
+        'ownerFunction', v_row.owner_function
+      ),
+      p_actor_id,
+      p_actor_email
+    );
+
+    v_total := v_total + 1;
+    v_salu_cycles := v_salu_cycles + 1;
+    if coalesce((v_result ->> 'created')::boolean, false) then v_created := v_created + 1; end if;
+    if coalesce((v_result ->> 'assessed')::boolean, false) then v_assessed := v_assessed + 1; end if;
+  end loop;
+
+  return pg_catalog.jsonb_build_object(
+    'regnr', v_regnr,
+    'sources', pg_catalog.jsonb_build_object(
+      'nybil', v_nybil,
+      'completedCheckins', v_checkins,
+      'saluCycles', v_salu_cycles,
+      'total', v_total
+    ),
+    'created', v_created,
+    'assessed', v_assessed,
+    'unchanged', v_total - v_assessed
+  );
+end;
+$$;
+
+revoke all on function public.enforce_checkpoint_assessment_verification_mode()
+  from public, anon, authenticated;
+revoke all on function public.sync_vehicle_source_checkpoints(text, uuid, text)
+  from public, anon, authenticated;
+
+grant execute on function public.enforce_checkpoint_assessment_verification_mode()
+  to service_role;
+grant execute on function public.sync_vehicle_source_checkpoints(text, uuid, text)
+  to service_role;
+
+commit;

--- a/tests/checkpoint-source-adapters.test.ts
+++ b/tests/checkpoint-source-adapters.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { NextRequest } from 'next/server';
+import { proxy } from '../proxy';
+
+const definitions = readFileSync(
+  join(process.cwd(), 'migrations/20260820225411_seed_checkpoint_source_definitions_v1.sql'),
+  'utf8',
+);
+const adapter = readFileSync(
+  join(process.cwd(), 'migrations/20260820225623_add_verified_checkpoint_source_adapter_v1.sql'),
+  'utf8',
+);
+const syncMigration = readFileSync(
+  join(process.cwd(), 'migrations/20260820230052_sync_and_harden_checkpoint_sources_v1.sql'),
+  'utf8',
+);
+const syncApi = readFileSync(
+  join(process.cwd(), 'app/api/vehicle-checkpoints/sync/route.ts'),
+  'utf8',
+);
+
+test('first source definitions are narrow versioned facts and do not duplicate SALU checkpoints', () => {
+  for (const checkpointCode of [
+    'NYBIL_BASELINE_CAPTURED',
+    'CHECKIN_COMPLETED',
+    'SALU_CYCLE_CREATED',
+  ]) {
+    assert.match(definitions, new RegExp(`'${checkpointCode}'`));
+  }
+
+  assert.match(definitions, /'NYBIL'[\s\S]*'CHECKIN'[\s\S]*'SALU'/);
+  assert.match(definitions, /'SYSTEM'/);
+  assert.match(definitions, /on conflict \(checkpoint_code, definition_version\) do nothing/i);
+  assert.doesNotMatch(definitions, /insert into public\.vehicle_checkpoints/i);
+  assert.doesNotMatch(definitions, /insert into public\.salu_checkpoints/i);
+});
+
+test('verified source adapter is atomic, idempotent and only accepts SYSTEM definitions', () => {
+  assert.match(adapter, /function public\.record_verified_source_checkpoint/i);
+  assert.match(adapter, /verification_mode <> 'SYSTEM'/i);
+  assert.match(adapter, /for update/i);
+  assert.match(adapter, /insert into public\.vehicle_checkpoints/i);
+  assert.match(adapter, /insert into public\.checkpoint_assessments/i);
+  assert.match(adapter, /'CHECKPOINT_CREATED'/);
+  assert.match(adapter, /'CHECKPOINT_ASSESSED'/);
+  assert.match(adapter, /actor_source[\s\S]*'SYSTEM'/i);
+  assert.match(adapter, /to service_role/i);
+});
+
+test('database blocks manual assessment of SYSTEM checkpoints and preserves evidence rules', () => {
+  assert.match(syncMigration, /function public\.enforce_checkpoint_assessment_verification_mode/i);
+  assert.match(syncMigration, /System checkpoint can only be assessed by a system source/);
+  assert.match(syncMigration, /before insert on public\.checkpoint_assessments/i);
+  assert.match(syncMigration, /Approved checkpoint requires evidence/);
+  assert.match(syncMigration, /from public, anon, authenticated/i);
+  assert.match(syncMigration, /to service_role/i);
+});
+
+test('vehicle source synchronization uses only concrete Nybil, completed Check-in and SALU records', () => {
+  assert.match(syncMigration, /function public\.sync_vehicle_source_checkpoints/i);
+  assert.match(syncMigration, /from public\.nybil_inventering/i);
+  assert.match(syncMigration, /from public\.checkins/i);
+  assert.match(syncMigration, /status = 'COMPLETED'/i);
+  assert.match(syncMigration, /completed_at is not null/i);
+  assert.match(syncMigration, /from public\.salu_flags/i);
+  assert.match(syncMigration, /'nybil:' \|\| v_row\.id::text/i);
+  assert.match(syncMigration, /'checkin:' \|\| v_row\.id::text/i);
+  assert.match(syncMigration, /'salu:' \|\| v_row\.flag_id::text/i);
+  assert.match(syncMigration, /record_verified_source_checkpoint/g);
+  assert.doesNotMatch(syncMigration, /insert into public\.salu_checkpoints/i);
+});
+
+test('source sync API is authenticated and delegates the whole vehicle sync to one server RPC', () => {
+  assert.match(syncApi, /verifyApiUser\(request\)/);
+  assert.match(syncApi, /vehicleExists/);
+  assert.match(syncApi, /rpc\('sync_vehicle_source_checkpoints'/);
+  assert.match(syncApi, /p_actor_id:\s*verification\.user\.id/);
+  assert.match(syncApi, /p_actor_email:\s*verification\.user\.email/);
+  assert.doesNotMatch(syncApi, /record_verified_source_checkpoint/);
+});
+
+test('checkpoint source synchronization stays behind the central API authentication boundary', async () => {
+  const response = await proxy(new NextRequest(
+    'http://localhost/api/vehicle-checkpoints/sync',
+    { method: 'POST' },
+  ));
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: 'Authentication required' });
+});


### PR DESCRIPTION
## Sammanfattning
- seedar de första tre verkliga, versionsstyrda source-checkpoints: `NYBIL_BASELINE_CAPTURED`, `CHECKIN_COMPLETED` och `SALU_CYCLE_CREATED`
- lägger en atomisk adapter som materialiserar och systemverifierar en checkpoint från en konkret källpost
- lägger en atomisk synk för ett registreringsnummer över Nybil, slutförda Check-ins och SALU-cykler
- varje källpost får egen cykelnyckel och kan synkas om utan dubletter
- skriver `CHECKPOINT_CREATED` och `CHECKPOINT_ASSESSED` i den append-only fordonsresan
- blockerar manuell bedömning av checkpoints med verifieringsläge `SYSTEM`
- lägger autentiserat server-API `/api/vehicle-checkpoints/sync`

## Avgränsning
- SALU:s befintliga checkpoints S00–S28 dupliceras eller flyttas inte
- källpunkterna bekräftar endast att en konkret källpost finns och har rätt status; de bedömer inte kvaliteten i hela formuläret
- inga historiska fordon backfillas automatiskt i denna release
- ingen hård FK till `vehicles` införs

## Production
Migrationerna är redan applicerade och synkade till repository.

Efter migration:
- 3 checkpoint-definitioner
- 0 fordonscheckpoints
- 0 assessments
- `anon`/`authenticated` saknar execute på source- och sync-RPC
- endast `service_role` har execute

## Test
- definitionernas smala source-semantik och SALU-avgränsning
- atomisk/idempotent source-adapter
- system-only-bedömningar och evidensregler
- synk endast från Nybil, `COMPLETED` Check-in och SALU-flaggor
- autentiserat API och central auth-boundary