### PR TITLE
Vagnkort: visa generiska kontrollpunkter och verifierade utfall

### DIFF
--- a/app/api/vehicle-checkpoints/read-model/route.ts
+++ b/app/api/vehicle-checkpoints/read-model/route.ts
@@ -4,6 +4,33 @@ import { verifyApiUser } from '@/lib/server-auth';
 
 const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
 
+type AssessmentRow = {
+  assessment_id: string;
+  checkpoint_id: string;
+  previous_status: string;
+  status: string;
+  comment: string | null;
+  evidence_refs: unknown;
+  actor_id: string | null;
+  actor_email: string | null;
+  actor_source: string;
+  assessed_at: string;
+  metadata: unknown;
+};
+
+type JourneyEventRow = {
+  event_id: string;
+  event_type: string;
+  occurred_at: string;
+  source_system: string;
+  source_entity: string | null;
+  source_record_id: string | null;
+  actor_source: string;
+  actor_name: string | null;
+  actor_email: string | null;
+  payload: unknown;
+};
+
 function cleanRegnr(value: unknown): string {
   return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
 }
@@ -145,18 +172,21 @@ export async function GET(request: Request) {
       ]),
     );
 
-    const assessmentMap = new Map<string, (typeof assessmentResponse.data extends Array<infer T> ? T : never)>();
-    for (const assessment of assessmentResponse.data ?? []) {
-      const checkpointId = assessment.checkpoint_id as string;
-      if (!assessmentMap.has(checkpointId)) assessmentMap.set(checkpointId, assessment);
+    const assessments = (assessmentResponse.data ?? []) as AssessmentRow[];
+    const assessmentMap = new Map<string, AssessmentRow>();
+    for (const assessment of assessments) {
+      if (!assessmentMap.has(assessment.checkpoint_id)) {
+        assessmentMap.set(assessment.checkpoint_id, assessment);
+      }
     }
 
+    const checkpointJourneyEvents = (checkpointEventResponse.data ?? []) as JourneyEventRow[];
     const checkpointEventMap = new Map<string, {
-      created: (typeof checkpointEventResponse.data extends Array<infer T> ? T : never) | null;
-      assessed: (typeof checkpointEventResponse.data extends Array<infer T> ? T : never) | null;
+      created: JourneyEventRow | null;
+      assessed: JourneyEventRow | null;
     }>();
 
-    for (const event of checkpointEventResponse.data ?? []) {
+    for (const event of checkpointJourneyEvents) {
       const checkpointId = checkpointIdFromPayload(event.payload);
       if (!checkpointId) continue;
       const existing = checkpointEventMap.get(checkpointId) ?? { created: null, assessed: null };
@@ -165,8 +195,9 @@ export async function GET(request: Request) {
       checkpointEventMap.set(checkpointId, existing);
     }
 
+    const linkedEvents = (linkedEventResponse.data ?? []) as JourneyEventRow[];
     const linkedEventMap = new Map(
-      (linkedEventResponse.data ?? []).map((event) => [event.event_id as string, event]),
+      linkedEvents.map((event) => [event.event_id, event]),
     );
 
     const enriched = checkpointRows.map((checkpoint) => {

--- a/app/api/vehicle-checkpoints/read-model/route.ts
+++ b/app/api/vehicle-checkpoints/read-model/route.ts
@@ -1,0 +1,230 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+
+function cleanRegnr(value: unknown): string {
+  return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function checkpointIdFromPayload(payload: unknown): string | null {
+  return stringValue(asRecord(payload)?.checkpointId);
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr: string) {
+  const [vehicle, nybil, checkin, salu] = await Promise.all([
+    admin.from('vehicles').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('nybil_inventering').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('checkins').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('salu_vehicle_state').select('regnr').eq('regnr', regnr).limit(1),
+  ]);
+
+  const failed = [vehicle, nybil, checkin, salu].find((response) => response.error);
+  if (failed?.error) throw failed.error;
+  return [vehicle, nybil, checkin, salu].some((response) => (response.data?.length ?? 0) > 0);
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const regnr = cleanRegnr(new URL(request.url).searchParams.get('reg'));
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-checkpoint-read-model] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Checkpoint engine unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    const { data: checkpoints, error: checkpointError } = await admin
+      .from('vehicle_checkpoints')
+      .select('checkpoint_id,checkpoint_code,definition_version,cycle_key,status,due_at,source_journey_event_id,source_context,created_at,updated_at')
+      .eq('regnr', regnr)
+      .order('created_at', { ascending: false });
+
+    if (checkpointError) throw checkpointError;
+
+    const checkpointRows = checkpoints ?? [];
+    if (checkpointRows.length === 0) {
+      return NextResponse.json({
+        data: {
+          regnr,
+          summary: {
+            total: 0,
+            approved: 0,
+            waiting: 0,
+            deviations: 0,
+            notRelevant: 0,
+            blocking: 0,
+            unresolvedBlocking: 0,
+            verifiedOutcomes: 0,
+          },
+          checkpoints: [],
+        },
+      });
+    }
+
+    const checkpointIds = checkpointRows.map((row) => row.checkpoint_id as string);
+    const checkpointCodes = [...new Set(checkpointRows.map((row) => row.checkpoint_code as string))];
+    const linkedEventIds = checkpointRows
+      .map((row) => row.source_journey_event_id as string | null)
+      .filter((eventId): eventId is string => Boolean(eventId));
+
+    const [definitionResponse, assessmentResponse, checkpointEventResponse, linkedEventResponse] = await Promise.all([
+      admin
+        .from('checkpoint_definitions')
+        .select('checkpoint_code,definition_version,domain,title,description,owner_function,verification_mode,blocking')
+        .in('checkpoint_code', checkpointCodes),
+      admin
+        .from('checkpoint_assessments')
+        .select('assessment_id,checkpoint_id,previous_status,status,comment,evidence_refs,actor_id,actor_email,actor_source,assessed_at,metadata')
+        .in('checkpoint_id', checkpointIds)
+        .order('assessed_at', { ascending: false }),
+      admin
+        .from('vehicle_journey_events')
+        .select('event_id,event_type,occurred_at,source_system,source_entity,source_record_id,actor_source,actor_name,actor_email,payload')
+        .eq('regnr', regnr)
+        .eq('source_system', 'CHECKPOINT_ENGINE')
+        .in('event_type', ['CHECKPOINT_CREATED', 'CHECKPOINT_ASSESSED'])
+        .order('occurred_at', { ascending: false }),
+      linkedEventIds.length === 0
+        ? Promise.resolve({ data: [], error: null })
+        : admin
+            .from('vehicle_journey_events')
+            .select('event_id,event_type,occurred_at,source_system,source_entity,source_record_id,actor_source,actor_name,actor_email,payload')
+            .in('event_id', linkedEventIds),
+    ]);
+
+    const failed = [
+      ['definitions', definitionResponse.error],
+      ['assessments', assessmentResponse.error],
+      ['checkpoint events', checkpointEventResponse.error],
+      ['linked source events', linkedEventResponse.error],
+    ].find(([, error]) => error);
+    if (failed?.[1]) {
+      console.error(`[vehicle-checkpoint-read-model] ${failed[0]} query failed:`, failed[1]);
+      throw failed[1];
+    }
+
+    const definitionMap = new Map(
+      (definitionResponse.data ?? []).map((definition) => [
+        `${definition.checkpoint_code}:${definition.definition_version}`,
+        definition,
+      ]),
+    );
+
+    const assessmentMap = new Map<string, (typeof assessmentResponse.data extends Array<infer T> ? T : never)>();
+    for (const assessment of assessmentResponse.data ?? []) {
+      const checkpointId = assessment.checkpoint_id as string;
+      if (!assessmentMap.has(checkpointId)) assessmentMap.set(checkpointId, assessment);
+    }
+
+    const checkpointEventMap = new Map<string, {
+      created: (typeof checkpointEventResponse.data extends Array<infer T> ? T : never) | null;
+      assessed: (typeof checkpointEventResponse.data extends Array<infer T> ? T : never) | null;
+    }>();
+
+    for (const event of checkpointEventResponse.data ?? []) {
+      const checkpointId = checkpointIdFromPayload(event.payload);
+      if (!checkpointId) continue;
+      const existing = checkpointEventMap.get(checkpointId) ?? { created: null, assessed: null };
+      if (event.event_type === 'CHECKPOINT_CREATED' && !existing.created) existing.created = event;
+      if (event.event_type === 'CHECKPOINT_ASSESSED' && !existing.assessed) existing.assessed = event;
+      checkpointEventMap.set(checkpointId, existing);
+    }
+
+    const linkedEventMap = new Map(
+      (linkedEventResponse.data ?? []).map((event) => [event.event_id as string, event]),
+    );
+
+    const enriched = checkpointRows.map((checkpoint) => {
+      const definition = definitionMap.get(`${checkpoint.checkpoint_code}:${checkpoint.definition_version}`) ?? null;
+      const latestAssessment = assessmentMap.get(checkpoint.checkpoint_id as string) ?? null;
+      const checkpointEvents = checkpointEventMap.get(checkpoint.checkpoint_id as string) ?? {
+        created: null,
+        assessed: null,
+      };
+      const sourceContext = asRecord(checkpoint.source_context) ?? {};
+
+      return {
+        ...checkpoint,
+        definition,
+        latestAssessment,
+        source: {
+          kind: stringValue(sourceContext.sourceKind),
+          entity: stringValue(sourceContext.sourceEntity),
+          recordId: stringValue(sourceContext.sourceRecordId),
+          occurredAt: stringValue(sourceContext.occurredAt),
+          status: stringValue(sourceContext.sourceStatus),
+          context: sourceContext,
+          linkedJourneyEvent: checkpoint.source_journey_event_id
+            ? linkedEventMap.get(checkpoint.source_journey_event_id as string) ?? null
+            : null,
+        },
+        checkpointEvents,
+      };
+    });
+
+    const summary = enriched.reduce((totals, checkpoint) => {
+      totals.total += 1;
+      if (checkpoint.status === 'GODKAND') totals.approved += 1;
+      if (checkpoint.status === 'VANTAR') totals.waiting += 1;
+      if (checkpoint.status === 'AVVIKELSE') totals.deviations += 1;
+      if (checkpoint.status === 'EJ_RELEVANT') totals.notRelevant += 1;
+      if (checkpoint.latestAssessment) totals.verifiedOutcomes += 1;
+      if (checkpoint.definition?.blocking) {
+        totals.blocking += 1;
+        if (checkpoint.status === 'VANTAR' || checkpoint.status === 'AVVIKELSE') {
+          totals.unresolvedBlocking += 1;
+        }
+      }
+      return totals;
+    }, {
+      total: 0,
+      approved: 0,
+      waiting: 0,
+      deviations: 0,
+      notRelevant: 0,
+      blocking: 0,
+      unresolvedBlocking: 0,
+      verifiedOutcomes: 0,
+    });
+
+    return NextResponse.json({ data: { regnr, summary, checkpoints: enriched } });
+  } catch (error) {
+    console.error('[vehicle-checkpoint-read-model] Read failed:', error);
+    return NextResponse.json({ error: 'Could not load checkpoint read model' }, { status: 500 });
+  }
+}

--- a/app/vagnkort/generic-checkpoints-panel.tsx
+++ b/app/vagnkort/generic-checkpoints-panel.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type CheckpointSummary = {
+  total: number;
+  approved: number;
+  waiting: number;
+  deviations: number;
+  notRelevant: number;
+  blocking: number;
+  unresolvedBlocking: number;
+  verifiedOutcomes: number;
+};
+
+type CheckpointDefinition = {
+  checkpoint_code: string;
+  definition_version: number;
+  domain: string;
+  title: string;
+  description: string | null;
+  owner_function: string;
+  verification_mode: string;
+  blocking: boolean;
+};
+
+type CheckpointAssessment = {
+  assessment_id: string;
+  previous_status: string;
+  status: string;
+  comment: string | null;
+  evidence_refs: unknown[];
+  actor_email: string | null;
+  actor_source: string;
+  assessed_at: string;
+};
+
+type CheckpointEvent = {
+  event_id: string;
+  event_type: string;
+  occurred_at: string;
+  source_system: string;
+  source_entity: string | null;
+  source_record_id: string | null;
+  actor_source: string;
+  actor_name: string | null;
+  actor_email: string | null;
+};
+
+type GenericCheckpoint = {
+  checkpoint_id: string;
+  checkpoint_code: string;
+  definition_version: number;
+  cycle_key: string;
+  status: string;
+  due_at: string | null;
+  created_at: string;
+  updated_at: string;
+  definition: CheckpointDefinition | null;
+  latestAssessment: CheckpointAssessment | null;
+  source: {
+    kind: string | null;
+    entity: string | null;
+    recordId: string | null;
+    occurredAt: string | null;
+    status: string | null;
+    linkedJourneyEvent: CheckpointEvent | null;
+  };
+  checkpointEvents: {
+    created: CheckpointEvent | null;
+    assessed: CheckpointEvent | null;
+  };
+};
+
+type CheckpointReadModelResponse = {
+  data?: {
+    regnr: string;
+    summary: CheckpointSummary;
+    checkpoints: GenericCheckpoint[];
+  };
+  error?: string;
+};
+
+type SyncResponse = {
+  data?: {
+    created?: number;
+    assessed?: number;
+    unchanged?: number;
+  };
+  error?: string;
+};
+
+type Props = {
+  regnr: string;
+  refreshNonce: number;
+};
+
+const statusLabels: Record<string, string> = {
+  GODKAND: 'Godkänd',
+  VANTAR: 'Väntar',
+  AVVIKELSE: 'Avvikelse',
+  EJ_RELEVANT: 'Ej relevant',
+};
+
+const domainLabels: Record<string, string> = {
+  NYBIL: 'Nybil',
+  DRIFT: 'Drift',
+  CHECKIN: 'Check-in',
+  SERVICE: 'Service',
+  SALU: 'SALU',
+  PLANERING: 'Planering',
+  INKOP: 'Inköp',
+  OTHER: 'Övrigt',
+};
+
+const sourceLabels: Record<string, string> = {
+  nybil_inventering: 'Nybil-registrering',
+  checkins: 'Check-in',
+  salu_flags: 'SALU-cykel',
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return '—';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('sv-SE');
+}
+
+function shortId(value: string | null | undefined) {
+  if (!value) return '—';
+  return value.length > 18 ? `${value.slice(0, 8)}…${value.slice(-6)}` : value;
+}
+
+function statusStyle(status: string): React.CSSProperties {
+  if (status === 'GODKAND') return { background: '#e7f6eb', color: '#165c2e' };
+  if (status === 'AVVIKELSE') return { background: '#fde8e7', color: '#8a1f17' };
+  if (status === 'VANTAR') return { background: '#fff2db', color: '#704300' };
+  return { background: '#eeeeee', color: '#444444' };
+}
+
+export default function GenericCheckpointsPanel({ regnr, refreshNonce }: Props) {
+  const [data, setData] = useState<CheckpointReadModelResponse['data'] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [localRefreshNonce, setLocalRefreshNonce] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const response = await fetch(
+          `/api/vehicle-checkpoints/read-model?reg=${encodeURIComponent(regnr)}`,
+        );
+        const body = await response.json() as CheckpointReadModelResponse;
+        if (!response.ok || !body.data) {
+          throw new Error(body.error || 'Kunde inte hämta kontrollpunkterna');
+        }
+        if (!cancelled) setData(body.data);
+      } catch (err) {
+        if (!cancelled) {
+          setData(null);
+          setError(err instanceof Error ? err.message : 'Kunde inte hämta kontrollpunkterna');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setLoading(true);
+      setError('');
+      void load();
+    });
+
+    return () => { cancelled = true; };
+  }, [regnr, refreshNonce, localRefreshNonce]);
+
+  async function synchronizeSources() {
+    setSyncing(true);
+    setError('');
+    setMessage('');
+
+    try {
+      const response = await fetch('/api/vehicle-checkpoints/sync', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ regnr }),
+      });
+      const body = await response.json() as SyncResponse;
+      if (!response.ok) throw new Error(body.error || 'Kunde inte synkronisera kontrollpunkterna');
+
+      const created = body.data?.created ?? 0;
+      const assessed = body.data?.assessed ?? 0;
+      setMessage(created || assessed
+        ? `${created} kontrollpunkter skapades och ${assessed} utfall verifierades.`
+        : 'Kontrollpunkterna var redan synkroniserade.');
+      setLocalRefreshNonce((value) => value + 1);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Kunde inte synkronisera kontrollpunkterna');
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  return (
+    <div style={{ marginTop: '1.1rem', borderTop: '1px solid #e5e5e5', paddingTop: '1rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '.7rem', alignItems: 'start', flexWrap: 'wrap' }}>
+        <div>
+          <div style={{ fontWeight: 700 }}>Kontrollpunkter i fordonsresan</div>
+          <div style={{ color: '#666', fontSize: 13, marginTop: '.15rem' }}>
+            Generiska kontrollpunkter ovanpå Nybil, Check-in och SALU. SALU:s S00–S28 visas fortsatt separat.
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => void synchronizeSources()}
+          disabled={syncing}
+          style={{ border: '1px solid #bbb', borderRadius: 7, background: '#fff', padding: '.45rem .7rem', cursor: 'pointer', whiteSpace: 'nowrap' }}
+        >
+          {syncing ? 'Synkroniserar…' : 'Synkronisera källor'}
+        </button>
+      </div>
+
+      {loading && <p style={{ color: '#666' }}>Hämtar kontrollpunkter…</p>}
+      {error && <p style={{ color: '#a00' }}>{error}</p>}
+      {message && <p style={{ color: '#165c2e' }}>{message}</p>}
+
+      {!loading && data && (
+        <>
+          <div style={{ display: 'flex', gap: '.4rem', flexWrap: 'wrap', marginTop: '.75rem' }}>
+            <span style={{ background: '#eee', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>
+              {data.summary.total} totalt
+            </span>
+            <span style={{ background: '#e7f6eb', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>
+              {data.summary.approved} godkända
+            </span>
+            <span style={{ background: '#fff2db', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>
+              {data.summary.waiting} väntar
+            </span>
+            <span style={{ background: '#fde8e7', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>
+              {data.summary.deviations} avvikelser
+            </span>
+            <span style={{ background: '#eee', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>
+              {data.summary.verifiedOutcomes} verifierade utfall
+            </span>
+          </div>
+
+          {data.summary.unresolvedBlocking > 0 && (
+            <div style={{ background: '#fde8e7', borderRadius: 8, padding: '.65rem .75rem', marginTop: '.7rem' }}>
+              {data.summary.unresolvedBlocking} blockerande kontrollpunkter är fortfarande olösta.
+            </div>
+          )}
+
+          {data.checkpoints.length === 0 ? (
+            <div style={{ background: '#f6f6f6', borderRadius: 8, padding: '.7rem .75rem', marginTop: '.7rem', color: '#555' }}>
+              Inga generiska kontrollpunkter finns ännu. Nya källhändelser skrivs in automatiskt; äldre Nybil-, Check-in- och SALU-poster kan hämtas med synkroniseringen ovan.
+            </div>
+          ) : (
+            <div style={{ display: 'grid', gap: '.65rem', marginTop: '.8rem' }}>
+              {data.checkpoints.map((checkpoint) => {
+                const definition = checkpoint.definition;
+                const assessment = checkpoint.latestAssessment;
+                const sourceEvent = checkpoint.source.linkedJourneyEvent
+                  ?? checkpoint.checkpointEvents.assessed
+                  ?? checkpoint.checkpointEvents.created;
+                const blocking = definition?.blocking === true;
+
+                return (
+                  <article key={checkpoint.checkpoint_id} style={{ border: '1px solid #e4e4e4', borderRadius: 9, padding: '.75rem' }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: '.6rem', alignItems: 'start', flexWrap: 'wrap' }}>
+                      <div>
+                        <strong>{definition?.title ?? checkpoint.checkpoint_code}</strong>
+                        <div style={{ color: '#666', fontSize: 12, marginTop: '.15rem' }}>
+                          {domainLabels[definition?.domain ?? ''] ?? definition?.domain ?? 'Okänd domän'} · version {checkpoint.definition_version}
+                        </div>
+                      </div>
+                      <div style={{ display: 'flex', gap: '.35rem', flexWrap: 'wrap' }}>
+                        {blocking && (
+                          <span style={{ background: '#fde8e7', borderRadius: 999, padding: '.2rem .5rem', fontSize: 12, fontWeight: 700 }}>
+                            Blockerande
+                          </span>
+                        )}
+                        <span style={{ ...statusStyle(checkpoint.status), borderRadius: 999, padding: '.2rem .5rem', fontSize: 12, fontWeight: 700 }}>
+                          {statusLabels[checkpoint.status] ?? checkpoint.status}
+                        </span>
+                      </div>
+                    </div>
+
+                    {definition?.description && (
+                      <p style={{ margin: '.5rem 0 0', color: '#555', fontSize: 13 }}>{definition.description}</p>
+                    )}
+
+                    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))', gap: '.55rem', marginTop: '.65rem' }}>
+                      <div style={{ background: '#f7f7f7', borderRadius: 7, padding: '.55rem' }}>
+                        <div style={{ fontSize: 12, color: '#666', marginBottom: '.2rem' }}>Verifierat utfall</div>
+                        {assessment ? (
+                          <>
+                            <strong>{statusLabels[assessment.status] ?? assessment.status}</strong>
+                            <div style={{ fontSize: 12, color: '#666', marginTop: '.15rem' }}>
+                              {formatDate(assessment.assessed_at)} · {assessment.actor_source}
+                              {assessment.actor_email ? ` · ${assessment.actor_email}` : ''}
+                            </div>
+                            <div style={{ fontSize: 12, color: '#666', marginTop: '.15rem' }}>
+                              {assessment.evidence_refs.length} evidensreferenser
+                            </div>
+                            {assessment.comment && <div style={{ marginTop: '.3rem', fontSize: 13 }}>{assessment.comment}</div>}
+                          </>
+                        ) : (
+                          <span style={{ color: '#666', fontSize: 13 }}>Inget verifierat utfall ännu.</span>
+                        )}
+                      </div>
+
+                      <div style={{ background: '#f7f7f7', borderRadius: 7, padding: '.55rem' }}>
+                        <div style={{ fontSize: 12, color: '#666', marginBottom: '.2rem' }}>Källhändelse</div>
+                        <strong>{sourceLabels[checkpoint.source.entity ?? ''] ?? checkpoint.source.entity ?? 'Källa saknas'}</strong>
+                        <div style={{ fontSize: 12, color: '#666', marginTop: '.15rem' }}>
+                          {formatDate(checkpoint.source.occurredAt ?? sourceEvent?.occurred_at)}
+                          {checkpoint.source.status ? ` · ${checkpoint.source.status}` : ''}
+                        </div>
+                        <div style={{ fontSize: 12, color: '#666', marginTop: '.15rem' }}>
+                          Källpost: {shortId(checkpoint.source.recordId)}
+                        </div>
+                        {sourceEvent && (
+                          <div style={{ fontSize: 12, color: '#666', marginTop: '.15rem' }}>
+                            Fordonsresan: {sourceEvent.event_type} · {shortId(sourceEvent.event_id)}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    <div style={{ color: '#777', fontSize: 11, marginTop: '.5rem' }}>
+                      Cykel: {checkpoint.cycle_key} · Ägare: {definition?.owner_function ?? '—'} · Verifiering: {definition?.verification_mode ?? '—'}
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/vagnkort/journey-metrics-panel.tsx
+++ b/app/vagnkort/journey-metrics-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import GenericCheckpointsPanel from './generic-checkpoints-panel';
 
 type JourneyMetrics = {
   lifecycleStartAt: string | null;
@@ -157,6 +158,7 @@ export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
           ))}
         </div>
       )}
+      <GenericCheckpointsPanel regnr={regnr} refreshNonce={refreshNonce} />
     </div>
   );
 }

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -17,6 +17,7 @@ const protectedApiPaths = [
   '/api/notify-arrival',
   '/api/notify-nybil',
   '/api/vehicle-checkpoints?reg=GEU29F',
+  '/api/vehicle-checkpoints/read-model?reg=GEU29F',
   '/api/vehicle-documents',
   '/api/vehicle-documents/00000000-0000-4000-8000-000000000000',
   '/api/vehicle-edits',

--- a/tests/vagnkort-generic-checkpoints.test.ts
+++ b/tests/vagnkort-generic-checkpoints.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { NextRequest } from 'next/server';
+import { proxy } from '../proxy';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+const readModelApi = read('app/api/vehicle-checkpoints/read-model/route.ts');
+const panel = read('app/vagnkort/generic-checkpoints-panel.tsx');
+const metricsPanel = read('app/vagnkort/journey-metrics-panel.tsx');
+
+test('checkpoint read model enriches current status with definition, verified outcome and journey events', () => {
+  assert.match(readModelApi, /verifyApiUser\(request\)/);
+  assert.match(readModelApi, /vehicleExists/);
+  assert.match(readModelApi, /from\('vehicle_checkpoints'\)/);
+  assert.match(readModelApi, /from\('checkpoint_definitions'\)/);
+  assert.match(readModelApi, /from\('checkpoint_assessments'\)/);
+  assert.match(readModelApi, /from\('vehicle_journey_events'\)/);
+  assert.match(readModelApi, /CHECKPOINT_CREATED/);
+  assert.match(readModelApi, /CHECKPOINT_ASSESSED/);
+  assert.match(readModelApi, /latestAssessment/);
+  assert.match(readModelApi, /linkedJourneyEvent/);
+  assert.match(readModelApi, /checkpointEvents/);
+});
+
+test('checkpoint read model exposes blocking readiness without duplicating SALU checkpoints', () => {
+  assert.match(readModelApi, /unresolvedBlocking/);
+  assert.match(readModelApi, /checkpoint\.definition\?\.blocking/);
+  assert.match(readModelApi, /checkpoint\.status === 'VANTAR' \|\| checkpoint\.status === 'AVVIKELSE'/);
+  assert.doesNotMatch(readModelApi, /from\('salu_checkpoints'\)/);
+  assert.doesNotMatch(readModelApi, /insert\(/);
+});
+
+test('Vagnkort displays generic checkpoints, verified outcomes and source events', () => {
+  assert.match(metricsPanel, /GenericCheckpointsPanel/);
+  assert.match(metricsPanel, /<GenericCheckpointsPanel regnr=\{regnr\} refreshNonce=\{refreshNonce\} \/>/);
+  assert.match(panel, /Kontrollpunkter i fordonsresan/);
+  assert.match(panel, /Blockerande/);
+  assert.match(panel, /Verifierat utfall/);
+  assert.match(panel, /Källhändelse/);
+  assert.match(panel, /Fordonsresan:/);
+  assert.match(panel, /SALU:s S00–S28 visas fortsatt separat/);
+  assert.match(panel, /\/api\/vehicle-checkpoints\/read-model\?reg=/);
+});
+
+test('Vagnkort source synchronization is explicit and remains the repair path', () => {
+  assert.match(panel, /Synkronisera källor/);
+  assert.match(panel, /fetch\('\/api\/vehicle-checkpoints\/sync'/);
+  assert.match(panel, /method:\s*'POST'/);
+  assert.match(panel, /JSON\.stringify\(\{ regnr \}\)/);
+  assert.doesNotMatch(readModelApi, /sync_vehicle_source_checkpoints/);
+});
+
+test('checkpoint read model stays behind the central API authentication boundary', async () => {
+  const response = await proxy(new NextRequest(
+    'http://localhost/api/vehicle-checkpoints/read-model?reg=GEU29F',
+  ));
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: 'Authentication required' });
+});

--- a/tests/vagnkort-generic-checkpoints.test.ts
+++ b/tests/vagnkort-generic-checkpoints.test.ts
@@ -12,6 +12,7 @@ const metricsPanel = read('app/vagnkort/journey-metrics-panel.tsx');
 
 test('checkpoint read model enriches current status with definition, verified outcome and journey events', () => {
   assert.match(readModelApi, /verifyApiUser\(request\)/);
+  assert.match(readModelApi, /SUPABASE_SERVICE_ROLE_KEY/);
   assert.match(readModelApi, /vehicleExists/);
   assert.match(readModelApi, /from\('vehicle_checkpoints'\)/);
   assert.match(readModelApi, /from\('checkpoint_definitions'\)/);
@@ -22,6 +23,7 @@ test('checkpoint read model enriches current status with definition, verified ou
   assert.match(readModelApi, /latestAssessment/);
   assert.match(readModelApi, /linkedJourneyEvent/);
   assert.match(readModelApi, /checkpointEvents/);
+  assert.doesNotMatch(readModelApi, /\.(insert|update|upsert|delete)\(/);
 });
 
 test('checkpoint read model exposes blocking readiness without duplicating SALU checkpoints', () => {


### PR DESCRIPTION
## Sammanfattning
- lägger ett autentiserat checkpoint-read model-API för Vagnkortet
- läser generiska fordonscheckpoints tillsammans med versionsdefinition, senaste verifierade assessment och fordonsrese-händelser
- visar blockerande status, verifierat utfall, evidensantal, källa och source/cycle-identitet
- visar summering för godkända, väntande, avvikelser och olösta blockerande punkter
- håller SALU:s befintliga S00–S28 separat och duplicerar inte SALU-domänen
- erbjuder explicit `Synkronisera källor` för historiska/avstämningsfall; läsning muterar aldrig data

## Källhändelse
Panelen visar i första hand en direkt länkad journey-event när den finns. Annars visas checkpointens senaste `CHECKPOINT_ASSESSED`/`CHECKPOINT_CREATED` tillsammans med den konkreta Nybil-, Check-in- eller SALU-källposten.

## Säkerhet
- read model använder `verifyApiUser`
- all databasläsning sker server-side med service role
- ingen ny browser-grant eller Production-schemaändring
- synkningen använder befintligt autentiserat server-API

## Test
- read model-kontrakt för definition, assessment och journey-events
- blockerande readiness och SALU-avgränsning
- UI-kontrakt för status, verifierat utfall och källhändelse
- explicit sync som reparationsväg, inte mutation vid GET
- central auth-boundary för det nya API:t