### PR TITLE
Kontrollpunktsmotor: write-through från Nybil, Check-in och SALU

### DIFF
--- a/migrations/20260820231226_add_checkpoint_write_through_adapters_v1.sql
+++ b/migrations/20260820231226_add_checkpoint_write_through_adapters_v1.sql
@@ -1,0 +1,299 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Write-through must never make Nybil, Check-in or SALU unavailable. Failures
+-- are durable and can be repaired by the existing source synchronization RPC.
+create table public.checkpoint_write_through_failures (
+  failure_id uuid primary key default gen_random_uuid(),
+  regnr text not null check (length(trim(regnr)) > 0),
+  checkpoint_code text not null check (length(trim(checkpoint_code)) > 0),
+  cycle_key text not null check (length(trim(cycle_key)) > 0),
+  source_entity text not null check (length(trim(source_entity)) > 0),
+  source_record_id text not null check (length(trim(source_record_id)) > 0),
+  error_code text,
+  error_message text not null,
+  attempts integer not null default 1 check (attempts > 0),
+  first_failed_at timestamptz not null default now(),
+  last_failed_at timestamptz not null default now(),
+  resolved_at timestamptz,
+  unique (regnr, checkpoint_code, cycle_key, source_entity, source_record_id)
+);
+
+create index checkpoint_write_through_failures_unresolved_idx
+  on public.checkpoint_write_through_failures (last_failed_at, regnr)
+  where resolved_at is null;
+
+alter table public.checkpoint_write_through_failures enable row level security;
+revoke all on public.checkpoint_write_through_failures from public, anon, authenticated;
+grant select, insert, update, delete on public.checkpoint_write_through_failures to service_role;
+
+-- Mark durable failures resolved whenever either write-through or the repair
+-- synchronization reaches a GODKAND source checkpoint.
+create or replace function public.resolve_checkpoint_write_through_failure()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+begin
+  if new.status = 'GODKAND' then
+    update public.checkpoint_write_through_failures
+    set resolved_at = coalesce(resolved_at, pg_catalog.now())
+    where regnr = new.regnr
+      and checkpoint_code = new.checkpoint_code
+      and cycle_key = new.cycle_key
+      and source_entity = new.source_context ->> 'sourceEntity'
+      and source_record_id = new.source_context ->> 'sourceRecordId'
+      and resolved_at is null;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists checkpoint_write_through_failure_resolved_insert
+  on public.vehicle_checkpoints;
+create trigger checkpoint_write_through_failure_resolved_insert
+after insert on public.vehicle_checkpoints
+for each row execute function public.resolve_checkpoint_write_through_failure();
+
+drop trigger if exists checkpoint_write_through_failure_resolved_update
+  on public.vehicle_checkpoints;
+create trigger checkpoint_write_through_failure_resolved_update
+after update of status, source_context on public.vehicle_checkpoints
+for each row execute function public.resolve_checkpoint_write_through_failure();
+
+-- Safe wrapper around the strict source adapter. The source write remains the
+-- authority; a checkpoint failure is logged instead of rolling back the source.
+create or replace function public.try_record_verified_source_checkpoint(
+  p_regnr text,
+  p_checkpoint_code text,
+  p_cycle_key text,
+  p_occurred_at timestamptz,
+  p_source_entity text,
+  p_source_record_id text,
+  p_source_journey_event_id uuid,
+  p_source_context jsonb,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_regnr text;
+  v_checkpoint_code text;
+  v_cycle_key text;
+  v_source_entity text;
+  v_source_record_id text;
+  v_error_code text;
+  v_error_message text;
+begin
+  v_regnr := upper(regexp_replace(coalesce(p_regnr, ''), '\s+', '', 'g'));
+  v_checkpoint_code := upper(trim(coalesce(p_checkpoint_code, '')));
+  v_cycle_key := coalesce(nullif(trim(p_cycle_key), ''), 'default');
+  v_source_entity := coalesce(nullif(trim(p_source_entity), ''), 'UNKNOWN');
+  v_source_record_id := coalesce(nullif(trim(p_source_record_id), ''), 'UNKNOWN');
+
+  begin
+    perform public.record_verified_source_checkpoint(
+      p_regnr,
+      p_checkpoint_code,
+      p_cycle_key,
+      p_occurred_at,
+      p_source_entity,
+      p_source_record_id,
+      p_source_journey_event_id,
+      p_source_context,
+      p_actor_id,
+      p_actor_email
+    );
+
+    return true;
+  exception when others then
+    v_error_code := SQLSTATE;
+    v_error_message := SQLERRM;
+
+    begin
+      insert into public.checkpoint_write_through_failures as failure (
+        regnr,
+        checkpoint_code,
+        cycle_key,
+        source_entity,
+        source_record_id,
+        error_code,
+        error_message
+      ) values (
+        coalesce(nullif(v_regnr, ''), 'UNKNOWN'),
+        coalesce(nullif(v_checkpoint_code, ''), 'UNKNOWN'),
+        v_cycle_key,
+        v_source_entity,
+        v_source_record_id,
+        v_error_code,
+        pg_catalog.left(v_error_message, 2000)
+      )
+      on conflict (regnr, checkpoint_code, cycle_key, source_entity, source_record_id)
+      do update set
+        error_code = excluded.error_code,
+        error_message = excluded.error_message,
+        attempts = failure.attempts + 1,
+        last_failed_at = pg_catalog.now(),
+        resolved_at = null;
+    exception when others then
+      raise warning '[checkpoint-write-through] Could not persist failure for %.%: %',
+        v_source_entity,
+        v_source_record_id,
+        SQLERRM;
+    end;
+
+    raise warning '[checkpoint-write-through] %.% failed [%]: %',
+      v_source_entity,
+      v_source_record_id,
+      v_error_code,
+      v_error_message;
+
+    return false;
+  end;
+end;
+$$;
+
+create or replace function public.write_through_nybil_checkpoint()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+begin
+  perform public.try_record_verified_source_checkpoint(
+    new.regnr,
+    'NYBIL_BASELINE_CAPTURED',
+    'nybil:' || new.id::text,
+    coalesce(new.created_at, new.updated_at, pg_catalog.now()),
+    'nybil_inventering',
+    new.id::text,
+    null,
+    pg_catalog.jsonb_build_object(
+      'sourceKind', 'NYBIL_BASELINE',
+      'sourceStatus', 'RECORDED',
+      'registeredBy', new.registrerad_av,
+      'fullName', new.fullstandigt_namn
+    ),
+    auth.uid(),
+    nullif(trim(new.registrerad_av), '')
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function public.write_through_checkin_checkpoint()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+begin
+  if new.status <> 'COMPLETED' or new.completed_at is null then
+    return new;
+  end if;
+
+  perform public.try_record_verified_source_checkpoint(
+    new.regnr,
+    'CHECKIN_COMPLETED',
+    'checkin:' || new.id::text,
+    new.completed_at,
+    'checkins',
+    new.id::text,
+    null,
+    pg_catalog.jsonb_build_object(
+      'sourceKind', 'CHECKIN',
+      'sourceStatus', 'COMPLETED',
+      'completedBy', new.completed_by,
+      'checkerName', new.checker_name,
+      'checkerEmail', new.checker_email
+    ),
+    coalesce(new.completed_by, auth.uid()),
+    nullif(trim(new.checker_email), '')
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function public.write_through_salu_checkpoint()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+begin
+  perform public.try_record_verified_source_checkpoint(
+    new.regnr,
+    'SALU_CYCLE_CREATED',
+    'salu:' || new.flag_id::text,
+    coalesce(new.created_at, pg_catalog.now()),
+    'salu_flags',
+    new.flag_id::text,
+    null,
+    pg_catalog.jsonb_build_object(
+      'sourceKind', 'SALU_CYCLE',
+      'sourceStatus', new.status,
+      'cycleSaludatum', new.cycle_saludatum,
+      'currentSaludatum', new.current_saludatum,
+      'ownerFunction', new.owner_function
+    ),
+    coalesce(new.created_by, auth.uid()),
+    null
+  );
+
+  return new;
+end;
+$$;
+
+drop trigger if exists nybil_checkpoint_write_through
+  on public.nybil_inventering;
+create trigger nybil_checkpoint_write_through
+after insert or update on public.nybil_inventering
+for each row execute function public.write_through_nybil_checkpoint();
+
+drop trigger if exists checkin_checkpoint_write_through
+  on public.checkins;
+create trigger checkin_checkpoint_write_through
+after insert or update on public.checkins
+for each row
+when (new.status = 'COMPLETED' and new.completed_at is not null)
+execute function public.write_through_checkin_checkpoint();
+
+drop trigger if exists salu_checkpoint_write_through
+  on public.salu_flags;
+create trigger salu_checkpoint_write_through
+after insert on public.salu_flags
+for each row execute function public.write_through_salu_checkpoint();
+
+revoke all on function public.resolve_checkpoint_write_through_failure()
+  from public, anon, authenticated;
+revoke all on function public.try_record_verified_source_checkpoint(text, text, text, timestamptz, text, text, uuid, jsonb, uuid, text)
+  from public, anon, authenticated;
+revoke all on function public.write_through_nybil_checkpoint()
+  from public, anon, authenticated;
+revoke all on function public.write_through_checkin_checkpoint()
+  from public, anon, authenticated;
+revoke all on function public.write_through_salu_checkpoint()
+  from public, anon, authenticated;
+
+grant execute on function public.resolve_checkpoint_write_through_failure()
+  to service_role;
+grant execute on function public.try_record_verified_source_checkpoint(text, text, text, timestamptz, text, text, uuid, jsonb, uuid, text)
+  to service_role;
+grant execute on function public.write_through_nybil_checkpoint()
+  to service_role;
+grant execute on function public.write_through_checkin_checkpoint()
+  to service_role;
+grant execute on function public.write_through_salu_checkpoint()
+  to service_role;
+
+commit;

--- a/migrations/20260820231719_harden_checkpoint_write_through_actor_identity_v1.sql
+++ b/migrations/20260820231719_harden_checkpoint_write_through_actor_identity_v1.sql
@@ -1,0 +1,115 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Source display names stay in source_context. Actor email comes from verified
+-- JWT claims (or the canonical Check-in email) and is never populated with a name.
+create or replace function public.write_through_nybil_checkpoint()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+begin
+  perform public.try_record_verified_source_checkpoint(
+    new.regnr,
+    'NYBIL_BASELINE_CAPTURED',
+    'nybil:' || new.id::text,
+    coalesce(new.created_at, new.updated_at, pg_catalog.now()),
+    'nybil_inventering',
+    new.id::text,
+    null,
+    pg_catalog.jsonb_build_object(
+      'sourceKind', 'NYBIL_BASELINE',
+      'sourceStatus', 'RECORDED',
+      'registeredBy', new.registrerad_av,
+      'fullName', new.fullstandigt_namn
+    ),
+    auth.uid(),
+    nullif(auth.jwt() ->> 'email', '')
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function public.write_through_checkin_checkpoint()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+begin
+  if new.status <> 'COMPLETED' or new.completed_at is null then
+    return new;
+  end if;
+
+  perform public.try_record_verified_source_checkpoint(
+    new.regnr,
+    'CHECKIN_COMPLETED',
+    'checkin:' || new.id::text,
+    new.completed_at,
+    'checkins',
+    new.id::text,
+    null,
+    pg_catalog.jsonb_build_object(
+      'sourceKind', 'CHECKIN',
+      'sourceStatus', 'COMPLETED',
+      'completedBy', new.completed_by,
+      'checkerName', new.checker_name,
+      'checkerEmail', new.checker_email
+    ),
+    coalesce(new.completed_by, auth.uid()),
+    coalesce(nullif(trim(new.checker_email), ''), nullif(auth.jwt() ->> 'email', ''))
+  );
+
+  return new;
+end;
+$$;
+
+create or replace function public.write_through_salu_checkpoint()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+begin
+  perform public.try_record_verified_source_checkpoint(
+    new.regnr,
+    'SALU_CYCLE_CREATED',
+    'salu:' || new.flag_id::text,
+    coalesce(new.created_at, pg_catalog.now()),
+    'salu_flags',
+    new.flag_id::text,
+    null,
+    pg_catalog.jsonb_build_object(
+      'sourceKind', 'SALU_CYCLE',
+      'sourceStatus', new.status,
+      'cycleSaludatum', new.cycle_saludatum,
+      'currentSaludatum', new.current_saludatum,
+      'ownerFunction', new.owner_function
+    ),
+    coalesce(new.created_by, auth.uid()),
+    nullif(auth.jwt() ->> 'email', '')
+  );
+
+  return new;
+end;
+$$;
+
+revoke all on function public.write_through_nybil_checkpoint()
+  from public, anon, authenticated;
+revoke all on function public.write_through_checkin_checkpoint()
+  from public, anon, authenticated;
+revoke all on function public.write_through_salu_checkpoint()
+  from public, anon, authenticated;
+
+grant execute on function public.write_through_nybil_checkpoint()
+  to service_role;
+grant execute on function public.write_through_checkin_checkpoint()
+  to service_role;
+grant execute on function public.write_through_salu_checkpoint()
+  to service_role;
+
+commit;

--- a/tests/checkpoint-write-through-adapters.test.ts
+++ b/tests/checkpoint-write-through-adapters.test.ts
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const writeThrough = readFileSync(
+  join(process.cwd(), 'migrations/20260820231226_add_checkpoint_write_through_adapters_v1.sql'),
+  'utf8',
+);
+const actorIdentity = readFileSync(
+  join(process.cwd(), 'migrations/20260820231719_harden_checkpoint_write_through_actor_identity_v1.sql'),
+  'utf8',
+);
+const repairSync = readFileSync(
+  join(process.cwd(), 'migrations/20260820230052_sync_and_harden_checkpoint_sources_v1.sql'),
+  'utf8',
+);
+
+test('write-through adapters cover Nybil, completed Check-in and SALU creation', () => {
+  assert.match(writeThrough, /create trigger nybil_checkpoint_write_through[\s\S]*after insert or update on public\.nybil_inventering/i);
+  assert.match(writeThrough, /create trigger checkin_checkpoint_write_through[\s\S]*after insert or update on public\.checkins/i);
+  assert.match(writeThrough, /when \(new\.status = 'COMPLETED' and new\.completed_at is not null\)/i);
+  assert.match(writeThrough, /create trigger salu_checkpoint_write_through[\s\S]*after insert on public\.salu_flags/i);
+
+  assert.match(writeThrough, /'NYBIL_BASELINE_CAPTURED'/);
+  assert.match(writeThrough, /'CHECKIN_COMPLETED'/);
+  assert.match(writeThrough, /'SALU_CYCLE_CREATED'/);
+  assert.match(writeThrough, /'nybil:' \|\| new\.id::text/i);
+  assert.match(writeThrough, /'checkin:' \|\| new\.id::text/i);
+  assert.match(writeThrough, /'salu:' \|\| new\.flag_id::text/i);
+});
+
+test('source writes remain authoritative when checkpoint write-through fails', () => {
+  assert.match(writeThrough, /function public\.try_record_verified_source_checkpoint/i);
+  assert.match(writeThrough, /perform public\.record_verified_source_checkpoint/i);
+  assert.match(writeThrough, /exception when others/i);
+  assert.match(writeThrough, /insert into public\.checkpoint_write_through_failures as failure/i);
+  assert.match(writeThrough, /on conflict \(regnr, checkpoint_code, cycle_key, source_entity, source_record_id\)/i);
+  assert.match(writeThrough, /attempts = failure\.attempts \+ 1/i);
+  assert.match(writeThrough, /return false/i);
+  assert.doesNotMatch(writeThrough, /raise exception '\[checkpoint-write-through\]/i);
+});
+
+test('failed write-through is durable, server-only and repairable through source sync', () => {
+  assert.match(writeThrough, /create table public\.checkpoint_write_through_failures/i);
+  assert.match(writeThrough, /where resolved_at is null/i);
+  assert.match(writeThrough, /function public\.resolve_checkpoint_write_through_failure/i);
+  assert.match(writeThrough, /after update of status, source_context on public\.vehicle_checkpoints/i);
+  assert.match(writeThrough, /set resolved_at = coalesce\(resolved_at, pg_catalog\.now\(\)\)/i);
+  assert.match(writeThrough, /enable row level security/i);
+  assert.match(writeThrough, /revoke all on public\.checkpoint_write_through_failures from public, anon, authenticated/i);
+  assert.match(writeThrough, /grant select, insert, update, delete on public\.checkpoint_write_through_failures to service_role/i);
+
+  assert.match(repairSync, /function public\.sync_vehicle_source_checkpoints/i);
+  assert.match(repairSync, /record_verified_source_checkpoint/g);
+});
+
+test('write-through functions stay server-controlled while source-table triggers can invoke them', () => {
+  for (const functionName of [
+    'try_record_verified_source_checkpoint',
+    'write_through_nybil_checkpoint',
+    'write_through_checkin_checkpoint',
+    'write_through_salu_checkpoint',
+  ]) {
+    assert.match(
+      writeThrough,
+      new RegExp(`revoke all on function public\\.${functionName}[\\s\\S]*from public, anon, authenticated`, 'i'),
+    );
+    assert.match(
+      writeThrough,
+      new RegExp(`grant execute on function public\\.${functionName}[\\s\\S]*to service_role`, 'i'),
+    );
+  }
+
+  assert.match(writeThrough, /language plpgsql[\s\S]*security definer[\s\S]*set search_path = pg_catalog/i);
+});
+
+test('write-through actor identity never stores a display name in actor_email', () => {
+  assert.match(actorIdentity, /nullif\(auth\.jwt\(\) ->> 'email', ''\)/i);
+  assert.match(actorIdentity, /coalesce\(nullif\(trim\(new\.checker_email\), ''\), nullif\(auth\.jwt\(\) ->> 'email', ''\)\)/i);
+  assert.match(actorIdentity, /'registeredBy', new\.registrerad_av/i);
+  assert.match(actorIdentity, /'fullName', new\.fullstandigt_namn/i);
+  assert.doesNotMatch(actorIdentity, /nullif\(trim\(new\.registrerad_av\), ''\)/i);
+});
+
+test('write-through migration does not backfill historical source rows', () => {
+  assert.doesNotMatch(writeThrough, /from public\.nybil_inventering/i);
+  assert.doesNotMatch(writeThrough, /from public\.checkins/i);
+  assert.doesNotMatch(writeThrough, /from public\.salu_flags/i);
+  assert.doesNotMatch(writeThrough, /insert into public\.vehicle_checkpoints[\s\S]*select/i);
+});


### PR DESCRIPTION
## Sammanfattning
- skapar checkpoints direkt när en Nybil-post skrivs, en Check-in når `COMPLETED` eller en SALU-flagga skapas
- återanvänder den atomiska och idempotenta `record_verified_source_checkpoint`
- behåller synk-API:t som reparations- och avstämningsväg, inte primär skrivväg
- skriver fortsatt `CHECKPOINT_CREATED` och `CHECKPOINT_ASSESSED` i den append-only fordonsresan
- använder källpostens UUID som cykelnyckel, så upprepade updates inte skapar dubletter

## Felhantering
Källprocessen är fortsatt auktoritativ. Ett fel i checkpointlagret får inte blockera Nybil, Check-in eller SALU.

- write-through körs via en fail-open-wrapper
- felet loggas durabelt i server-only `checkpoint_write_through_failures`
- upprepade fel räknas på samma source/cycle
- lyckad write-through eller senare source-sync markerar felet löst

## Säkerhet
- triggerfunktionerna är `security definer` med låst `search_path`
- checkpoint- och fellager är fortsatt server-only
- `anon` och `authenticated` saknar direkt tabell- och funktionsaccess
- `service_role` har nödvändiga rättigheter
- aktörens e-post tas från verifierad JWT eller Check-ins kanoniska `checker_email`; displaynamn läggs endast i source context

## Production
Migrationerna är applicerade och repository-versionerna matchar Production.

Verifierat i rollback-baserade integrationstester mot Production:
- Nybil, Check-in och SALU skapade både checkpoint och SYSTEM-assessment i samma source-transaction
- en avsiktligt trasig checkpointdefinition blockerade inte Nybil-skrivningen och skapade en failure-post
- alla testtransaktioner rullades tillbaka; efter test: 0 checkpoints, 0 assessments, 0 failures och 0 test-SALU-rader

## Test
- triggerkontrakt för alla tre källor
- idempotenta source-cycle keys
- fail-open och durabel fellogg
- automatisk resolution via write-through/sync
- RLS och service-role-only
- verifierad actor identity
- ingen historisk backfill i migrationen