### PR TITLE
Kontrollpunktsmotor: åtgärder, ansvar och ny verifiering

### DIFF
--- a/app/api/checkpoint-actions/read-model/route.ts
+++ b/app/api/checkpoint-actions/read-model/route.ts
@@ -1,0 +1,228 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+
+type CheckpointRow = {
+  checkpoint_id: string;
+  checkpoint_code: string;
+  definition_version: number;
+  status: string;
+};
+
+type ActionRow = {
+  action_id: string;
+  checkpoint_id: string;
+  source_assessment_id: string;
+  title: string;
+  description: string | null;
+  owner_function: string;
+  owner_ref: string | null;
+  deadline_at: string;
+  blocking: boolean;
+  status: string;
+  outcome: string | null;
+  outcome_comment: string | null;
+  verification_assessment_id: string | null;
+  created_by_email: string | null;
+  created_at: string;
+  accepted_at: string | null;
+  ready_for_verification_at: string | null;
+  verified_at: string | null;
+  cancelled_at: string | null;
+  cancel_reason: string | null;
+  updated_by_email: string | null;
+  updated_at: string;
+};
+
+type ActionEventRow = {
+  action_event_id: string;
+  action_id: string;
+  checkpoint_id: string;
+  event_type: string;
+  previous_status: string | null;
+  status: string;
+  comment: string | null;
+  actor_email: string | null;
+  actor_source: string;
+  occurred_at: string;
+  payload: unknown;
+};
+
+function cleanRegnr(value: unknown): string {
+  return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr: string) {
+  const [vehicle, nybil, checkin, salu] = await Promise.all([
+    admin.from('vehicles').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('nybil_inventering').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('checkins').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('salu_vehicle_state').select('regnr').eq('regnr', regnr).limit(1),
+  ]);
+
+  const failed = [vehicle, nybil, checkin, salu].find((response) => response.error);
+  if (failed?.error) throw failed.error;
+
+  return [vehicle, nybil, checkin, salu]
+    .some((response) => (response.data?.length ?? 0) > 0);
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const regnr = cleanRegnr(new URL(request.url).searchParams.get('reg'));
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[checkpoint-action-read-model] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Checkpoint actions unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    const { data: checkpointData, error: checkpointError } = await admin
+      .from('vehicle_checkpoints')
+      .select('checkpoint_id,checkpoint_code,definition_version,status')
+      .eq('regnr', regnr);
+
+    if (checkpointError) throw checkpointError;
+
+    const checkpoints = (checkpointData ?? []) as CheckpointRow[];
+    if (checkpoints.length === 0) {
+      return NextResponse.json({
+        data: {
+          regnr,
+          summary: {
+            total: 0,
+            open: 0,
+            overdue: 0,
+            blockingOpen: 0,
+            readyForVerification: 0,
+            verified: 0,
+            cancelled: 0,
+          },
+          actions: [],
+        },
+      });
+    }
+
+    const checkpointIds = checkpoints.map((checkpoint) => checkpoint.checkpoint_id);
+    const checkpointCodes = [...new Set(checkpoints.map((checkpoint) => checkpoint.checkpoint_code))];
+
+    const [actionResponse, definitionResponse] = await Promise.all([
+      admin
+        .from('checkpoint_actions')
+        .select('action_id,checkpoint_id,source_assessment_id,title,description,owner_function,owner_ref,deadline_at,blocking,status,outcome,outcome_comment,verification_assessment_id,created_by_email,created_at,accepted_at,ready_for_verification_at,verified_at,cancelled_at,cancel_reason,updated_by_email,updated_at')
+        .in('checkpoint_id', checkpointIds)
+        .order('created_at', { ascending: false }),
+      admin
+        .from('checkpoint_definitions')
+        .select('checkpoint_code,definition_version,domain,title,owner_function,blocking')
+        .in('checkpoint_code', checkpointCodes),
+    ]);
+
+    if (actionResponse.error) throw actionResponse.error;
+    if (definitionResponse.error) throw definitionResponse.error;
+
+    const actions = (actionResponse.data ?? []) as ActionRow[];
+    const actionIds = actions.map((action) => action.action_id);
+
+    const { data: eventData, error: eventError } = actionIds.length === 0
+      ? { data: [], error: null }
+      : await admin
+          .from('checkpoint_action_events')
+          .select('action_event_id,action_id,checkpoint_id,event_type,previous_status,status,comment,actor_email,actor_source,occurred_at,payload')
+          .in('action_id', actionIds)
+          .order('occurred_at', { ascending: false });
+
+    if (eventError) throw eventError;
+
+    const checkpointMap = new Map(
+      checkpoints.map((checkpoint) => [checkpoint.checkpoint_id, checkpoint]),
+    );
+    const definitionMap = new Map(
+      (definitionResponse.data ?? []).map((definition) => [
+        `${definition.checkpoint_code}:${definition.definition_version}`,
+        definition,
+      ]),
+    );
+
+    const eventsByAction = new Map<string, ActionEventRow[]>();
+    for (const event of (eventData ?? []) as ActionEventRow[]) {
+      const existing = eventsByAction.get(event.action_id) ?? [];
+      existing.push(event);
+      eventsByAction.set(event.action_id, existing);
+    }
+
+    const now = Date.now();
+    const enriched = actions.map((action) => {
+      const checkpoint = checkpointMap.get(action.checkpoint_id) ?? null;
+      const definition = checkpoint
+        ? definitionMap.get(`${checkpoint.checkpoint_code}:${checkpoint.definition_version}`) ?? null
+        : null;
+      const terminal = action.status === 'VERIFIED' || action.status === 'CANCELLED';
+      const deadline = new Date(action.deadline_at).getTime();
+
+      return {
+        ...action,
+        overdue: !terminal && Number.isFinite(deadline) && deadline < now,
+        checkpoint: checkpoint
+          ? {
+              ...checkpoint,
+              definition,
+            }
+          : null,
+        events: eventsByAction.get(action.action_id) ?? [],
+      };
+    });
+
+    const summary = enriched.reduce((totals, action) => {
+      totals.total += 1;
+      if (action.status === 'VERIFIED') totals.verified += 1;
+      if (action.status === 'CANCELLED') totals.cancelled += 1;
+      if (action.status === 'READY_FOR_VERIFICATION') totals.readyForVerification += 1;
+      if (action.overdue) totals.overdue += 1;
+      if (action.status !== 'VERIFIED' && action.status !== 'CANCELLED') {
+        totals.open += 1;
+        if (action.blocking) totals.blockingOpen += 1;
+      }
+      return totals;
+    }, {
+      total: 0,
+      open: 0,
+      overdue: 0,
+      blockingOpen: 0,
+      readyForVerification: 0,
+      verified: 0,
+      cancelled: 0,
+    });
+
+    return NextResponse.json({ data: { regnr, summary, actions: enriched } });
+  } catch (error) {
+    console.error('[checkpoint-action-read-model] Read failed:', error);
+    return NextResponse.json({ error: 'Could not load checkpoint actions' }, { status: 500 });
+  }
+}

--- a/app/api/checkpoint-actions/route.ts
+++ b/app/api/checkpoint-actions/route.ts
@@ -1,0 +1,289 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const TRANSITION_STATUSES = [
+  'ACCEPTED',
+  'IN_PROGRESS',
+  'READY_FOR_VERIFICATION',
+  'CANCELLED',
+] as const;
+
+const ACTION_OUTCOMES = [
+  'ATGARDAD',
+  'ACCEPTERAD_AVVIKELSE',
+  'EJ_RELEVANT',
+  'FORTSATT_AVVIKELSE',
+] as const;
+
+function cleanRegnr(value: unknown): string {
+  return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
+}
+
+function cleanUuid(value: unknown): string | null {
+  return typeof value === 'string' && UUID_RE.test(value.trim()) ? value.trim() : null;
+}
+
+function cleanText(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  return value.trim().slice(0, maxLength);
+}
+
+function cleanTimestamp(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+function cleanEvidenceRefs(value: unknown): string[] | undefined {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value) || value.length > 50) return undefined;
+
+  const refs = value.map((entry) => {
+    if (typeof entry !== 'string') return null;
+    const cleaned = entry.trim().slice(0, 300);
+    return cleaned || null;
+  });
+
+  return refs.some((entry) => entry === null) ? undefined : refs as string[];
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr: string) {
+  const [vehicle, nybil, checkin, salu] = await Promise.all([
+    admin.from('vehicles').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('nybil_inventering').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('checkins').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('salu_vehicle_state').select('regnr').eq('regnr', regnr).limit(1),
+  ]);
+
+  const failed = [vehicle, nybil, checkin, salu].find((response) => response.error);
+  if (failed?.error) throw failed.error;
+
+  return [vehicle, nybil, checkin, salu]
+    .some((response) => (response.data?.length ?? 0) > 0);
+}
+
+async function checkpointBelongsToVehicle(
+  admin: ReturnType<typeof createAdminClient>,
+  checkpointId: string,
+  regnr: string,
+) {
+  const { data, error } = await admin
+    .from('vehicle_checkpoints')
+    .select('checkpoint_id')
+    .eq('checkpoint_id', checkpointId)
+    .eq('regnr', regnr)
+    .maybeSingle();
+
+  if (error) throw error;
+  return Boolean(data);
+}
+
+async function actionBelongsToVehicle(
+  admin: ReturnType<typeof createAdminClient>,
+  actionId: string,
+  regnr: string,
+) {
+  const { data: action, error: actionError } = await admin
+    .from('checkpoint_actions')
+    .select('checkpoint_id')
+    .eq('action_id', actionId)
+    .maybeSingle();
+
+  if (actionError) throw actionError;
+  if (!action) return false;
+
+  return checkpointBelongsToVehicle(admin, action.checkpoint_id, regnr);
+}
+
+function rpcErrorResponse(error: { code?: string; message?: string }) {
+  if (error.code === '22023') {
+    return NextResponse.json({ error: error.message || 'Invalid action input' }, { status: 400 });
+  }
+  if (error.code === 'P0002') {
+    return NextResponse.json({ error: error.message || 'Action context not found' }, { status: 404 });
+  }
+  if (error.code === 'P0001') {
+    return NextResponse.json({ error: error.message || 'Action state conflict' }, { status: 409 });
+  }
+  return null;
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const regnr = cleanRegnr(body.regnr ?? body.reg);
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  const action = typeof body.action === 'string' ? body.action.trim().toUpperCase() : '';
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[checkpoint-actions] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Checkpoint actions unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    if (action === 'CREATE') {
+      const checkpointId = cleanUuid(body.checkpointId);
+      const title = cleanText(body.title, 200);
+      const description = cleanText(body.description, 1000);
+      const ownerFunction = cleanText(body.ownerFunction, 120);
+      const ownerRef = cleanText(body.ownerRef, 200);
+      const deadlineAt = cleanTimestamp(body.deadlineAt);
+      const blocking = body.blocking === undefined ? true : body.blocking === true;
+
+      if (!checkpointId) {
+        return NextResponse.json({ error: 'Invalid checkpoint id' }, { status: 400 });
+      }
+      if (!(await checkpointBelongsToVehicle(admin, checkpointId, regnr))) {
+        return NextResponse.json({ error: 'Checkpoint not found for vehicle' }, { status: 404 });
+      }
+      if (!title) {
+        return NextResponse.json({ error: 'Action title is required' }, { status: 400 });
+      }
+      if (!ownerFunction) {
+        return NextResponse.json({ error: 'Action owner function is required' }, { status: 400 });
+      }
+      if (!deadlineAt) {
+        return NextResponse.json({ error: 'Valid action deadline is required' }, { status: 400 });
+      }
+
+      const { data, error } = await admin.rpc('create_checkpoint_action', {
+        p_checkpoint_id: checkpointId,
+        p_title: title,
+        p_description: description,
+        p_owner_function: ownerFunction,
+        p_owner_ref: ownerRef,
+        p_deadline_at: deadlineAt,
+        p_blocking: blocking,
+        p_actor_id: verification.user.id,
+        p_actor_email: verification.user.email,
+      });
+
+      if (error) {
+        const response = rpcErrorResponse(error);
+        if (response) return response;
+        throw error;
+      }
+
+      return NextResponse.json({ data }, { status: 201 });
+    }
+
+    if (action === 'TRANSITION') {
+      const actionId = cleanUuid(body.actionId);
+      const nextStatus = typeof body.nextStatus === 'string'
+        ? body.nextStatus.trim().toUpperCase()
+        : '';
+      const comment = cleanText(body.comment, 1000);
+
+      if (!actionId) {
+        return NextResponse.json({ error: 'Invalid action id' }, { status: 400 });
+      }
+      if (!TRANSITION_STATUSES.includes(nextStatus as (typeof TRANSITION_STATUSES)[number])) {
+        return NextResponse.json({ error: 'Invalid action transition status' }, { status: 400 });
+      }
+      if (!(await actionBelongsToVehicle(admin, actionId, regnr))) {
+        return NextResponse.json({ error: 'Checkpoint action not found for vehicle' }, { status: 404 });
+      }
+      if (nextStatus === 'CANCELLED' && !comment) {
+        return NextResponse.json({ error: 'Cancellation requires a reason' }, { status: 400 });
+      }
+
+      const { data, error } = await admin.rpc('transition_checkpoint_action', {
+        p_action_id: actionId,
+        p_next_status: nextStatus,
+        p_comment: comment,
+        p_actor_id: verification.user.id,
+        p_actor_email: verification.user.email,
+      });
+
+      if (error) {
+        const response = rpcErrorResponse(error);
+        if (response) return response;
+        throw error;
+      }
+
+      return NextResponse.json({ data });
+    }
+
+    if (action === 'VERIFY') {
+      const actionId = cleanUuid(body.actionId);
+      const outcome = typeof body.outcome === 'string' ? body.outcome.trim().toUpperCase() : '';
+      const comment = cleanText(body.comment, 1000);
+      const evidenceRefs = cleanEvidenceRefs(body.evidenceRefs);
+
+      if (!actionId) {
+        return NextResponse.json({ error: 'Invalid action id' }, { status: 400 });
+      }
+      if (!ACTION_OUTCOMES.includes(outcome as (typeof ACTION_OUTCOMES)[number])) {
+        return NextResponse.json({ error: 'Invalid action outcome' }, { status: 400 });
+      }
+      if (!(await actionBelongsToVehicle(admin, actionId, regnr))) {
+        return NextResponse.json({ error: 'Checkpoint action not found for vehicle' }, { status: 404 });
+      }
+      if (evidenceRefs === undefined) {
+        return NextResponse.json({ error: 'Invalid evidence refs' }, { status: 400 });
+      }
+      if (
+        (outcome === 'ACCEPTERAD_AVVIKELSE' || outcome === 'FORTSATT_AVVIKELSE')
+        && !comment
+      ) {
+        return NextResponse.json({ error: 'Selected outcome requires a comment' }, { status: 400 });
+      }
+
+      const { data, error } = await admin.rpc('verify_checkpoint_action', {
+        p_action_id: actionId,
+        p_outcome: outcome,
+        p_comment: comment,
+        p_evidence_refs: evidenceRefs,
+        p_actor_id: verification.user.id,
+        p_actor_email: verification.user.email,
+      });
+
+      if (error) {
+        const response = rpcErrorResponse(error);
+        if (response) return response;
+        throw error;
+      }
+
+      return NextResponse.json({ data });
+    }
+
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 });
+  } catch (error) {
+    console.error('[checkpoint-actions] Operation failed:', error);
+    return NextResponse.json({ error: 'Checkpoint action operation failed' }, { status: 500 });
+  }
+}

--- a/app/vagnkort/checkpoint-actions-panel.tsx
+++ b/app/vagnkort/checkpoint-actions-panel.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+type CheckpointOption = {
+  checkpoint_id: string;
+  checkpoint_code: string;
+  status: string;
+  definition: {
+    title: string;
+    domain: string;
+  } | null;
+};
+
+type ActionEvent = {
+  action_event_id: string;
+  event_type: string;
+  previous_status: string | null;
+  status: string;
+  comment: string | null;
+  actor_email: string | null;
+  actor_source: string;
+  occurred_at: string;
+};
+
+type CheckpointAction = {
+  action_id: string;
+  checkpoint_id: string;
+  title: string;
+  description: string | null;
+  owner_function: string;
+  owner_ref: string | null;
+  deadline_at: string;
+  blocking: boolean;
+  status: string;
+  outcome: string | null;
+  outcome_comment: string | null;
+  created_at: string;
+  accepted_at: string | null;
+  ready_for_verification_at: string | null;
+  verified_at: string | null;
+  cancelled_at: string | null;
+  cancel_reason: string | null;
+  overdue: boolean;
+  checkpoint: {
+    checkpoint_id: string;
+    checkpoint_code: string;
+    status: string;
+    definition: {
+      title: string;
+      domain: string;
+    } | null;
+  } | null;
+  events: ActionEvent[];
+};
+
+type ActionReadModel = {
+  regnr: string;
+  summary: {
+    total: number;
+    open: number;
+    overdue: number;
+    blockingOpen: number;
+    readyForVerification: number;
+    verified: number;
+    cancelled: number;
+  };
+  actions: CheckpointAction[];
+};
+
+type Props = {
+  regnr: string;
+  checkpoints: CheckpointOption[];
+  refreshNonce: number;
+  onChanged?: () => void;
+};
+
+const actionStatusLabels: Record<string, string> = {
+  CREATED: 'Skapad',
+  ACCEPTED: 'Accepterad',
+  IN_PROGRESS: 'Pågår',
+  READY_FOR_VERIFICATION: 'Klar för verifiering',
+  VERIFIED: 'Verifierad',
+  CANCELLED: 'Avbruten',
+};
+
+const outcomeLabels: Record<string, string> = {
+  ATGARDAD: 'Åtgärdad',
+  ACCEPTERAD_AVVIKELSE: 'Accepterad avvikelse',
+  EJ_RELEVANT: 'Ej relevant',
+  FORTSATT_AVVIKELSE: 'Fortsatt avvikelse',
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return '—';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('sv-SE');
+}
+
+function statusStyle(status: string): React.CSSProperties {
+  if (status === 'VERIFIED') return { background: '#e7f6eb', color: '#165c2e' };
+  if (status === 'CANCELLED') return { background: '#eeeeee', color: '#555555' };
+  if (status === 'READY_FOR_VERIFICATION') return { background: '#e8f0ff', color: '#244d93' };
+  return { background: '#fff2db', color: '#704300' };
+}
+
+function defaultDeadline() {
+  const date = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60 * 1000);
+  return local.toISOString().slice(0, 16);
+}
+
+export default function CheckpointActionsPanel({
+  regnr,
+  checkpoints,
+  refreshNonce,
+  onChanged,
+}: Props) {
+  const [data, setData] = useState<ActionReadModel | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [localRefreshNonce, setLocalRefreshNonce] = useState(0);
+  const [busyActionId, setBusyActionId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const deviations = useMemo(
+    () => checkpoints.filter((checkpoint) => checkpoint.status === 'AVVIKELSE'),
+    [checkpoints],
+  );
+
+  const [checkpointId, setCheckpointId] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [ownerFunction, setOwnerFunction] = useState('BILKONTROLL');
+  const [ownerRef, setOwnerRef] = useState('');
+  const [deadlineAt, setDeadlineAt] = useState(defaultDeadline);
+  const [blocking, setBlocking] = useState(true);
+  const [comments, setComments] = useState<Record<string, string>>({});
+  const [outcomes, setOutcomes] = useState<Record<string, string>>({});
+  const [evidence, setEvidence] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (checkpointId && deviations.some((checkpoint) => checkpoint.checkpoint_id === checkpointId)) return;
+    setCheckpointId(deviations[0]?.checkpoint_id ?? '');
+  }, [checkpointId, deviations]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const response = await fetch(
+          `/api/checkpoint-actions/read-model?reg=${encodeURIComponent(regnr)}`,
+        );
+        const body = await response.json() as { data?: ActionReadModel; error?: string };
+        if (!response.ok || !body.data) {
+          throw new Error(body.error || 'Kunde inte hämta åtgärderna');
+        }
+        if (!cancelled) setData(body.data);
+      } catch (err) {
+        if (!cancelled) {
+          setData(null);
+          setError(err instanceof Error ? err.message : 'Kunde inte hämta åtgärderna');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    queueMicrotask(() => {
+      if (cancelled) return;
+      setLoading(true);
+      setError('');
+      void load();
+    });
+
+    return () => { cancelled = true; };
+  }, [regnr, refreshNonce, localRefreshNonce]);
+
+  function refresh(text?: string) {
+    if (text) setMessage(text);
+    setLocalRefreshNonce((value) => value + 1);
+    onChanged?.();
+  }
+
+  async function post(payload: Record<string, unknown>) {
+    const response = await fetch('/api/checkpoint-actions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ regnr, ...payload }),
+    });
+    const body = await response.json() as { data?: unknown; error?: string };
+    if (!response.ok) throw new Error(body.error || 'Åtgärden misslyckades');
+    return body.data;
+  }
+
+  async function createAction(event: FormEvent) {
+    event.preventDefault();
+    setCreating(true);
+    setError('');
+    setMessage('');
+
+    try {
+      await post({
+        action: 'CREATE',
+        checkpointId,
+        title,
+        description,
+        ownerFunction,
+        ownerRef,
+        deadlineAt,
+        blocking,
+      });
+      setTitle('');
+      setDescription('');
+      setOwnerRef('');
+      setDeadlineAt(defaultDeadline());
+      refresh('Åtgärden skapades och lades i fordonsresan.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Kunde inte skapa åtgärden');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function transitionAction(actionId: string, nextStatus: string) {
+    setBusyActionId(actionId);
+    setError('');
+    setMessage('');
+
+    try {
+      await post({
+        action: 'TRANSITION',
+        actionId,
+        nextStatus,
+        comment: comments[actionId] ?? '',
+      });
+      setComments((current) => ({ ...current, [actionId]: '' }));
+      refresh('Åtgärdens status uppdaterades.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Kunde inte uppdatera åtgärden');
+    } finally {
+      setBusyActionId(null);
+    }
+  }
+
+  async function verifyAction(actionId: string) {
+    setBusyActionId(actionId);
+    setError('');
+    setMessage('');
+
+    try {
+      const evidenceRefs = (evidence[actionId] ?? '')
+        .split(/[\n,]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+
+      await post({
+        action: 'VERIFY',
+        actionId,
+        outcome: outcomes[actionId] ?? 'ATGARDAD',
+        comment: comments[actionId] ?? '',
+        evidenceRefs,
+      });
+      setComments((current) => ({ ...current, [actionId]: '' }));
+      setEvidence((current) => ({ ...current, [actionId]: '' }));
+      refresh('Ny verifiering registrerades och kontrollpunkten uppdaterades.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Kunde inte verifiera åtgärden');
+    } finally {
+      setBusyActionId(null);
+    }
+  }
+
+  const summary = data?.summary;
+
+  return (
+    <div style={{ marginTop: '1rem', borderTop: '1px solid #e5e5e5', paddingTop: '1rem' }}>
+      <div>
+        <div style={{ fontWeight: 700 }}>Åtgärder och ny verifiering</div>
+        <div style={{ color: '#666', fontSize: 13, marginTop: '.15rem' }}>
+          En avvikelse får ansvar, deadline och utförande. Åtgärden avslutas först efter en separat verifiering.
+        </div>
+      </div>
+
+      {summary && (
+        <div style={{ display: 'flex', gap: '.4rem', flexWrap: 'wrap', marginTop: '.7rem' }}>
+          <span style={{ background: '#eee', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>{summary.total} totalt</span>
+          <span style={{ background: '#fff2db', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>{summary.open} öppna</span>
+          <span style={{ background: '#fde8e7', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>{summary.overdue} försenade</span>
+          <span style={{ background: '#fde8e7', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>{summary.blockingOpen} blockerande</span>
+          <span style={{ background: '#e8f0ff', borderRadius: 999, padding: '.25rem .55rem', fontSize: 12 }}>{summary.readyForVerification} för verifiering</span>
+        </div>
+      )}
+
+      {error && <p style={{ color: '#a00' }}>{error}</p>}
+      {message && <p style={{ color: '#165c2e' }}>{message}</p>}
+
+      {deviations.length > 0 && (
+        <form onSubmit={createAction} style={{ marginTop: '.8rem', background: '#f7f7f7', borderRadius: 9, padding: '.75rem', display: 'grid', gap: '.55rem' }}>
+          <strong>Skapa åtgärd för avvikelse</strong>
+          <select value={checkpointId} onChange={(event) => setCheckpointId(event.target.value)} required style={{ padding: '.55rem', borderRadius: 7, border: '1px solid #bbb' }}>
+            {deviations.map((checkpoint) => (
+              <option key={checkpoint.checkpoint_id} value={checkpoint.checkpoint_id}>
+                {checkpoint.definition?.title ?? checkpoint.checkpoint_code}
+              </option>
+            ))}
+          </select>
+          <input value={title} onChange={(event) => setTitle(event.target.value)} required placeholder="Vad ska åtgärdas?" maxLength={200} style={{ padding: '.55rem', borderRadius: 7, border: '1px solid #bbb' }} />
+          <textarea value={description} onChange={(event) => setDescription(event.target.value)} placeholder="Beskrivning" maxLength={1000} rows={2} style={{ padding: '.55rem', borderRadius: 7, border: '1px solid #bbb' }} />
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '.55rem' }}>
+            <input value={ownerFunction} onChange={(event) => setOwnerFunction(event.target.value)} required placeholder="Ansvarig funktion" maxLength={120} style={{ padding: '.55rem', borderRadius: 7, border: '1px solid #bbb' }} />
+            <input value={ownerRef} onChange={(event) => setOwnerRef(event.target.value)} placeholder="Ansvarig person/referens" maxLength={200} style={{ padding: '.55rem', borderRadius: 7, border: '1px solid #bbb' }} />
+            <input type="datetime-local" value={deadlineAt} onChange={(event) => setDeadlineAt(event.target.value)} required style={{ padding: '.55rem', borderRadius: 7, border: '1px solid #bbb' }} />
+          </div>
+          <label style={{ display: 'flex', gap: '.45rem', alignItems: 'center', fontSize: 13 }}>
+            <input type="checkbox" checked={blocking} onChange={(event) => setBlocking(event.target.checked)} />
+            Blockerar nästa steg tills åtgärden är verifierad
+          </label>
+          <button type="submit" disabled={creating} style={{ justifySelf: 'start', border: 0, borderRadius: 7, background: '#111', color: '#fff', padding: '.55rem .8rem', fontWeight: 700 }}>
+            {creating ? 'Skapar…' : 'Skapa åtgärd'}
+          </button>
+        </form>
+      )}
+
+      {loading && <p style={{ color: '#666' }}>Hämtar åtgärder…</p>}
+      {!loading && data?.actions.length === 0 && (
+        <div style={{ marginTop: '.7rem', background: '#f6f6f6', borderRadius: 8, padding: '.7rem .75rem', color: '#555' }}>
+          Inga generiska åtgärder ännu.
+        </div>
+      )}
+
+      {!loading && data && data.actions.length > 0 && (
+        <div style={{ display: 'grid', gap: '.65rem', marginTop: '.8rem' }}>
+          {data.actions.map((action) => {
+            const busy = busyActionId === action.action_id;
+            const terminal = action.status === 'VERIFIED' || action.status === 'CANCELLED';
+
+            return (
+              <article key={action.action_id} style={{ border: action.overdue ? '1px solid #d33' : '1px solid #e4e4e4', borderRadius: 9, padding: '.75rem' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'start', gap: '.6rem', flexWrap: 'wrap' }}>
+                  <div>
+                    <strong>{action.title}</strong>
+                    <div style={{ color: '#666', fontSize: 12, marginTop: '.15rem' }}>
+                      {action.checkpoint?.definition?.title ?? action.checkpoint?.checkpoint_code ?? 'Kontrollpunkt'}
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: '.35rem', flexWrap: 'wrap' }}>
+                    {action.blocking && <span style={{ background: '#fde8e7', borderRadius: 999, padding: '.2rem .5rem', fontSize: 12, fontWeight: 700 }}>Blockerande</span>}
+                    {action.overdue && <span style={{ background: '#fde8e7', color: '#8a1f17', borderRadius: 999, padding: '.2rem .5rem', fontSize: 12, fontWeight: 700 }}>Försenad</span>}
+                    <span style={{ ...statusStyle(action.status), borderRadius: 999, padding: '.2rem .5rem', fontSize: 12, fontWeight: 700 }}>{actionStatusLabels[action.status] ?? action.status}</span>
+                  </div>
+                </div>
+
+                {action.description && <p style={{ margin: '.5rem 0 0', color: '#555', fontSize: 13 }}>{action.description}</p>}
+
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))', gap: '.45rem', marginTop: '.6rem', fontSize: 13 }}>
+                  <div><strong>Ansvar:</strong> {action.owner_function}{action.owner_ref ? ` · ${action.owner_ref}` : ''}</div>
+                  <div><strong>Deadline:</strong> {formatDate(action.deadline_at)}</div>
+                  <div><strong>Utfall:</strong> {action.outcome ? outcomeLabels[action.outcome] ?? action.outcome : '—'}</div>
+                </div>
+
+                {!terminal && (
+                  <div style={{ display: 'grid', gap: '.45rem', marginTop: '.65rem' }}>
+                    <input value={comments[action.action_id] ?? ''} onChange={(event) => setComments((current) => ({ ...current, [action.action_id]: event.target.value }))} placeholder="Kommentar / avbrottsorsak" maxLength={1000} style={{ padding: '.5rem', borderRadius: 7, border: '1px solid #bbb' }} />
+                    <div style={{ display: 'flex', gap: '.4rem', flexWrap: 'wrap' }}>
+                      {action.status === 'CREATED' && <button type="button" disabled={busy} onClick={() => void transitionAction(action.action_id, 'ACCEPTED')}>Acceptera</button>}
+                      {action.status === 'ACCEPTED' && <button type="button" disabled={busy} onClick={() => void transitionAction(action.action_id, 'IN_PROGRESS')}>Starta</button>}
+                      {action.status === 'IN_PROGRESS' && <button type="button" disabled={busy} onClick={() => void transitionAction(action.action_id, 'READY_FOR_VERIFICATION')}>Klar för verifiering</button>}
+                      {action.status === 'READY_FOR_VERIFICATION' && <button type="button" disabled={busy} onClick={() => void transitionAction(action.action_id, 'IN_PROGRESS')}>Tillbaka till pågår</button>}
+                      <button type="button" disabled={busy} onClick={() => void transitionAction(action.action_id, 'CANCELLED')}>Avbryt</button>
+                    </div>
+                  </div>
+                )}
+
+                {action.status === 'READY_FOR_VERIFICATION' && (
+                  <div style={{ marginTop: '.65rem', background: '#eef3ff', borderRadius: 8, padding: '.65rem', display: 'grid', gap: '.45rem' }}>
+                    <strong>Ny verifiering</strong>
+                    <select value={outcomes[action.action_id] ?? 'ATGARDAD'} onChange={(event) => setOutcomes((current) => ({ ...current, [action.action_id]: event.target.value }))} style={{ padding: '.5rem', borderRadius: 7, border: '1px solid #bbb' }}>
+                      {Object.entries(outcomeLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+                    </select>
+                    <textarea value={evidence[action.action_id] ?? ''} onChange={(event) => setEvidence((current) => ({ ...current, [action.action_id]: event.target.value }))} placeholder="Evidensreferenser, en per rad" rows={2} style={{ padding: '.5rem', borderRadius: 7, border: '1px solid #bbb' }} />
+                    <button type="button" disabled={busy} onClick={() => void verifyAction(action.action_id)} style={{ justifySelf: 'start', border: 0, borderRadius: 7, background: '#244d93', color: '#fff', padding: '.5rem .75rem', fontWeight: 700 }}>
+                      {busy ? 'Verifierar…' : 'Verifiera utfall'}
+                    </button>
+                  </div>
+                )}
+
+                {action.events.length > 0 && (
+                  <details style={{ marginTop: '.6rem' }}>
+                    <summary style={{ cursor: 'pointer', fontSize: 12, color: '#666' }}>Historik ({action.events.length})</summary>
+                    {action.events.slice(0, 5).map((event) => (
+                      <div key={event.action_event_id} style={{ borderTop: '1px solid #eee', padding: '.35rem 0', fontSize: 12 }}>
+                        <strong>{event.event_type}</strong> · {actionStatusLabels[event.status] ?? event.status} · {formatDate(event.occurred_at)}
+                        {event.actor_email ? ` · ${event.actor_email}` : ''}
+                        {event.comment && <div>{event.comment}</div>}
+                      </div>
+                    ))}
+                  </details>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/vagnkort/checkpoint-actions-panel.tsx
+++ b/app/vagnkort/checkpoint-actions-panel.tsx
@@ -140,10 +140,11 @@ export default function CheckpointActionsPanel({
   const [outcomes, setOutcomes] = useState<Record<string, string>>({});
   const [evidence, setEvidence] = useState<Record<string, string>>({});
 
-  useEffect(() => {
-    if (checkpointId && deviations.some((checkpoint) => checkpoint.checkpoint_id === checkpointId)) return;
-    setCheckpointId(deviations[0]?.checkpoint_id ?? '');
-  }, [checkpointId, deviations]);
+  const selectedCheckpointId = deviations.some(
+    (checkpoint) => checkpoint.checkpoint_id === checkpointId,
+  )
+    ? checkpointId
+    : deviations[0]?.checkpoint_id ?? '';
 
   useEffect(() => {
     let cancelled = false;
@@ -204,7 +205,7 @@ export default function CheckpointActionsPanel({
     try {
       await post({
         action: 'CREATE',
-        checkpointId,
+        checkpointId: selectedCheckpointId,
         title,
         description,
         ownerFunction,
@@ -300,7 +301,7 @@ export default function CheckpointActionsPanel({
       {deviations.length > 0 && (
         <form onSubmit={createAction} style={{ marginTop: '.8rem', background: '#f7f7f7', borderRadius: 9, padding: '.75rem', display: 'grid', gap: '.55rem' }}>
           <strong>Skapa åtgärd för avvikelse</strong>
-          <select value={checkpointId} onChange={(event) => setCheckpointId(event.target.value)} required style={{ padding: '.55rem', borderRadius: 7, border: '1px solid #bbb' }}>
+          <select value={selectedCheckpointId} onChange={(event) => setCheckpointId(event.target.value)} required style={{ padding: '.55rem', borderRadius: 7, border: '1px solid #bbb' }}>
             {deviations.map((checkpoint) => (
               <option key={checkpoint.checkpoint_id} value={checkpoint.checkpoint_id}>
                 {checkpoint.definition?.title ?? checkpoint.checkpoint_code}

--- a/app/vagnkort/checkpoint-actions-wrapper.tsx
+++ b/app/vagnkort/checkpoint-actions-wrapper.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import CheckpointActionsPanel from './checkpoint-actions-panel';
+
+type CheckpointOption = {
+  checkpoint_id: string;
+  checkpoint_code: string;
+  status: string;
+  definition: {
+    title: string;
+    domain: string;
+  } | null;
+};
+
+type Props = {
+  regnr: string;
+  refreshNonce: number;
+};
+
+export default function CheckpointActionsWrapper({ regnr, refreshNonce }: Props) {
+  const [checkpoints, setCheckpoints] = useState<CheckpointOption[]>([]);
+  const [localRefreshNonce, setLocalRefreshNonce] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const response = await fetch(
+          `/api/vehicle-checkpoints/read-model?reg=${encodeURIComponent(regnr)}`,
+        );
+        const body = await response.json() as {
+          data?: { checkpoints?: CheckpointOption[] };
+        };
+        if (!cancelled && response.ok) {
+          setCheckpoints(body.data?.checkpoints ?? []);
+        }
+      } catch {
+        if (!cancelled) setCheckpoints([]);
+      }
+    };
+
+    void load();
+    return () => { cancelled = true; };
+  }, [regnr, refreshNonce, localRefreshNonce]);
+
+  return (
+    <CheckpointActionsPanel
+      regnr={regnr}
+      checkpoints={checkpoints}
+      refreshNonce={refreshNonce + localRefreshNonce}
+      onChanged={() => setLocalRefreshNonce((value) => value + 1)}
+    />
+  );
+}

--- a/app/vagnkort/journey-metrics-panel.tsx
+++ b/app/vagnkort/journey-metrics-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import CheckpointActionsWrapper from './checkpoint-actions-wrapper';
 import GenericCheckpointsPanel from './generic-checkpoints-panel';
 
 type JourneyMetrics = {
@@ -159,6 +160,7 @@ export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
         </div>
       )}
       <GenericCheckpointsPanel regnr={regnr} refreshNonce={refreshNonce} />
+      <CheckpointActionsWrapper regnr={regnr} refreshNonce={refreshNonce} />
     </div>
   );
 }

--- a/migrations/20260821013000_create_checkpoint_actions_foundation.sql
+++ b/migrations/20260821013000_create_checkpoint_actions_foundation.sql
@@ -1,0 +1,643 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Generic remediation layer above checkpoint assessments. SALU keeps its own
+-- inline actions and child processes; this table serves non-SALU and shared
+-- checkpoint workflows without duplicating those domain contracts.
+create table public.checkpoint_actions (
+  action_id uuid primary key default gen_random_uuid(),
+  checkpoint_id uuid not null references public.vehicle_checkpoints(checkpoint_id) on delete restrict,
+  source_assessment_id uuid not null references public.checkpoint_assessments(assessment_id) on delete restrict,
+  title text not null check (length(trim(title)) between 1 and 200),
+  description text,
+  owner_function text not null check (length(trim(owner_function)) between 1 and 120),
+  owner_ref text,
+  deadline_at timestamptz not null,
+  blocking boolean not null default true,
+  status text not null default 'CREATED'
+    check (status in (
+      'CREATED',
+      'ACCEPTED',
+      'IN_PROGRESS',
+      'READY_FOR_VERIFICATION',
+      'VERIFIED',
+      'CANCELLED'
+    )),
+  outcome text
+    check (outcome is null or outcome in (
+      'ATGARDAD',
+      'ACCEPTERAD_AVVIKELSE',
+      'EJ_RELEVANT',
+      'FORTSATT_AVVIKELSE'
+    )),
+  outcome_comment text,
+  verification_assessment_id uuid references public.checkpoint_assessments(assessment_id) on delete restrict,
+  created_by uuid,
+  created_by_email text,
+  created_at timestamptz not null default now(),
+  accepted_by uuid,
+  accepted_at timestamptz,
+  ready_for_verification_at timestamptz,
+  verified_by uuid,
+  verified_at timestamptz,
+  cancelled_by uuid,
+  cancelled_at timestamptz,
+  cancel_reason text,
+  updated_by uuid,
+  updated_by_email text,
+  updated_at timestamptz not null default now(),
+  check ((accepted_by is null) = (accepted_at is null)),
+  check ((verified_by is null) = (verified_at is null)),
+  check ((cancelled_by is null) = (cancelled_at is null)),
+  check (
+    status not in ('ACCEPTED', 'IN_PROGRESS', 'READY_FOR_VERIFICATION', 'VERIFIED')
+    or (accepted_by is not null and accepted_at is not null)
+  ),
+  check (
+    status <> 'READY_FOR_VERIFICATION'
+    or ready_for_verification_at is not null
+  ),
+  check (
+    status <> 'VERIFIED'
+    or (
+      outcome is not null
+      and verification_assessment_id is not null
+      and verified_by is not null
+      and verified_at is not null
+    )
+  ),
+  check (
+    status <> 'CANCELLED'
+    or (
+      cancelled_by is not null
+      and cancelled_at is not null
+      and length(trim(coalesce(cancel_reason, ''))) > 0
+    )
+  ),
+  check (status = 'VERIFIED' or outcome is null),
+  check (status = 'VERIFIED' or verification_assessment_id is null),
+  check (status = 'CANCELLED' or cancel_reason is null)
+);
+
+create index checkpoint_actions_checkpoint_status_idx
+  on public.checkpoint_actions (checkpoint_id, status, deadline_at);
+create index checkpoint_actions_open_deadline_idx
+  on public.checkpoint_actions (deadline_at, checkpoint_id)
+  where status not in ('VERIFIED', 'CANCELLED');
+create index checkpoint_actions_source_assessment_idx
+  on public.checkpoint_actions (source_assessment_id);
+create index checkpoint_actions_verification_assessment_idx
+  on public.checkpoint_actions (verification_assessment_id)
+  where verification_assessment_id is not null;
+
+-- Immutable workflow history. The current checkpoint_actions row is only the
+-- operational projection used by the UI.
+create table public.checkpoint_action_events (
+  action_event_id uuid primary key default gen_random_uuid(),
+  action_id uuid not null references public.checkpoint_actions(action_id) on delete restrict,
+  checkpoint_id uuid not null references public.vehicle_checkpoints(checkpoint_id) on delete restrict,
+  event_type text not null
+    check (event_type in (
+      'ACTION_CREATED',
+      'ACTION_STATUS_CHANGED',
+      'ACTION_VERIFIED',
+      'ACTION_CANCELLED'
+    )),
+  previous_status text
+    check (previous_status is null or previous_status in (
+      'CREATED',
+      'ACCEPTED',
+      'IN_PROGRESS',
+      'READY_FOR_VERIFICATION',
+      'VERIFIED',
+      'CANCELLED'
+    )),
+  status text not null
+    check (status in (
+      'CREATED',
+      'ACCEPTED',
+      'IN_PROGRESS',
+      'READY_FOR_VERIFICATION',
+      'VERIFIED',
+      'CANCELLED'
+    )),
+  comment text,
+  actor_id uuid,
+  actor_email text,
+  actor_source text not null default 'MANUELL'
+    check (actor_source in ('SYSTEM', 'MANUELL', 'EXTERNAL')),
+  occurred_at timestamptz not null default now(),
+  payload jsonb not null default '{}'::jsonb,
+  check (jsonb_typeof(payload) = 'object')
+);
+
+create index checkpoint_action_events_action_time_idx
+  on public.checkpoint_action_events (action_id, occurred_at desc);
+create index checkpoint_action_events_checkpoint_time_idx
+  on public.checkpoint_action_events (checkpoint_id, occurred_at desc);
+
+create or replace function public.reject_checkpoint_action_event_mutation()
+returns trigger
+language plpgsql
+security invoker
+set search_path = pg_catalog
+as $$
+begin
+  raise exception 'checkpoint_action_events is append-only; write a new event instead';
+end;
+$$;
+
+create trigger checkpoint_action_events_append_only_update
+before update on public.checkpoint_action_events
+for each row execute function public.reject_checkpoint_action_event_mutation();
+
+create trigger checkpoint_action_events_append_only_delete
+before delete on public.checkpoint_action_events
+for each row execute function public.reject_checkpoint_action_event_mutation();
+
+create or replace function public.create_checkpoint_action(
+  p_checkpoint_id uuid,
+  p_title text,
+  p_description text,
+  p_owner_function text,
+  p_owner_ref text,
+  p_deadline_at timestamptz,
+  p_blocking boolean,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_checkpoint public.vehicle_checkpoints%rowtype;
+  v_assessment public.checkpoint_assessments%rowtype;
+  v_action public.checkpoint_actions%rowtype;
+begin
+  if length(trim(coalesce(p_title, ''))) = 0 then
+    raise exception 'Action title is required' using errcode = '22023';
+  end if;
+
+  if length(trim(coalesce(p_owner_function, ''))) = 0 then
+    raise exception 'Action owner function is required' using errcode = '22023';
+  end if;
+
+  if p_deadline_at is null then
+    raise exception 'Action deadline is required' using errcode = '22023';
+  end if;
+
+  select * into v_checkpoint
+  from public.vehicle_checkpoints
+  where checkpoint_id = p_checkpoint_id
+  for update;
+
+  if not found then
+    raise exception 'Checkpoint not found' using errcode = 'P0002';
+  end if;
+
+  if v_checkpoint.status <> 'AVVIKELSE' then
+    raise exception 'Actions can only be created for a checkpoint deviation' using errcode = 'P0001';
+  end if;
+
+  select * into v_assessment
+  from public.checkpoint_assessments
+  where checkpoint_id = p_checkpoint_id
+    and status = 'AVVIKELSE'
+  order by assessed_at desc, assessment_id desc
+  limit 1;
+
+  if not found then
+    raise exception 'Deviation assessment not found' using errcode = 'P0002';
+  end if;
+
+  insert into public.checkpoint_actions (
+    checkpoint_id,
+    source_assessment_id,
+    title,
+    description,
+    owner_function,
+    owner_ref,
+    deadline_at,
+    blocking,
+    created_by,
+    created_by_email,
+    updated_by,
+    updated_by_email
+  ) values (
+    p_checkpoint_id,
+    v_assessment.assessment_id,
+    trim(p_title),
+    nullif(trim(coalesce(p_description, '')), ''),
+    trim(p_owner_function),
+    nullif(trim(coalesce(p_owner_ref, '')), ''),
+    p_deadline_at,
+    coalesce(p_blocking, true),
+    p_actor_id,
+    p_actor_email,
+    p_actor_id,
+    p_actor_email
+  )
+  returning * into v_action;
+
+  insert into public.checkpoint_action_events (
+    action_id,
+    checkpoint_id,
+    event_type,
+    previous_status,
+    status,
+    actor_id,
+    actor_email,
+    actor_source,
+    payload
+  ) values (
+    v_action.action_id,
+    p_checkpoint_id,
+    'ACTION_CREATED',
+    null,
+    'CREATED',
+    p_actor_id,
+    p_actor_email,
+    'MANUELL',
+    pg_catalog.jsonb_build_object(
+      'title', v_action.title,
+      'ownerFunction', v_action.owner_function,
+      'ownerRef', v_action.owner_ref,
+      'deadlineAt', v_action.deadline_at,
+      'blocking', v_action.blocking,
+      'sourceAssessmentId', v_action.source_assessment_id
+    )
+  );
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    v_checkpoint.regnr,
+    'CHECKPOINT_ACTION_CREATED',
+    'checkpoint-action-created:' || v_action.action_id::text,
+    pg_catalog.now(),
+    'CHECKPOINT_ENGINE',
+    'checkpoint_actions',
+    v_action.action_id::text,
+    p_actor_id,
+    'MANUELL',
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'actionId', v_action.action_id,
+      'checkpointId', p_checkpoint_id,
+      'checkpointCode', v_checkpoint.checkpoint_code,
+      'status', v_action.status,
+      'title', v_action.title,
+      'ownerFunction', v_action.owner_function,
+      'ownerRef', v_action.owner_ref,
+      'deadlineAt', v_action.deadline_at,
+      'blocking', v_action.blocking
+    )
+  );
+
+  return to_jsonb(v_action);
+end;
+$$;
+
+create or replace function public.transition_checkpoint_action(
+  p_action_id uuid,
+  p_next_status text,
+  p_comment text,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_action public.checkpoint_actions%rowtype;
+  v_checkpoint public.vehicle_checkpoints%rowtype;
+  v_allowed boolean := false;
+  v_event_type text := 'ACTION_STATUS_CHANGED';
+begin
+  select * into v_action
+  from public.checkpoint_actions
+  where action_id = p_action_id
+  for update;
+
+  if not found then
+    raise exception 'Checkpoint action not found' using errcode = 'P0002';
+  end if;
+
+  select * into v_checkpoint
+  from public.vehicle_checkpoints
+  where checkpoint_id = v_action.checkpoint_id;
+
+  if v_action.status in ('VERIFIED', 'CANCELLED') then
+    raise exception 'Terminal checkpoint action cannot transition' using errcode = 'P0001';
+  end if;
+
+  v_allowed := case
+    when v_action.status = 'CREATED' and p_next_status in ('ACCEPTED', 'CANCELLED') then true
+    when v_action.status = 'ACCEPTED' and p_next_status in ('IN_PROGRESS', 'CANCELLED') then true
+    when v_action.status = 'IN_PROGRESS' and p_next_status in ('READY_FOR_VERIFICATION', 'CANCELLED') then true
+    when v_action.status = 'READY_FOR_VERIFICATION' and p_next_status in ('IN_PROGRESS', 'CANCELLED') then true
+    else false
+  end;
+
+  if not v_allowed then
+    raise exception 'Invalid checkpoint action transition % -> %', v_action.status, p_next_status
+      using errcode = '22023';
+  end if;
+
+  if p_next_status = 'CANCELLED' and length(trim(coalesce(p_comment, ''))) = 0 then
+    raise exception 'Cancellation requires a reason' using errcode = '22023';
+  end if;
+
+  if p_next_status = 'CANCELLED' then
+    v_event_type := 'ACTION_CANCELLED';
+  end if;
+
+  update public.checkpoint_actions
+  set status = p_next_status,
+      accepted_by = case when p_next_status = 'ACCEPTED' then p_actor_id else accepted_by end,
+      accepted_at = case when p_next_status = 'ACCEPTED' then pg_catalog.now() else accepted_at end,
+      ready_for_verification_at = case
+        when p_next_status = 'READY_FOR_VERIFICATION' then pg_catalog.now()
+        when p_next_status = 'IN_PROGRESS' then null
+        else ready_for_verification_at
+      end,
+      cancelled_by = case when p_next_status = 'CANCELLED' then p_actor_id else cancelled_by end,
+      cancelled_at = case when p_next_status = 'CANCELLED' then pg_catalog.now() else cancelled_at end,
+      cancel_reason = case
+        when p_next_status = 'CANCELLED' then trim(p_comment)
+        else cancel_reason
+      end,
+      updated_by = p_actor_id,
+      updated_by_email = p_actor_email,
+      updated_at = pg_catalog.now()
+  where action_id = p_action_id
+  returning * into v_action;
+
+  insert into public.checkpoint_action_events (
+    action_id,
+    checkpoint_id,
+    event_type,
+    previous_status,
+    status,
+    comment,
+    actor_id,
+    actor_email,
+    actor_source,
+    payload
+  ) values (
+    p_action_id,
+    v_action.checkpoint_id,
+    v_event_type,
+    case
+      when p_next_status = 'ACCEPTED' then 'CREATED'
+      when p_next_status = 'IN_PROGRESS' and v_action.ready_for_verification_at is null then 'ACCEPTED'
+      when p_next_status = 'IN_PROGRESS' then 'READY_FOR_VERIFICATION'
+      when p_next_status = 'READY_FOR_VERIFICATION' then 'IN_PROGRESS'
+      when p_next_status = 'CANCELLED' then null
+      else null
+    end,
+    p_next_status,
+    nullif(trim(coalesce(p_comment, '')), ''),
+    p_actor_id,
+    p_actor_email,
+    'MANUELL',
+    pg_catalog.jsonb_build_object(
+      'ownerFunction', v_action.owner_function,
+      'ownerRef', v_action.owner_ref,
+      'deadlineAt', v_action.deadline_at,
+      'blocking', v_action.blocking
+    )
+  );
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    v_checkpoint.regnr,
+    case
+      when p_next_status = 'CANCELLED' then 'CHECKPOINT_ACTION_CANCELLED'
+      else 'CHECKPOINT_ACTION_STATUS_CHANGED'
+    end,
+    'checkpoint-action:' || p_action_id::text || ':' || p_next_status || ':' || pg_catalog.extract(epoch from pg_catalog.clock_timestamp())::text,
+    pg_catalog.now(),
+    'CHECKPOINT_ENGINE',
+    'checkpoint_actions',
+    p_action_id::text,
+    p_actor_id,
+    'MANUELL',
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'actionId', p_action_id,
+      'checkpointId', v_action.checkpoint_id,
+      'checkpointCode', v_checkpoint.checkpoint_code,
+      'status', p_next_status,
+      'comment', nullif(trim(coalesce(p_comment, '')), ''),
+      'blocking', v_action.blocking,
+      'deadlineAt', v_action.deadline_at
+    )
+  );
+
+  return to_jsonb(v_action);
+end;
+$$;
+
+create or replace function public.verify_checkpoint_action(
+  p_action_id uuid,
+  p_outcome text,
+  p_comment text,
+  p_evidence_refs jsonb,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_action public.checkpoint_actions%rowtype;
+  v_checkpoint public.vehicle_checkpoints%rowtype;
+  v_checkpoint_status text;
+  v_assessment_result jsonb;
+  v_assessment_id uuid;
+begin
+  if p_outcome not in ('ATGARDAD', 'ACCEPTERAD_AVVIKELSE', 'EJ_RELEVANT', 'FORTSATT_AVVIKELSE') then
+    raise exception 'Invalid checkpoint action outcome' using errcode = '22023';
+  end if;
+
+  if pg_catalog.jsonb_typeof(coalesce(p_evidence_refs, '[]'::jsonb)) <> 'array' then
+    raise exception 'Evidence refs must be an array' using errcode = '22023';
+  end if;
+
+  if p_outcome in ('ACCEPTERAD_AVVIKELSE', 'FORTSATT_AVVIKELSE')
+     and length(trim(coalesce(p_comment, ''))) = 0 then
+    raise exception 'Selected outcome requires a comment' using errcode = '22023';
+  end if;
+
+  select * into v_action
+  from public.checkpoint_actions
+  where action_id = p_action_id
+  for update;
+
+  if not found then
+    raise exception 'Checkpoint action not found' using errcode = 'P0002';
+  end if;
+
+  if v_action.status <> 'READY_FOR_VERIFICATION' then
+    raise exception 'Checkpoint action is not ready for verification' using errcode = 'P0001';
+  end if;
+
+  select * into v_checkpoint
+  from public.vehicle_checkpoints
+  where checkpoint_id = v_action.checkpoint_id
+  for update;
+
+  v_checkpoint_status := case
+    when p_outcome in ('ATGARDAD', 'ACCEPTERAD_AVVIKELSE') then 'GODKAND'
+    when p_outcome = 'EJ_RELEVANT' then 'EJ_RELEVANT'
+    else 'AVVIKELSE'
+  end;
+
+  v_assessment_result := public.assess_vehicle_checkpoint(
+    v_action.checkpoint_id,
+    v_checkpoint_status,
+    nullif(trim(coalesce(p_comment, '')), ''),
+    coalesce(p_evidence_refs, '[]'::jsonb),
+    p_actor_id,
+    p_actor_email,
+    'MANUELL'
+  );
+
+  v_assessment_id := (v_assessment_result ->> 'assessment_id')::uuid;
+
+  update public.checkpoint_actions
+  set status = 'VERIFIED',
+      outcome = p_outcome,
+      outcome_comment = nullif(trim(coalesce(p_comment, '')), ''),
+      verification_assessment_id = v_assessment_id,
+      verified_by = p_actor_id,
+      verified_at = pg_catalog.now(),
+      updated_by = p_actor_id,
+      updated_by_email = p_actor_email,
+      updated_at = pg_catalog.now()
+  where action_id = p_action_id
+  returning * into v_action;
+
+  insert into public.checkpoint_action_events (
+    action_id,
+    checkpoint_id,
+    event_type,
+    previous_status,
+    status,
+    comment,
+    actor_id,
+    actor_email,
+    actor_source,
+    payload
+  ) values (
+    p_action_id,
+    v_action.checkpoint_id,
+    'ACTION_VERIFIED',
+    'READY_FOR_VERIFICATION',
+    'VERIFIED',
+    v_action.outcome_comment,
+    p_actor_id,
+    p_actor_email,
+    'MANUELL',
+    pg_catalog.jsonb_build_object(
+      'outcome', p_outcome,
+      'checkpointStatus', v_checkpoint_status,
+      'verificationAssessmentId', v_assessment_id,
+      'evidenceRefs', coalesce(p_evidence_refs, '[]'::jsonb)
+    )
+  );
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    v_checkpoint.regnr,
+    'CHECKPOINT_ACTION_VERIFIED',
+    'checkpoint-action-verified:' || p_action_id::text,
+    pg_catalog.now(),
+    'CHECKPOINT_ENGINE',
+    'checkpoint_actions',
+    p_action_id::text,
+    p_actor_id,
+    'MANUELL',
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'actionId', p_action_id,
+      'checkpointId', v_action.checkpoint_id,
+      'checkpointCode', v_checkpoint.checkpoint_code,
+      'outcome', p_outcome,
+      'checkpointStatus', v_checkpoint_status,
+      'verificationAssessmentId', v_assessment_id,
+      'evidenceRefs', coalesce(p_evidence_refs, '[]'::jsonb)
+    )
+  );
+
+  return to_jsonb(v_action);
+end;
+$$;
+
+alter table public.checkpoint_actions enable row level security;
+alter table public.checkpoint_action_events enable row level security;
+
+revoke all on public.checkpoint_actions from public, anon, authenticated;
+revoke all on public.checkpoint_action_events from public, anon, authenticated;
+revoke all on function public.reject_checkpoint_action_event_mutation()
+  from public, anon, authenticated;
+revoke all on function public.create_checkpoint_action(uuid, text, text, text, text, timestamptz, boolean, uuid, text)
+  from public, anon, authenticated;
+revoke all on function public.transition_checkpoint_action(uuid, text, text, uuid, text)
+  from public, anon, authenticated;
+revoke all on function public.verify_checkpoint_action(uuid, text, text, jsonb, uuid, text)
+  from public, anon, authenticated;
+
+grant select, insert, update on public.checkpoint_actions to service_role;
+grant select, insert on public.checkpoint_action_events to service_role;
+grant execute on function public.reject_checkpoint_action_event_mutation()
+  to service_role;
+grant execute on function public.create_checkpoint_action(uuid, text, text, text, text, timestamptz, boolean, uuid, text)
+  to service_role;
+grant execute on function public.transition_checkpoint_action(uuid, text, text, uuid, text)
+  to service_role;
+grant execute on function public.verify_checkpoint_action(uuid, text, text, jsonb, uuid, text)
+  to service_role;
+
+commit;

--- a/migrations/20260821013000_create_checkpoint_actions_foundation.sql
+++ b/migrations/20260821013000_create_checkpoint_actions_foundation.sql
@@ -443,7 +443,7 @@ begin
       when p_next_status = 'CANCELLED' then 'CHECKPOINT_ACTION_CANCELLED'
       else 'CHECKPOINT_ACTION_STATUS_CHANGED'
     end,
-    'checkpoint-action:' || p_action_id::text || ':' || p_next_status || ':' || pg_catalog.extract(epoch from pg_catalog.clock_timestamp())::text,
+    'checkpoint-action:' || p_action_id::text || ':' || p_next_status || ':' || extract(epoch from pg_catalog.clock_timestamp())::text,
     pg_catalog.now(),
     'CHECKPOINT_ENGINE',
     'checkpoint_actions',

--- a/migrations/20260821013100_harden_checkpoint_action_transitions.sql
+++ b/migrations/20260821013100_harden_checkpoint_action_transitions.sql
@@ -1,0 +1,166 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Preserve the actual prior status in immutable history and derive the journey
+-- event key from the durable action event instead of wall-clock text.
+create or replace function public.transition_checkpoint_action(
+  p_action_id uuid,
+  p_next_status text,
+  p_comment text,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_action public.checkpoint_actions%rowtype;
+  v_checkpoint public.vehicle_checkpoints%rowtype;
+  v_previous_status text;
+  v_allowed boolean := false;
+  v_event_type text := 'ACTION_STATUS_CHANGED';
+  v_action_event_id uuid;
+begin
+  select * into v_action
+  from public.checkpoint_actions
+  where action_id = p_action_id
+  for update;
+
+  if not found then
+    raise exception 'Checkpoint action not found' using errcode = 'P0002';
+  end if;
+
+  v_previous_status := v_action.status;
+
+  select * into v_checkpoint
+  from public.vehicle_checkpoints
+  where checkpoint_id = v_action.checkpoint_id;
+
+  if v_previous_status in ('VERIFIED', 'CANCELLED') then
+    raise exception 'Terminal checkpoint action cannot transition' using errcode = 'P0001';
+  end if;
+
+  v_allowed := case
+    when v_previous_status = 'CREATED' and p_next_status in ('ACCEPTED', 'CANCELLED') then true
+    when v_previous_status = 'ACCEPTED' and p_next_status in ('IN_PROGRESS', 'CANCELLED') then true
+    when v_previous_status = 'IN_PROGRESS' and p_next_status in ('READY_FOR_VERIFICATION', 'CANCELLED') then true
+    when v_previous_status = 'READY_FOR_VERIFICATION' and p_next_status in ('IN_PROGRESS', 'CANCELLED') then true
+    else false
+  end;
+
+  if not v_allowed then
+    raise exception 'Invalid checkpoint action transition % -> %', v_previous_status, p_next_status
+      using errcode = '22023';
+  end if;
+
+  if p_next_status = 'CANCELLED' and length(trim(coalesce(p_comment, ''))) = 0 then
+    raise exception 'Cancellation requires a reason' using errcode = '22023';
+  end if;
+
+  if p_next_status = 'CANCELLED' then
+    v_event_type := 'ACTION_CANCELLED';
+  end if;
+
+  update public.checkpoint_actions
+  set status = p_next_status,
+      accepted_by = case when p_next_status = 'ACCEPTED' then p_actor_id else accepted_by end,
+      accepted_at = case when p_next_status = 'ACCEPTED' then pg_catalog.now() else accepted_at end,
+      ready_for_verification_at = case
+        when p_next_status = 'READY_FOR_VERIFICATION' then pg_catalog.now()
+        when p_next_status = 'IN_PROGRESS' then null
+        else ready_for_verification_at
+      end,
+      cancelled_by = case when p_next_status = 'CANCELLED' then p_actor_id else cancelled_by end,
+      cancelled_at = case when p_next_status = 'CANCELLED' then pg_catalog.now() else cancelled_at end,
+      cancel_reason = case
+        when p_next_status = 'CANCELLED' then trim(p_comment)
+        else cancel_reason
+      end,
+      updated_by = p_actor_id,
+      updated_by_email = p_actor_email,
+      updated_at = pg_catalog.now()
+  where action_id = p_action_id
+  returning * into v_action;
+
+  insert into public.checkpoint_action_events (
+    action_id,
+    checkpoint_id,
+    event_type,
+    previous_status,
+    status,
+    comment,
+    actor_id,
+    actor_email,
+    actor_source,
+    payload
+  ) values (
+    p_action_id,
+    v_action.checkpoint_id,
+    v_event_type,
+    v_previous_status,
+    p_next_status,
+    nullif(trim(coalesce(p_comment, '')), ''),
+    p_actor_id,
+    p_actor_email,
+    'MANUELL',
+    pg_catalog.jsonb_build_object(
+      'ownerFunction', v_action.owner_function,
+      'ownerRef', v_action.owner_ref,
+      'deadlineAt', v_action.deadline_at,
+      'blocking', v_action.blocking
+    )
+  )
+  returning action_event_id into v_action_event_id;
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    v_checkpoint.regnr,
+    case
+      when p_next_status = 'CANCELLED' then 'CHECKPOINT_ACTION_CANCELLED'
+      else 'CHECKPOINT_ACTION_STATUS_CHANGED'
+    end,
+    'checkpoint-action-event:' || v_action_event_id::text,
+    pg_catalog.now(),
+    'CHECKPOINT_ENGINE',
+    'checkpoint_action_events',
+    v_action_event_id::text,
+    p_actor_id,
+    'MANUELL',
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'actionId', p_action_id,
+      'checkpointId', v_action.checkpoint_id,
+      'checkpointCode', v_checkpoint.checkpoint_code,
+      'previousStatus', v_previous_status,
+      'status', p_next_status,
+      'comment', nullif(trim(coalesce(p_comment, '')), ''),
+      'blocking', v_action.blocking,
+      'deadlineAt', v_action.deadline_at
+    )
+  );
+
+  return to_jsonb(v_action);
+end;
+$$;
+
+revoke all on function public.transition_checkpoint_action(uuid, text, text, uuid, text)
+  from public, anon, authenticated;
+grant execute on function public.transition_checkpoint_action(uuid, text, text, uuid, text)
+  to service_role;
+
+commit;

--- a/migrations/20260821013200_guard_checkpoint_resolution_by_blocking_actions.sql
+++ b/migrations/20260821013200_guard_checkpoint_resolution_by_blocking_actions.sql
@@ -1,0 +1,199 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- A verified action becomes terminal, but the checkpoint itself must remain an
+-- AVVIKELSE while another blocking action for the same checkpoint is still open.
+-- This keeps action completion separate from final checkpoint resolution.
+create or replace function public.verify_checkpoint_action(
+  p_action_id uuid,
+  p_outcome text,
+  p_comment text,
+  p_evidence_refs jsonb,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_action public.checkpoint_actions%rowtype;
+  v_checkpoint public.vehicle_checkpoints%rowtype;
+  v_checkpoint_status text;
+  v_assessment_comment text;
+  v_assessment_result jsonb;
+  v_assessment_id uuid;
+  v_remaining_blocking_actions integer := 0;
+begin
+  if p_outcome not in (
+    'ATGARDAD',
+    'ACCEPTERAD_AVVIKELSE',
+    'EJ_RELEVANT',
+    'FORTSATT_AVVIKELSE'
+  ) then
+    raise exception 'Invalid checkpoint action outcome' using errcode = '22023';
+  end if;
+
+  if pg_catalog.jsonb_typeof(coalesce(p_evidence_refs, '[]'::jsonb)) <> 'array' then
+    raise exception 'Evidence refs must be an array' using errcode = '22023';
+  end if;
+
+  if p_outcome in ('ACCEPTERAD_AVVIKELSE', 'FORTSATT_AVVIKELSE')
+     and length(trim(coalesce(p_comment, ''))) = 0 then
+    raise exception 'Selected outcome requires a comment' using errcode = '22023';
+  end if;
+
+  select * into v_action
+  from public.checkpoint_actions
+  where action_id = p_action_id
+  for update;
+
+  if not found then
+    raise exception 'Checkpoint action not found' using errcode = 'P0002';
+  end if;
+
+  if v_action.status <> 'READY_FOR_VERIFICATION' then
+    raise exception 'Checkpoint action is not ready for verification' using errcode = 'P0001';
+  end if;
+
+  select * into v_checkpoint
+  from public.vehicle_checkpoints
+  where checkpoint_id = v_action.checkpoint_id
+  for update;
+
+  select count(*)::integer
+  into v_remaining_blocking_actions
+  from public.checkpoint_actions
+  where checkpoint_id = v_action.checkpoint_id
+    and action_id <> p_action_id
+    and blocking
+    and status not in ('VERIFIED', 'CANCELLED');
+
+  v_checkpoint_status := case
+    when p_outcome = 'FORTSATT_AVVIKELSE' then 'AVVIKELSE'
+    when v_remaining_blocking_actions > 0 then 'AVVIKELSE'
+    when p_outcome in ('ATGARDAD', 'ACCEPTERAD_AVVIKELSE') then 'GODKAND'
+    when p_outcome = 'EJ_RELEVANT' then 'EJ_RELEVANT'
+    else 'AVVIKELSE'
+  end;
+
+  v_assessment_comment := nullif(trim(coalesce(p_comment, '')), '');
+
+  if v_remaining_blocking_actions > 0 and p_outcome <> 'FORTSATT_AVVIKELSE' then
+    v_assessment_comment := concat_ws(
+      ' ',
+      v_assessment_comment,
+      'Åtgärden verifierades, men ' || v_remaining_blocking_actions::text ||
+        ' annan blockerande åtgärd återstår.'
+    );
+  end if;
+
+  v_assessment_result := public.assess_vehicle_checkpoint(
+    v_action.checkpoint_id,
+    v_checkpoint_status,
+    v_assessment_comment,
+    coalesce(p_evidence_refs, '[]'::jsonb),
+    p_actor_id,
+    p_actor_email,
+    'MANUELL'
+  );
+
+  v_assessment_id := (v_assessment_result ->> 'assessment_id')::uuid;
+
+  update public.checkpoint_actions
+  set status = 'VERIFIED',
+      outcome = p_outcome,
+      outcome_comment = nullif(trim(coalesce(p_comment, '')), ''),
+      verification_assessment_id = v_assessment_id,
+      verified_by = p_actor_id,
+      verified_at = pg_catalog.now(),
+      updated_by = p_actor_id,
+      updated_by_email = p_actor_email,
+      updated_at = pg_catalog.now()
+  where action_id = p_action_id
+  returning * into v_action;
+
+  insert into public.checkpoint_action_events (
+    action_id,
+    checkpoint_id,
+    event_type,
+    previous_status,
+    status,
+    comment,
+    actor_id,
+    actor_email,
+    actor_source,
+    payload
+  ) values (
+    p_action_id,
+    v_action.checkpoint_id,
+    'ACTION_VERIFIED',
+    'READY_FOR_VERIFICATION',
+    'VERIFIED',
+    v_action.outcome_comment,
+    p_actor_id,
+    p_actor_email,
+    'MANUELL',
+    pg_catalog.jsonb_build_object(
+      'outcome', p_outcome,
+      'checkpointStatus', v_checkpoint_status,
+      'verificationAssessmentId', v_assessment_id,
+      'evidenceRefs', coalesce(p_evidence_refs, '[]'::jsonb),
+      'remainingBlockingActions', v_remaining_blocking_actions,
+      'checkpointResolved', v_checkpoint_status <> 'AVVIKELSE'
+    )
+  );
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    v_checkpoint.regnr,
+    'CHECKPOINT_ACTION_VERIFIED',
+    'checkpoint-action-verified:' || p_action_id::text,
+    pg_catalog.now(),
+    'CHECKPOINT_ENGINE',
+    'checkpoint_actions',
+    p_action_id::text,
+    p_actor_id,
+    'MANUELL',
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'actionId', p_action_id,
+      'checkpointId', v_action.checkpoint_id,
+      'checkpointCode', v_checkpoint.checkpoint_code,
+      'outcome', p_outcome,
+      'checkpointStatus', v_checkpoint_status,
+      'verificationAssessmentId', v_assessment_id,
+      'evidenceRefs', coalesce(p_evidence_refs, '[]'::jsonb),
+      'remainingBlockingActions', v_remaining_blocking_actions,
+      'checkpointResolved', v_checkpoint_status <> 'AVVIKELSE'
+    )
+  );
+
+  return to_jsonb(v_action) || pg_catalog.jsonb_build_object(
+    'checkpoint_status', v_checkpoint_status,
+    'remaining_blocking_actions', v_remaining_blocking_actions,
+    'checkpoint_resolved', v_checkpoint_status <> 'AVVIKELSE'
+  );
+end;
+$$;
+
+revoke all on function public.verify_checkpoint_action(uuid, text, text, jsonb, uuid, text)
+  from public, anon, authenticated;
+grant execute on function public.verify_checkpoint_action(uuid, text, text, jsonb, uuid, text)
+  to service_role;
+
+commit;

--- a/tests/checkpoint-actions.test.ts
+++ b/tests/checkpoint-actions.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
 const migration = read('migrations/20260821013000_create_checkpoint_actions_foundation.sql');
 const transitionHardening = read('migrations/20260821013100_harden_checkpoint_action_transitions.sql');
+const blockingGuard = read('migrations/20260821013200_guard_checkpoint_resolution_by_blocking_actions.sql');
 const api = read('app/api/checkpoint-actions/route.ts');
 const readModel = read('app/api/checkpoint-actions/read-model/route.ts');
 const panel = read('app/vagnkort/checkpoint-actions-panel.tsx');
@@ -60,6 +61,18 @@ test('verification requires READY_FOR_VERIFICATION and creates a new checkpoint 
   assert.match(migration, /else 'AVVIKELSE'/i);
 });
 
+test('checkpoint resolution waits until all other blocking actions are terminal', () => {
+  assert.match(blockingGuard, /function public\.verify_checkpoint_action/i);
+  assert.match(blockingGuard, /v_remaining_blocking_actions integer := 0/i);
+  assert.match(blockingGuard, /action_id <> p_action_id/i);
+  assert.match(blockingGuard, /and blocking/i);
+  assert.match(blockingGuard, /status not in \('VERIFIED', 'CANCELLED'\)/i);
+  assert.match(blockingGuard, /when v_remaining_blocking_actions > 0 then 'AVVIKELSE'/i);
+  assert.match(blockingGuard, /remainingBlockingActions/i);
+  assert.match(blockingGuard, /checkpointResolved/i);
+  assert.match(blockingGuard, /checkpoint_resolved/i);
+});
+
 test('generic actions do not duplicate SALU inline actions or child processes', () => {
   assert.doesNotMatch(migration, /insert into public\.salu_inline_actions/i);
   assert.doesNotMatch(migration, /insert into public\.salu_child_processes/i);
@@ -103,6 +116,7 @@ test('Vagnkort makes deviation actions operational through responsibility, deadl
   assert.match(panel, /Verifiera utfall/);
   assert.match(panel, /Försenad/);
   assert.match(panel, /Historik/);
+  assert.match(panel, /selectedCheckpointId/);
   assert.match(panel, /fetch\('\/api\/checkpoint-actions'/);
   assert.match(panel, /action: 'CREATE'/);
   assert.match(panel, /action: 'TRANSITION'/);

--- a/tests/checkpoint-actions.test.ts
+++ b/tests/checkpoint-actions.test.ts
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+const migration = read('migrations/20260821013000_create_checkpoint_actions_foundation.sql');
+const transitionHardening = read('migrations/20260821013100_harden_checkpoint_action_transitions.sql');
+const api = read('app/api/checkpoint-actions/route.ts');
+const readModel = read('app/api/checkpoint-actions/read-model/route.ts');
+const panel = read('app/vagnkort/checkpoint-actions-panel.tsx');
+const wrapper = read('app/vagnkort/checkpoint-actions-wrapper.tsx');
+const metricsPanel = read('app/vagnkort/journey-metrics-panel.tsx');
+
+test('checkpoint actions persist current projection and immutable workflow history server-side', () => {
+  assert.match(migration, /create table public\.checkpoint_actions/i);
+  assert.match(migration, /create table public\.checkpoint_action_events/i);
+  assert.match(migration, /'CREATED'[\s\S]*'ACCEPTED'[\s\S]*'IN_PROGRESS'[\s\S]*'READY_FOR_VERIFICATION'[\s\S]*'VERIFIED'[\s\S]*'CANCELLED'/i);
+  assert.match(migration, /checkpoint_action_events is append-only/i);
+  assert.match(migration, /before update on public\.checkpoint_action_events/i);
+  assert.match(migration, /before delete on public\.checkpoint_action_events/i);
+  assert.match(migration, /enable row level security/i);
+  assert.match(migration, /revoke all on public\.checkpoint_actions from public, anon, authenticated/i);
+  assert.match(migration, /revoke all on public\.checkpoint_action_events from public, anon, authenticated/i);
+  assert.match(migration, /to service_role/i);
+});
+
+test('action creation requires a real deviation assessment and appends journey history', () => {
+  assert.match(migration, /function public\.create_checkpoint_action/i);
+  assert.match(migration, /v_checkpoint\.status <> 'AVVIKELSE'/i);
+  assert.match(migration, /from public\.checkpoint_assessments[\s\S]*status = 'AVVIKELSE'/i);
+  assert.match(migration, /source_assessment_id/i);
+  assert.match(migration, /'ACTION_CREATED'/i);
+  assert.match(migration, /'CHECKPOINT_ACTION_CREATED'/i);
+  assert.match(migration, /insert into public\.vehicle_journey_events/i);
+});
+
+test('action status transitions are constrained and preserve the actual previous status', () => {
+  assert.match(transitionHardening, /function public\.transition_checkpoint_action/i);
+  assert.match(transitionHardening, /v_previous_status := v_action\.status/i);
+  assert.match(transitionHardening, /'CREATED' and p_next_status in \('ACCEPTED', 'CANCELLED'\)/i);
+  assert.match(transitionHardening, /'ACCEPTED' and p_next_status in \('IN_PROGRESS', 'CANCELLED'\)/i);
+  assert.match(transitionHardening, /'IN_PROGRESS' and p_next_status in \('READY_FOR_VERIFICATION', 'CANCELLED'\)/i);
+  assert.match(transitionHardening, /'READY_FOR_VERIFICATION' and p_next_status in \('IN_PROGRESS', 'CANCELLED'\)/i);
+  assert.match(transitionHardening, /Terminal checkpoint action cannot transition/i);
+  assert.match(transitionHardening, /Cancellation requires a reason/i);
+  assert.match(transitionHardening, /previous_status[\s\S]*v_previous_status/i);
+  assert.match(transitionHardening, /'checkpoint-action-event:' \|\| v_action_event_id::text/i);
+});
+
+test('verification requires READY_FOR_VERIFICATION and creates a new checkpoint assessment', () => {
+  assert.match(migration, /function public\.verify_checkpoint_action/i);
+  assert.match(migration, /v_action\.status <> 'READY_FOR_VERIFICATION'/i);
+  assert.match(migration, /public\.assess_vehicle_checkpoint\(/i);
+  assert.match(migration, /verification_assessment_id = v_assessment_id/i);
+  assert.match(migration, /'ACTION_VERIFIED'/i);
+  assert.match(migration, /'CHECKPOINT_ACTION_VERIFIED'/i);
+  assert.match(migration, /when p_outcome in \('ATGARDAD', 'ACCEPTERAD_AVVIKELSE'\) then 'GODKAND'/i);
+  assert.match(migration, /when p_outcome = 'EJ_RELEVANT' then 'EJ_RELEVANT'/i);
+  assert.match(migration, /else 'AVVIKELSE'/i);
+});
+
+test('generic actions do not duplicate SALU inline actions or child processes', () => {
+  assert.doesNotMatch(migration, /insert into public\.salu_inline_actions/i);
+  assert.doesNotMatch(migration, /insert into public\.salu_child_processes/i);
+  assert.doesNotMatch(api, /salu_inline_actions|salu_child_processes/i);
+  assert.doesNotMatch(readModel, /salu_inline_actions|salu_child_processes/i);
+});
+
+test('checkpoint action API authenticates, verifies vehicle ownership and delegates to RPCs', () => {
+  assert.match(api, /verifyApiUser\(request\)/);
+  assert.match(api, /vehicleExists/);
+  assert.match(api, /checkpointBelongsToVehicle/);
+  assert.match(api, /actionBelongsToVehicle/);
+  assert.match(api, /rpc\('create_checkpoint_action'/);
+  assert.match(api, /rpc\('transition_checkpoint_action'/);
+  assert.match(api, /rpc\('verify_checkpoint_action'/);
+  assert.match(api, /Cancellation requires a reason/);
+  assert.match(api, /Selected outcome requires a comment/);
+});
+
+test('action read model exposes overdue, blocking and verification-ready work without writes', () => {
+  assert.match(readModel, /verifyApiUser\(request\)/);
+  assert.match(readModel, /from\('checkpoint_actions'\)/);
+  assert.match(readModel, /from\('checkpoint_action_events'\)/);
+  assert.match(readModel, /overdue:/);
+  assert.match(readModel, /blockingOpen/);
+  assert.match(readModel, /readyForVerification/);
+  assert.doesNotMatch(readModel, /\.(insert|update|upsert|delete)\(/);
+});
+
+test('Vagnkort makes deviation actions operational through responsibility, deadline and re-verification', () => {
+  assert.match(metricsPanel, /CheckpointActionsWrapper/);
+  assert.match(wrapper, /\/api\/vehicle-checkpoints\/read-model\?reg=/);
+  assert.match(wrapper, /<CheckpointActionsPanel/);
+  assert.match(panel, /Åtgärder och ny verifiering/);
+  assert.match(panel, /Ansvarig funktion/);
+  assert.match(panel, /Ansvarig person\/referens/);
+  assert.match(panel, /datetime-local/);
+  assert.match(panel, /Blockerar nästa steg/);
+  assert.match(panel, /Acceptera/);
+  assert.match(panel, /Klar för verifiering/);
+  assert.match(panel, /Verifiera utfall/);
+  assert.match(panel, /Försenad/);
+  assert.match(panel, /Historik/);
+  assert.match(panel, /fetch\('\/api\/checkpoint-actions'/);
+  assert.match(panel, /action: 'CREATE'/);
+  assert.match(panel, /action: 'TRANSITION'/);
+  assert.match(panel, /action: 'VERIFY'/);
+});

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -12,6 +12,8 @@ import { proxy } from '../proxy'
 
 const protectedApiPaths = [
   '/api/checkin-damages',
+  '/api/checkpoint-actions',
+  '/api/checkpoint-actions/read-model?reg=GEU29F',
   '/api/damage-comments',
   '/api/notify',
   '/api/notify-arrival',


### PR DESCRIPTION
## Sammanfattning
- lägger det generiska åtgärds- och utfallslagret ovanpå checkpoint-assessments
- en åtgärd kopplas till bil, kontrollpunkt och den avvikelsebedömning som startade arbetet
- ansvarig funktion/person, deadline och blockerande status lagras strukturerat
- statusflöde: `CREATED → ACCEPTED → IN_PROGRESS → READY_FOR_VERIFICATION → VERIFIED`, alternativt `CANCELLED`
- verifiering skapar alltid en ny checkpoint-assessment; genomförd åtgärd godkänner aldrig kontrollpunkten automatiskt
- kontrollpunkten förblir `AVVIKELSE` så länge någon annan blockerande åtgärd är öppen
- möjliga utfall: `ATGARDAD`, `ACCEPTERAD_AVVIKELSE`, `EJ_RELEVANT`, `FORTSATT_AVVIKELSE`
- skriver append-only `checkpoint_action_events` och motsvarande händelser i fordonsresan
- visar öppna, blockerande, försenade och verifieringsklara åtgärder i Vagnkortet

## Avgränsning
- SALU:s befintliga inline actions och barnprocesser dupliceras eller flyttas inte
- detta är ett generiskt lager för fordonsresans gemensamma och icke-SALU-specifika kontrollpunkter
- ingen timer/escalation-motor och inga ekonomiska poster skapas i detta steg
- ingen historisk backfill och inga syntetiska verksamhetsdata

## Production
Migrationerna är applicerade i Production.

Rollback-baserade integrationstest verifierade:
- avvikelse → åtgärd → accepterad → pågår → klar för verifiering → verifierad
- kontrollpunkten fick en ny assessment och blev godkänd när arbetet var löst
- 5 append-only action-events och 7 fordonsrese-events skapades i testtransaktionen
- mutation av action-historiken blockerades
- ny åtgärd kunde inte skapas efter att avvikelsen var löst
- med två blockerande åtgärder låg kontrollpunkten kvar som `AVVIKELSE` efter den första verifieringen och blev `GODKAND` först efter den andra
- samtliga testdata rullades tillbaka; Production har 0 actions och 0 action-events efter test

## Säkerhet
- RLS är aktiverat
- `anon` och `authenticated` saknar direkt access
- endast `service_role` har tabell- och RPC-rättigheter
- API:t verifierar användaren och kontrollerar att checkpoint/action tillhör rätt bil

## Test
- databas- och transition-kontrakt
- separat verifiering och utfallsmappning
- blockerande fleråtgärdsflöde
- append-only historik
- autentiserade API:er och central auth-boundary
- Vagnkortets operativa åtgärdspanel och read model