### PR TITLE
Vagnkort: starta och avsluta fordonsperioder

### DIFF
--- a/app/api/vehicle-journey-periods/route.ts
+++ b/app/api/vehicle-journey-periods/route.ts
@@ -1,0 +1,216 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PERIOD_TYPES = ['PREPARATION', 'AVAILABLE', 'RENTAL', 'DOWNTIME', 'WORKSHOP', 'TRANSPORT', 'SALU', 'OTHER'] as const;
+type PeriodType = (typeof PERIOD_TYPES)[number];
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+function cleanRegnr(value: unknown): string {
+  return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
+}
+
+function cleanPeriodType(value: unknown): PeriodType | null {
+  const type = typeof value === 'string' ? value.trim().toUpperCase() : '';
+  return PERIOD_TYPES.includes(type as PeriodType) ? type as PeriodType : null;
+}
+
+function cleanText(value: unknown, maxLength = 500): string | null {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text ? text.slice(0, maxLength) : null;
+}
+
+function cleanTimestamp(value: unknown, fallbackNow = false): string | null {
+  if ((value === null || value === undefined || value === '') && fallbackNow) return new Date().toISOString();
+  if (typeof value !== 'string' || !value.trim()) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+async function vehicleExists(admin: ReturnType<typeof createAdminClient>, regnr: string) {
+  const [vehicle, nybil, checkin, salu, journey] = await Promise.all([
+    admin.from('vehicles').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('nybil_inventering').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('checkins').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('salu_vehicle_state').select('regnr').eq('regnr', regnr).limit(1),
+    admin.from('vehicle_journey_events').select('regnr').eq('regnr', regnr).limit(1),
+  ]);
+  const responses = [vehicle, nybil, checkin, salu, journey];
+  const failed = responses.find((response) => response.error);
+  if (failed?.error) throw failed.error;
+  return responses.some((response) => (response.data?.length ?? 0) > 0);
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const action = typeof body.action === 'string' ? body.action.trim().toLowerCase() : '';
+  const regnr = cleanRegnr(body.regnr);
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[vehicle-journey-periods] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Vehicle journey unavailable' }, { status: 503 });
+  }
+
+  try {
+    if (!(await vehicleExists(admin, regnr))) {
+      return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
+    }
+
+    if (action === 'start') {
+      const periodType = cleanPeriodType(body.periodType);
+      if (!periodType) return NextResponse.json({ error: 'Invalid period type' }, { status: 400 });
+
+      const startedAt = cleanTimestamp(body.startedAt, true);
+      if (!startedAt) return NextResponse.json({ error: 'Invalid start time' }, { status: 400 });
+
+      const reasonCode = cleanText(body.reasonCode, 80)?.toUpperCase().replace(/[^A-Z0-9_-]+/g, '_') ?? null;
+      const reasonText = cleanText(body.reasonText);
+      const periodId = crypto.randomUUID();
+
+      const { data: period, error: insertError } = await admin
+        .from('vehicle_journey_periods')
+        .insert({
+          period_id: periodId,
+          regnr,
+          period_type: periodType,
+          started_at: startedAt,
+          reason_code: reasonCode,
+          reason_text: reasonText,
+          source_system: 'VAGNKORT',
+          source_entity: 'vehicle_journey_periods',
+          source_record_id: periodId,
+          metadata: { createdVia: 'VAGNKORT' },
+          created_by: verification.user.id,
+        })
+        .select('period_id,period_type,started_at,ended_at,reason_code,reason_text')
+        .single();
+
+      if (insertError || !period) {
+        if (insertError?.code === '23505') {
+          return NextResponse.json({ error: 'An open period of this type already exists' }, { status: 409 });
+        }
+        console.error('[vehicle-journey-periods] Could not start period:', insertError);
+        return NextResponse.json({ error: 'Could not start period' }, { status: 500 });
+      }
+
+      const { data: event, error: eventError } = await admin
+        .from('vehicle_journey_events')
+        .insert({
+          regnr,
+          event_type: 'PERIOD_STARTED',
+          event_key: `vehicle-period:${periodId}:started`,
+          occurred_at: startedAt,
+          source_system: 'VAGNKORT',
+          source_entity: 'vehicle_journey_periods',
+          source_record_id: periodId,
+          actor_id: verification.user.id,
+          actor_source: 'MANUELL',
+          actor_email: verification.user.email,
+          payload: { periodType, reasonCode, reasonText },
+        })
+        .select('event_id')
+        .single();
+
+      if (eventError || !event) {
+        console.error('[vehicle-journey-periods] Could not append start event:', eventError);
+        await admin.from('vehicle_journey_periods').delete().eq('period_id', periodId);
+        return NextResponse.json({ error: 'Could not start period' }, { status: 500 });
+      }
+
+      const { error: linkError } = await admin
+        .from('vehicle_journey_periods')
+        .update({ source_event_id: event.event_id })
+        .eq('period_id', periodId);
+      if (linkError) console.error('[vehicle-journey-periods] Could not link start event:', linkError);
+
+      return NextResponse.json({ data: { ...period, source_event_id: event.event_id } }, { status: 201 });
+    }
+
+    if (action === 'end') {
+      const periodId = typeof body.periodId === 'string' ? body.periodId.trim() : '';
+      if (!UUID_RE.test(periodId)) return NextResponse.json({ error: 'Invalid period id' }, { status: 400 });
+
+      const endedAt = cleanTimestamp(body.endedAt, true);
+      if (!endedAt) return NextResponse.json({ error: 'Invalid end time' }, { status: 400 });
+
+      const { data: existing, error: fetchError } = await admin
+        .from('vehicle_journey_periods')
+        .select('period_id,period_type,started_at,ended_at,reason_code,reason_text')
+        .eq('period_id', periodId)
+        .eq('regnr', regnr)
+        .maybeSingle();
+      if (fetchError) throw fetchError;
+      if (!existing) return NextResponse.json({ error: 'Period not found for vehicle' }, { status: 404 });
+      if (existing.ended_at) return NextResponse.json({ error: 'Period is already ended' }, { status: 409 });
+      if (new Date(endedAt).getTime() < new Date(existing.started_at).getTime()) {
+        return NextResponse.json({ error: 'End time cannot be before start time' }, { status: 400 });
+      }
+
+      const { data: period, error: updateError } = await admin
+        .from('vehicle_journey_periods')
+        .update({ ended_at: endedAt })
+        .eq('period_id', periodId)
+        .is('ended_at', null)
+        .select('period_id,period_type,started_at,ended_at,reason_code,reason_text')
+        .maybeSingle();
+      if (updateError) throw updateError;
+      if (!period) return NextResponse.json({ error: 'Period was changed by another user' }, { status: 409 });
+
+      const { error: eventError } = await admin
+        .from('vehicle_journey_events')
+        .insert({
+          regnr,
+          event_type: 'PERIOD_ENDED',
+          event_key: `vehicle-period:${periodId}:ended`,
+          occurred_at: endedAt,
+          source_system: 'VAGNKORT',
+          source_entity: 'vehicle_journey_periods',
+          source_record_id: periodId,
+          actor_id: verification.user.id,
+          actor_source: 'MANUELL',
+          actor_email: verification.user.email,
+          payload: { periodType: existing.period_type, reasonCode: existing.reason_code, reasonText: existing.reason_text },
+        });
+
+      if (eventError) {
+        console.error('[vehicle-journey-periods] Could not append end event:', eventError);
+        await admin.from('vehicle_journey_periods').update({ ended_at: null }).eq('period_id', periodId).eq('ended_at', endedAt);
+        return NextResponse.json({ error: 'Could not end period' }, { status: 500 });
+      }
+
+      return NextResponse.json({ data: period });
+    }
+
+    return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+  } catch (error) {
+    console.error('[vehicle-journey-periods] Unexpected error:', error);
+    return NextResponse.json({ error: 'Vehicle journey update failed' }, { status: 500 });
+  }
+}

--- a/app/vagnkort/period-manager.tsx
+++ b/app/vagnkort/period-manager.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+
+type JourneyPeriod = {
+  period_id: string;
+  period_type: string;
+  started_at: string;
+  ended_at: string | null;
+  reason_code: string | null;
+  reason_text: string | null;
+};
+
+type Props = {
+  regnr: string;
+  openPeriods: JourneyPeriod[];
+  onChanged: () => void;
+};
+
+const TYPES = [
+  ['AVAILABLE', 'Tillgänglig'],
+  ['RENTAL', 'Uthyrd'],
+  ['DOWNTIME', 'Stillestånd'],
+  ['WORKSHOP', 'Verkstad'],
+  ['TRANSPORT', 'Transport'],
+  ['PREPARATION', 'Förberedelse'],
+  ['SALU', 'SALU'],
+  ['OTHER', 'Övrigt'],
+] as const;
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('sv-SE');
+}
+
+export default function PeriodManager({ regnr, openPeriods, onChanged }: Props) {
+  const [periodType, setPeriodType] = useState('AVAILABLE');
+  const [reasonText, setReasonText] = useState('');
+  const [busy, setBusy] = useState<string | null>(null);
+  const [message, setMessage] = useState('');
+
+  async function startPeriod(event: FormEvent) {
+    event.preventDefault();
+    setBusy('start');
+    setMessage('');
+    try {
+      const response = await fetch('/api/vehicle-journey-periods', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'start',
+          regnr,
+          periodType,
+          reasonText: reasonText || null,
+        }),
+      });
+      const body = await response.json() as { error?: string };
+      if (!response.ok) throw new Error(body.error || 'Kunde inte starta perioden');
+      setReasonText('');
+      onChanged();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Kunde inte starta perioden');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function endPeriod(periodId: string) {
+    setBusy(periodId);
+    setMessage('');
+    try {
+      const response = await fetch('/api/vehicle-journey-periods', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'end', regnr, periodId }),
+      });
+      const body = await response.json() as { error?: string };
+      if (!response.ok) throw new Error(body.error || 'Kunde inte avsluta perioden');
+      onChanged();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Kunde inte avsluta perioden');
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div>
+      <h2 style={{ marginTop: 0 }}>Aktuell period</h2>
+      {openPeriods.length === 0 ? (
+        <p>Ingen öppen period.</p>
+      ) : (
+        <div style={{ marginBottom: '1rem' }}>
+          {openPeriods.map((period) => (
+            <div key={period.period_id} style={{ display: 'flex', gap: '.8rem', alignItems: 'center', justifyContent: 'space-between', padding: '.6rem 0', borderBottom: '1px solid #eee', flexWrap: 'wrap' }}>
+              <div>
+                <strong>{period.period_type}</strong>
+                <div style={{ color: '#666', fontSize: 13 }}>{formatDate(period.started_at)}{period.reason_text ? ` · ${period.reason_text}` : ''}</div>
+              </div>
+              <button type="button" onClick={() => void endPeriod(period.period_id)} disabled={busy !== null} style={{ border: '1px solid #aaa', borderRadius: 7, background: '#fff', padding: '.5rem .75rem', cursor: 'pointer' }}>
+                {busy === period.period_id ? 'Avslutar…' : 'Avsluta period'}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <form onSubmit={startPeriod} style={{ display: 'grid', gap: '.6rem' }}>
+        <label style={{ display: 'grid', gap: '.25rem' }}>
+          <span style={{ fontSize: 13, fontWeight: 700 }}>Ny period</span>
+          <select value={periodType} onChange={(event) => setPeriodType(event.target.value)} disabled={busy !== null} style={{ padding: '.65rem', borderRadius: 7, border: '1px solid #bbb' }}>
+            {TYPES.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+          </select>
+        </label>
+        <label style={{ display: 'grid', gap: '.25rem' }}>
+          <span style={{ fontSize: 13, fontWeight: 700 }}>Orsak / kommentar</span>
+          <input value={reasonText} onChange={(event) => setReasonText(event.target.value)} maxLength={500} placeholder="Valfritt" disabled={busy !== null} style={{ padding: '.65rem', borderRadius: 7, border: '1px solid #bbb' }} />
+        </label>
+        <button type="submit" disabled={busy !== null} style={{ border: 0, borderRadius: 7, background: '#111', color: '#fff', padding: '.65rem .8rem', fontWeight: 700, cursor: 'pointer' }}>
+          {busy === 'start' ? 'Startar…' : 'Starta period'}
+        </button>
+      </form>
+      {message && <div style={{ color: '#a00', marginTop: '.65rem' }}>{message}</div>}
+    </div>
+  );
+}

--- a/app/vagnkort/vagnkort-client.tsx
+++ b/app/vagnkort/vagnkort-client.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import DocumentUpload from './document-upload';
+import PeriodManager from './period-manager';
 
 type JourneyPeriod = {
   period_id: string;
@@ -241,6 +242,9 @@ export default function VagnkortClient() {
             </section>
 
             <div style={grid}>
+              <section style={card}>
+                <PeriodManager regnr={data.regnr} openPeriods={data.journey.openPeriods} onChanged={() => setRefreshNonce((value) => value + 1)} />
+              </section>
               <section style={card}>
                 <h2 style={{ marginTop: 0 }}>Tid i resan</h2>
                 {Object.keys(data.journey.totalHoursByType).length === 0 ? <p>Inga perioder registrerade ännu.</p> : Object.entries(data.journey.totalHoursByType).map(([type, total]) => <div key={type} style={{ display: 'flex', justifyContent: 'space-between', padding: '.45rem 0', borderBottom: '1px solid #eee' }}><span>{type}</span><strong>{hours(total)}</strong></div>)}

--- a/migrations/20260821091800_enforce_one_open_vehicle_journey_period_type.sql
+++ b/migrations/20260821091800_enforce_one_open_vehicle_journey_period_type.sql
@@ -1,0 +1,3 @@
+create unique index if not exists vehicle_journey_periods_one_open_type_uidx
+  on public.vehicle_journey_periods (regnr, period_type)
+  where ended_at is null;

--- a/tests/vehicle-journey-period-write-contract.test.ts
+++ b/tests/vehicle-journey-period-write-contract.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const api = readFileSync(join(process.cwd(), 'app/api/vehicle-journey-periods/route.ts'), 'utf8');
+const manager = readFileSync(join(process.cwd(), 'app/vagnkort/period-manager.tsx'), 'utf8');
+const client = readFileSync(join(process.cwd(), 'app/vagnkort/vagnkort-client.tsx'), 'utf8');
+const migration = readFileSync(join(process.cwd(), 'migrations/20260821091800_enforce_one_open_vehicle_journey_period_type.sql'), 'utf8');
+
+test('journey period writes stay authenticated and server controlled', () => {
+  assert.match(api, /verifyApiUser\(request\)/);
+  assert.match(api, /SUPABASE_SERVICE_ROLE_KEY/);
+  assert.match(api, /vehicleExists/);
+  assert.match(api, /PERIOD_STARTED/);
+  assert.match(api, /PERIOD_ENDED/);
+  assert.match(api, /created_by:\s*verification\.user\.id/);
+});
+
+test('journey period API validates vehicle, period type and period ownership', () => {
+  assert.match(api, /Invalid regnr/);
+  assert.match(api, /Invalid period type/);
+  assert.match(api, /Period not found for vehicle/);
+  assert.match(api, /End time cannot be before start time/);
+  assert.match(api, /An open period of this type already exists/);
+});
+
+test('only one open period per vehicle and type is enforced in the database', () => {
+  assert.match(migration, /unique index/i);
+  assert.match(migration, /\(regnr, period_type\)/);
+  assert.match(migration, /where ended_at is null/i);
+});
+
+test('Vagnkort can start and end journey periods', () => {
+  assert.match(client, /<PeriodManager/);
+  assert.match(manager, /Starta period/);
+  assert.match(manager, /Avsluta period/);
+  assert.match(manager, /action:\s*'start'/);
+  assert.match(manager, /action:\s*'end'/);
+  assert.match(manager, /Stillestånd/);
+  assert.match(manager, /Verkstad/);
+  assert.match(manager, /Uthyrd/);
+});


### PR DESCRIPTION
Stängd som redundant. Main innehåller redan den atomiska periodlösningen via PR #368 (`/api/vehicle-journey/periods`, `journey-period-controls.tsx` och `20260820222728_atomic_vehicle_journey_period_events.sql`). Den här grenen ska inte mergas.