### PR TITLE
Tidslager: separera bilens huvudtillstånd från stilleståndsaktiviteter

### DIFF
--- a/app/api/vehicle-journey/metrics/route.ts
+++ b/app/api/vehicle-journey/metrics/route.ts
@@ -50,10 +50,15 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Vehicle journey unavailable' }, { status: 503 });
   }
 
-  const [periodsResponse, nybilResponse, vehicleResponse, saluResponse] = await Promise.all([
+  const [periodsResponse, activitiesResponse, nybilResponse, vehicleResponse, saluResponse] = await Promise.all([
     admin
       .from('vehicle_journey_periods')
       .select('period_type,started_at,ended_at,reason_code')
+      .eq('regnr', regnr)
+      .order('started_at', { ascending: true }),
+    admin
+      .from('vehicle_journey_activity_periods')
+      .select('activity_type,started_at,ended_at')
       .eq('regnr', regnr)
       .order('started_at', { ascending: true }),
     admin
@@ -76,6 +81,7 @@ export async function GET(request: Request) {
 
   const failedSource = firstError([
     ['periods', periodsResponse.error],
+    ['activities', activitiesResponse.error],
     ['nybil', nybilResponse.error],
     ['vehicle', vehicleResponse.error],
     ['SALU', saluResponse.error],
@@ -104,6 +110,7 @@ export async function GET(request: Request) {
 
   const metrics = computeJourneyLifecycleMetrics({
     periods: periodsResponse.data ?? [],
+    activities: activitiesResponse.data ?? [],
     lifecycleStartAt,
     lifecycleEndAt,
     saluAt,
@@ -115,6 +122,7 @@ export async function GET(request: Request) {
       metrics,
       coverage: {
         periodCount: periodsResponse.data?.length ?? 0,
+        activityPeriodCount: activitiesResponse.data?.length ?? 0,
         hasLifecycleStart: Boolean(lifecycleStartAt),
         hasLifecycleEnd: Boolean(lifecycleEndAt),
         hasSaluDate: Boolean(saluAt),

--- a/app/api/vehicle-journey/periods/route.ts
+++ b/app/api/vehicle-journey/periods/route.ts
@@ -5,18 +5,28 @@ import { verifyApiUser } from '@/lib/server-auth';
 const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const PERIOD_TYPES = [
+const PRIMARY_PERIOD_TYPES = [
   'PREPARATION',
   'AVAILABLE',
   'RENTAL',
   'DOWNTIME',
-  'WORKSHOP',
-  'TRANSPORT',
   'SALU',
   'OTHER',
 ] as const;
 
-type PeriodType = (typeof PERIOD_TYPES)[number];
+type PrimaryPeriodType = (typeof PRIMARY_PERIOD_TYPES)[number];
+
+const ACTIVITY_TYPES = [
+  'WORKSHOP',
+  'SERVICE',
+  'WAITING_PARTS',
+  'TRANSPORT',
+  'ADMINISTRATION',
+  'MISSING_EQUIPMENT',
+  'OTHER',
+] as const;
+
+type ActivityType = (typeof ACTIVITY_TYPES)[number];
 
 const DOWNTIME_REASONS = [
   'DAMAGE',
@@ -35,9 +45,14 @@ function cleanRegnr(value: unknown): string {
   return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
 }
 
-function cleanPeriodType(value: unknown): PeriodType | null {
+function cleanPrimaryPeriodType(value: unknown): PrimaryPeriodType | null {
   const periodType = typeof value === 'string' ? value.trim().toUpperCase() : '';
-  return PERIOD_TYPES.includes(periodType as PeriodType) ? periodType as PeriodType : null;
+  return PRIMARY_PERIOD_TYPES.includes(periodType as PrimaryPeriodType) ? periodType as PrimaryPeriodType : null;
+}
+
+function cleanActivityType(value: unknown): ActivityType | null {
+  const activityType = typeof value === 'string' ? value.trim().toUpperCase() : '';
+  return ACTIVITY_TYPES.includes(activityType as ActivityType) ? activityType as ActivityType : null;
 }
 
 function cleanReasonCode(value: unknown): string | null {
@@ -57,6 +72,10 @@ function parseTimestamp(value: unknown, fallbackToNow: boolean): string | null {
   if (typeof value !== 'string' || !value.trim()) return null;
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function cleanUuid(value: unknown): string | null {
+  return typeof value === 'string' && UUID_RE.test(value.trim()) ? value.trim() : null;
 }
 
 function createAdminClient() {
@@ -123,10 +142,10 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
     }
 
-    if (action === 'START') {
-      const periodType = cleanPeriodType(body.periodType);
+    if (action === 'START' || action === 'TRANSITION') {
+      const periodType = cleanPrimaryPeriodType(body.periodType);
       if (!periodType) {
-        return NextResponse.json({ error: 'Invalid period type' }, { status: 400 });
+        return NextResponse.json({ error: 'Invalid primary period type' }, { status: 400 });
       }
 
       const startedAt = parseTimestamp(body.startedAt, true);
@@ -146,32 +165,39 @@ export async function POST(request: Request) {
       }
 
       const periodId = crypto.randomUUID();
-      const { data: period, error: periodError } = await admin.rpc('start_vehicle_journey_period', {
+      const { data: period, error: periodError } = await admin.rpc('transition_vehicle_journey_state', {
         p_period_id: periodId,
         p_regnr: regnr,
         p_period_type: periodType,
         p_started_at: startedAt,
         p_reason_code: reasonCode,
         p_reason_text: reasonText,
+        p_source_system: 'VAGNKORT',
+        p_source_entity: 'vehicle_journey_periods',
+        p_source_record_id: periodId,
         p_actor_id: verification.user.id,
+        p_actor_source: 'MANUELL',
         p_actor_email: verification.user.email,
+        p_metadata: { createdVia: 'VAGNKORT' },
       });
 
       if (periodError) {
-        if (rpcErrorCode(periodError) === '23505') {
-          return NextResponse.json({ error: `${periodType} is already open for vehicle` }, { status: 409 });
+        const message = rpcErrorMessage(periodError);
+        if (message.includes('already in requested state')) {
+          return NextResponse.json({ error: 'Vehicle is already in requested state' }, { status: 409 });
         }
-        console.error('[vehicle-journey-periods] Atomic start failed:', periodError);
-        return NextResponse.json({ error: 'Could not start period' }, { status: 500 });
+        if (rpcErrorCode(periodError) === '22007') {
+          return NextResponse.json({ error: 'Transition time is before current state start' }, { status: 400 });
+        }
+        console.error('[vehicle-journey-periods] Atomic transition failed:', periodError);
+        return NextResponse.json({ error: 'Could not transition vehicle state' }, { status: 500 });
       }
 
       return NextResponse.json({ data: period }, { status: 201 });
     }
 
     if (action === 'CLOSE') {
-      const periodId = typeof body.periodId === 'string' && UUID_RE.test(body.periodId.trim())
-        ? body.periodId.trim()
-        : null;
+      const periodId = cleanUuid(body.periodId);
       if (!periodId) {
         return NextResponse.json({ error: 'Invalid period id' }, { status: 400 });
       }
@@ -206,6 +232,76 @@ export async function POST(request: Request) {
       }
 
       return NextResponse.json({ data: period });
+    }
+
+    if (action === 'START_ACTIVITY') {
+      const parentPeriodId = cleanUuid(body.parentPeriodId);
+      const activityType = cleanActivityType(body.activityType);
+      const startedAt = parseTimestamp(body.startedAt, true);
+      const reasonText = cleanReasonText(body.reasonText);
+      if (!parentPeriodId || !activityType || !startedAt) {
+        return NextResponse.json({ error: 'Invalid activity period input' }, { status: 400 });
+      }
+      if (activityType === 'OTHER' && !reasonText) {
+        return NextResponse.json({ error: 'Other activity requires a comment' }, { status: 400 });
+      }
+
+      const activityPeriodId = crypto.randomUUID();
+      const { data, error } = await admin.rpc('start_vehicle_journey_activity_period', {
+        p_activity_period_id: activityPeriodId,
+        p_parent_period_id: parentPeriodId,
+        p_regnr: regnr,
+        p_activity_type: activityType,
+        p_started_at: startedAt,
+        p_reason_text: reasonText,
+        p_source_system: 'VAGNKORT',
+        p_source_entity: 'vehicle_journey_activity_periods',
+        p_source_record_id: activityPeriodId,
+        p_actor_id: verification.user.id,
+        p_actor_source: 'MANUELL',
+        p_actor_email: verification.user.email,
+        p_metadata: { createdVia: 'VAGNKORT' },
+      });
+
+      if (error) {
+        if (rpcErrorCode(error) === '23505') {
+          return NextResponse.json({ error: `${activityType} is already open in this downtime` }, { status: 409 });
+        }
+        console.error('[vehicle-journey-periods] Activity start failed:', error);
+        return NextResponse.json({ error: 'Could not start journey activity' }, { status: 500 });
+      }
+      return NextResponse.json({ data }, { status: 201 });
+    }
+
+    if (action === 'CLOSE_ACTIVITY') {
+      const activityPeriodId = cleanUuid(body.activityPeriodId);
+      const endedAt = parseTimestamp(body.endedAt, true);
+      if (!activityPeriodId || !endedAt) {
+        return NextResponse.json({ error: 'Invalid activity close input' }, { status: 400 });
+      }
+
+      const { data, error } = await admin.rpc('close_vehicle_journey_activity_period', {
+        p_activity_period_id: activityPeriodId,
+        p_regnr: regnr,
+        p_ended_at: endedAt,
+        p_source_system: 'VAGNKORT',
+        p_source_entity: 'vehicle_journey_activity_periods',
+        p_source_record_id: activityPeriodId,
+        p_actor_id: verification.user.id,
+        p_actor_source: 'MANUELL',
+        p_actor_email: verification.user.email,
+      });
+
+      if (error) {
+        const code = rpcErrorCode(error);
+        const message = rpcErrorMessage(error);
+        if (code === 'P0002') return NextResponse.json({ error: 'Journey activity not found' }, { status: 404 });
+        if (message.includes('already closed')) return NextResponse.json({ error: 'Journey activity is already closed' }, { status: 409 });
+        if (code === '22007') return NextResponse.json({ error: 'Invalid activity end time' }, { status: 400 });
+        console.error('[vehicle-journey-periods] Activity close failed:', error);
+        return NextResponse.json({ error: 'Could not close journey activity' }, { status: 500 });
+      }
+      return NextResponse.json({ data });
     }
 
     return NextResponse.json({ error: 'Unknown action' }, { status: 400 });

--- a/app/vagnkort/journey-metrics-panel.tsx
+++ b/app/vagnkort/journey-metrics-panel.tsx
@@ -13,12 +13,17 @@ type JourneyMetrics = {
   rentalHours: number;
   downtimeHours: number;
   workshopHours: number;
-  availableHours: number;
+  serviceHours: number;
+  waitingPartsHours: number;
   transportHours: number;
+  administrationHours: number;
+  missingEquipmentHours: number;
+  availableHours: number;
   measuredOperationalHours: number;
   utilizationPct: number | null;
-  overlappingOperationalPeriods: boolean;
+  overlappingPrimaryPeriods: boolean;
   downtimeHoursByReason: Record<string, number>;
+  activityHoursByType: Record<string, number>;
   firstRentalAt: string | null;
   nybilToFirstRentalHours: number | null;
   lastRentalReturnAt: string | null;
@@ -35,6 +40,7 @@ type MetricsResponse = {
     metrics: JourneyMetrics;
     coverage: {
       periodCount: number;
+      activityPeriodCount: number;
       hasLifecycleStart: boolean;
       hasLifecycleEnd: boolean;
       hasSaluDate: boolean;
@@ -60,6 +66,16 @@ const reasonLabels: Record<string, string> = {
   UNSPECIFIED: 'Ej angiven',
 };
 
+const activityLabels: Record<string, string> = {
+  WORKSHOP: 'Verkstad',
+  SERVICE: 'Service',
+  WAITING_PARTS: 'Väntar reservdelar',
+  TRANSPORT: 'Transport',
+  ADMINISTRATION: 'Administration',
+  MISSING_EQUIPMENT: 'Saknad utrustning',
+  OTHER: 'Övrigt',
+};
+
 function formatHours(value: number | null | undefined) {
   if (value === null || value === undefined) return '—';
   if (value >= 24) return `${Math.round((value / 24) * 10) / 10} dygn`;
@@ -73,6 +89,7 @@ function formatPercent(value: number | null | undefined) {
 export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
   const [metrics, setMetrics] = useState<JourneyMetrics | null>(null);
   const [periodCount, setPeriodCount] = useState(0);
+  const [activityPeriodCount, setActivityPeriodCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
@@ -87,6 +104,7 @@ export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
         if (!cancelled) {
           setMetrics(body.data.metrics);
           setPeriodCount(body.data.coverage.periodCount);
+          setActivityPeriodCount(body.data.coverage.activityPeriodCount);
         }
       } catch (err) {
         if (!cancelled) {
@@ -114,6 +132,8 @@ export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
 
   const downtimeReasons = Object.entries(metrics.downtimeHoursByReason)
     .sort((left, right) => right[1] - left[1]);
+  const activities = Object.entries(metrics.activityHoursByType)
+    .sort((left, right) => right[1] - left[1]);
 
   const stats: Array<[string, string]> = [
     ['Livscykel', formatHours(metrics.lifecycleHours)],
@@ -121,7 +141,7 @@ export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
     ['Uthyrd tid', formatHours(metrics.rentalHours)],
     ['Nyttjandegrad', formatPercent(metrics.utilizationPct)],
     ['Stillestånd', formatHours(metrics.downtimeHours)],
-    ['Verkstad', formatHours(metrics.workshopHours)],
+    ['Verkstad inom stillestånd', formatHours(metrics.workshopHours)],
     ['Nybil → första uthyrning', formatHours(metrics.nybilToFirstRentalHours)],
     ['Snitt mellan uthyrningar', formatHours(metrics.averageHoursBetweenRentals)],
     ['Sista retur → SALU', formatHours(metrics.lastRentalToSaluHours)],
@@ -132,12 +152,12 @@ export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
       <div style={{ fontWeight: 700, marginBottom: '.55rem' }}>Resans nyckeltal</div>
       {periodCount === 0 && (
         <div style={{ background: '#f6f6f6', borderRadius: 8, padding: '.65rem .75rem', marginBottom: '.7rem', color: '#555' }}>
-          Ingen periodhistorik ännu. Nyckeltalen fylls på när uthyrning, stillestånd, verkstad och andra perioder registreras.
+          Ingen huvudperiodhistorik ännu. Nyckeltalen fylls på när bilens tillstånd registreras som Tillgänglig, Uthyrd, Stillestånd osv.
         </div>
       )}
-      {metrics.overlappingOperationalPeriods && (
+      {metrics.overlappingPrimaryPeriods && (
         <div style={{ background: '#fff2db', borderRadius: 8, padding: '.65rem .75rem', marginBottom: '.7rem' }}>
-          Operativa perioder överlappar. Nyttjandegrad visas därför inte förrän tidslinjen är entydig.
+          Huvudperioder överlappar. Nyttjandegrad visas därför inte förrän bilens tidslinje är entydig.
         </div>
       )}
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '.55rem' }}>
@@ -150,13 +170,27 @@ export default function JourneyMetricsPanel({ regnr, refreshNonce }: Props) {
       </div>
       {downtimeReasons.length > 0 && (
         <div style={{ marginTop: '.8rem' }}>
-          <div style={{ fontSize: 13, fontWeight: 700, marginBottom: '.25rem' }}>Stillestånd per orsak</div>
+          <div style={{ fontSize: 13, fontWeight: 700, marginBottom: '.25rem' }}>Stillestånd per huvudorsak</div>
           {downtimeReasons.map(([reason, total]) => (
             <div key={reason} style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', padding: '.3rem 0', borderTop: '1px solid #eee' }}>
               <span>{reasonLabels[reason] ?? reason}</span>
               <strong>{formatHours(total)}</strong>
             </div>
           ))}
+        </div>
+      )}
+      {activityPeriodCount > 0 && activities.length > 0 && (
+        <div style={{ marginTop: '.8rem' }}>
+          <div style={{ fontSize: 13, fontWeight: 700, marginBottom: '.25rem' }}>Aktiviteter inom stillestånd</div>
+          {activities.map(([activity, total]) => (
+            <div key={activity} style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', padding: '.3rem 0', borderTop: '1px solid #eee' }}>
+              <span>{activityLabels[activity] ?? activity}</span>
+              <strong>{formatHours(total)}</strong>
+            </div>
+          ))}
+          <div style={{ fontSize: 12, color: '#666', marginTop: '.4rem' }}>
+            Aktivitetstid är en del av stilleståndet och adderas inte till bilens totala operativa tid.
+          </div>
         </div>
       )}
       <GenericCheckpointsPanel regnr={regnr} refreshNonce={refreshNonce} />

--- a/app/vagnkort/journey-period-controls.tsx
+++ b/app/vagnkort/journey-period-controls.tsx
@@ -18,15 +18,13 @@ type Props = {
   onChanged: () => void;
 };
 
-const PERIOD_TYPES = [
+const PRIMARY_PERIOD_TYPES = [
   ['AVAILABLE', 'Tillgänglig'],
   ['RENTAL', 'Uthyrd'],
   ['DOWNTIME', 'Stillestånd'],
-  ['WORKSHOP', 'Verkstad'],
-  ['TRANSPORT', 'Transport'],
   ['PREPARATION', 'Förberedelse'],
   ['SALU', 'SALU'],
-  ['OTHER', 'Övrigt'],
+  ['OTHER', 'Övrigt huvudtillstånd'],
 ] as const;
 
 const DOWNTIME_REASONS = [
@@ -46,28 +44,28 @@ function localDateTimeValue(date = new Date()) {
 }
 
 export default function JourneyPeriodControls({ regnr, openPeriods, onChanged }: Props) {
-  const [periodType, setPeriodType] = useState('RENTAL');
+  const [periodType, setPeriodType] = useState('AVAILABLE');
   const [startedAt, setStartedAt] = useState(localDateTimeValue);
   const [reasonCode, setReasonCode] = useState('DAMAGE');
   const [reasonText, setReasonText] = useState('');
   const [busy, setBusy] = useState<string | null>(null);
   const [message, setMessage] = useState('');
 
-  const openByType = useMemo(
-    () => new Map(openPeriods.map((period) => [period.period_type, period])),
+  const currentPrimary = useMemo(
+    () => openPeriods.find((period) => period.ended_at === null) ?? null,
     [openPeriods],
   );
 
-  async function startPeriod(event: FormEvent) {
+  async function transitionPeriod(event: FormEvent) {
     event.preventDefault();
-    setBusy('start');
+    setBusy('transition');
     setMessage('');
     try {
       const response = await fetch('/api/vehicle-journey/periods', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          action: 'START',
+          action: 'TRANSITION',
           regnr,
           periodType,
           startedAt: new Date(startedAt).toISOString(),
@@ -76,19 +74,19 @@ export default function JourneyPeriodControls({ regnr, openPeriods, onChanged }:
         }),
       });
       const body = await response.json() as { error?: string };
-      if (!response.ok) throw new Error(body.error || 'Kunde inte starta perioden');
-      setMessage('Perioden är startad.');
+      if (!response.ok) throw new Error(body.error || 'Kunde inte byta huvudtillstånd');
+      setMessage('Bilens huvudtillstånd är uppdaterat. Föregående period avslutades vid samma tidpunkt.');
       setStartedAt(localDateTimeValue());
       setReasonText('');
       onChanged();
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Kunde inte starta perioden.');
+      setMessage(error instanceof Error ? error.message : 'Kunde inte byta huvudtillstånd.');
     } finally {
       setBusy(null);
     }
   }
 
-  async function closePeriod(period: JourneyPeriod) {
+  async function closeCurrent(period: JourneyPeriod) {
     setBusy(period.period_id);
     setMessage('');
     try {
@@ -103,11 +101,11 @@ export default function JourneyPeriodControls({ regnr, openPeriods, onChanged }:
         }),
       });
       const body = await response.json() as { error?: string };
-      if (!response.ok) throw new Error(body.error || 'Kunde inte avsluta perioden');
-      setMessage('Perioden är avslutad.');
+      if (!response.ok) throw new Error(body.error || 'Kunde inte avsluta huvudperioden');
+      setMessage('Huvudperioden är avslutad. Bilen saknar därefter fastställt huvudtillstånd tills nästa period startas.');
       onChanged();
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Kunde inte avsluta perioden.');
+      setMessage(error instanceof Error ? error.message : 'Kunde inte avsluta huvudperioden.');
     } finally {
       setBusy(null);
     }
@@ -115,36 +113,38 @@ export default function JourneyPeriodControls({ regnr, openPeriods, onChanged }:
 
   return (
     <div style={{ display: 'grid', gap: '.9rem' }}>
-      {openPeriods.length > 0 && (
+      <div style={{ background: '#f6f6f6', borderRadius: 8, padding: '.65rem .75rem', fontSize: 13, color: '#555' }}>
+        En bil har ett huvudtillstånd åt gången. Verkstad, service, transport och väntetid är aktiviteter inom ett stillestånd och räknas inte som parallella huvudperioder.
+      </div>
+
+      {currentPrimary && (
         <div style={{ display: 'grid', gap: '.45rem' }}>
-          <strong>Pågående perioder</strong>
-          {openPeriods.map((period) => (
-            <div key={period.period_id} style={{ display: 'flex', justifyContent: 'space-between', gap: '.75rem', alignItems: 'center', borderTop: '1px solid #eee', paddingTop: '.5rem' }}>
-              <div>
-                <div><strong>{period.period_type}</strong></div>
-                <div style={{ fontSize: 13, color: '#666' }}>{new Date(period.started_at).toLocaleString('sv-SE')}{period.reason_text ? ` · ${period.reason_text}` : period.reason_code ? ` · ${period.reason_code}` : ''}</div>
-              </div>
-              <button type="button" onClick={() => void closePeriod(period)} disabled={Boolean(busy)} style={{ border: 0, borderRadius: 8, background: '#111', color: '#fff', padding: '.55rem .75rem', fontWeight: 700 }}>
-                {busy === period.period_id ? 'Avslutar…' : 'Avsluta nu'}
-              </button>
+          <strong>Aktuellt huvudtillstånd</strong>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '.75rem', alignItems: 'center', borderTop: '1px solid #eee', paddingTop: '.5rem' }}>
+            <div>
+              <div><strong>{currentPrimary.period_type}</strong></div>
+              <div style={{ fontSize: 13, color: '#666' }}>{new Date(currentPrimary.started_at).toLocaleString('sv-SE')}{currentPrimary.reason_text ? ` · ${currentPrimary.reason_text}` : currentPrimary.reason_code ? ` · ${currentPrimary.reason_code}` : ''}</div>
             </div>
-          ))}
+            <button type="button" onClick={() => void closeCurrent(currentPrimary)} disabled={Boolean(busy)} style={{ border: 0, borderRadius: 8, background: '#111', color: '#fff', padding: '.55rem .75rem', fontWeight: 700 }}>
+              {busy === currentPrimary.period_id ? 'Avslutar…' : 'Avsluta utan nytt tillstånd'}
+            </button>
+          </div>
         </div>
       )}
 
-      <form onSubmit={startPeriod} style={{ display: 'grid', gap: '.65rem' }}>
-        <strong>Starta ny period</strong>
+      <form onSubmit={transitionPeriod} style={{ display: 'grid', gap: '.65rem' }}>
+        <strong>{currentPrimary ? 'Byt huvudtillstånd' : 'Starta huvudtillstånd'}</strong>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '.6rem' }}>
           <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
-            Typ
+            Tillstånd
             <select value={periodType} onChange={(event) => setPeriodType(event.target.value)} disabled={Boolean(busy)} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
-              {PERIOD_TYPES.map(([value, label]) => (
-                <option key={value} value={value} disabled={openByType.has(value)}>{label}{openByType.has(value) ? ' · pågår' : ''}</option>
+              {PRIMARY_PERIOD_TYPES.map(([value, label]) => (
+                <option key={value} value={value} disabled={currentPrimary?.period_type === value}>{label}{currentPrimary?.period_type === value ? ' · pågår' : ''}</option>
               ))}
             </select>
           </label>
           <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
-            Starttid
+            Tidpunkt för bytet
             <input type="datetime-local" value={startedAt} onChange={(event) => setStartedAt(event.target.value)} disabled={Boolean(busy)} required style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
           </label>
         </div>
@@ -152,20 +152,20 @@ export default function JourneyPeriodControls({ regnr, openPeriods, onChanged }:
         {periodType === 'DOWNTIME' && (
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '.6rem' }}>
             <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
-              Orsak
+              Huvudorsak
               <select value={reasonCode} onChange={(event) => setReasonCode(event.target.value)} disabled={Boolean(busy)} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
                 {DOWNTIME_REASONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
               </select>
             </label>
             <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
               Kommentar {reasonCode === 'OTHER' ? '(krävs)' : '(valfri)'}
-              <input value={reasonText} onChange={(event) => setReasonText(event.target.value)} required={reasonCode === 'OTHER'} disabled={Boolean(busy)} placeholder="T.ex. väntar delar från leverantör" style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
+              <input value={reasonText} onChange={(event) => setReasonText(event.target.value)} required={reasonCode === 'OTHER'} disabled={Boolean(busy)} placeholder="T.ex. skada, väntar delar eller administrativ spärr" style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
             </label>
           </div>
         )}
 
-        <button type="submit" disabled={Boolean(busy) || openByType.has(periodType)} style={{ justifySelf: 'start', border: 0, borderRadius: 8, background: '#111', color: '#fff', padding: '.65rem 1rem', fontWeight: 700 }}>
-          {busy === 'start' ? 'Startar…' : 'Starta period'}
+        <button type="submit" disabled={Boolean(busy) || currentPrimary?.period_type === periodType} style={{ justifySelf: 'start', border: 0, borderRadius: 8, background: '#111', color: '#fff', padding: '.65rem 1rem', fontWeight: 700 }}>
+          {busy === 'transition' ? 'Sparar…' : currentPrimary ? 'Byt tillstånd' : 'Starta tillstånd'}
         </button>
       </form>
 

--- a/lib/vehicle-journey-metrics.ts
+++ b/lib/vehicle-journey-metrics.ts
@@ -5,6 +5,12 @@ export type JourneyMetricPeriod = {
   reason_code?: string | null;
 };
 
+export type JourneyMetricActivityPeriod = {
+  activity_type: string;
+  started_at: string;
+  ended_at: string | null;
+};
+
 export type JourneyLifecycleMetrics = {
   lifecycleStartAt: string | null;
   lifecycleEndAt: string | null;
@@ -14,12 +20,17 @@ export type JourneyLifecycleMetrics = {
   rentalHours: number;
   downtimeHours: number;
   workshopHours: number;
-  availableHours: number;
+  serviceHours: number;
+  waitingPartsHours: number;
   transportHours: number;
+  administrationHours: number;
+  missingEquipmentHours: number;
+  availableHours: number;
   measuredOperationalHours: number;
   utilizationPct: number | null;
-  overlappingOperationalPeriods: boolean;
+  overlappingPrimaryPeriods: boolean;
   downtimeHoursByReason: Record<string, number>;
+  activityHoursByType: Record<string, number>;
   firstRentalAt: string | null;
   nybilToFirstRentalHours: number | null;
   lastRentalReturnAt: string | null;
@@ -32,13 +43,14 @@ export type JourneyLifecycleMetrics = {
 
 type MetricInput = {
   periods: JourneyMetricPeriod[];
+  activities?: JourneyMetricActivityPeriod[];
   lifecycleStartAt?: string | null;
   lifecycleEndAt?: string | null;
   saluAt?: string | null;
   now?: string;
 };
 
-const OPERATIONAL_TYPES = new Set(['AVAILABLE', 'RENTAL', 'DOWNTIME', 'WORKSHOP', 'TRANSPORT']);
+const PRIMARY_OPERATIONAL_TYPES = new Set(['AVAILABLE', 'RENTAL', 'DOWNTIME']);
 
 function parseMs(value: string | null | undefined): number | null {
   if (!value) return null;
@@ -61,7 +73,7 @@ function hoursBetween(start: string | null | undefined, end: string | null | und
   return roundHours((endMs - startMs) / 3_600_000);
 }
 
-function effectivePeriod(period: JourneyMetricPeriod, nowMs: number) {
+function effectivePeriod<T extends { started_at: string; ended_at: string | null }>(period: T, nowMs: number) {
   const startMs = parseMs(period.started_at);
   const endMs = period.ended_at ? parseMs(period.ended_at) : nowMs;
   if (startMs === null || endMs === null || endMs < startMs) return null;
@@ -86,16 +98,26 @@ function hasOverlap(periods: Array<{ startMs: number; endMs: number }>): boolean
 export function computeJourneyLifecycleMetrics(input: MetricInput): JourneyLifecycleMetrics {
   const now = input.now ?? new Date().toISOString();
   const nowMs = parseMs(now) ?? Date.now();
-  const effective = input.periods
-    .map((period) => effectivePeriod(period, nowMs))
-    .filter((period): period is NonNullable<ReturnType<typeof effectivePeriod>> => period !== null);
 
-  const hoursByType = effective.reduce<Record<string, number>>((totals, period) => {
+  const effectivePrimary = input.periods
+    .map((period) => effectivePeriod(period, nowMs))
+    .filter((period): period is NonNullable<ReturnType<typeof effectivePeriod<JourneyMetricPeriod>>> => period !== null);
+
+  const effectiveActivities = (input.activities ?? [])
+    .map((period) => effectivePeriod(period, nowMs))
+    .filter((period): period is NonNullable<ReturnType<typeof effectivePeriod<JourneyMetricActivityPeriod>>> => period !== null);
+
+  const hoursByType = effectivePrimary.reduce<Record<string, number>>((totals, period) => {
     totals[period.period_type] = roundHours((totals[period.period_type] ?? 0) + period.hours);
     return totals;
   }, {});
 
-  const downtimeHoursByReason = effective
+  const activityHoursByType = effectiveActivities.reduce<Record<string, number>>((totals, period) => {
+    totals[period.activity_type] = roundHours((totals[period.activity_type] ?? 0) + period.hours);
+    return totals;
+  }, {});
+
+  const downtimeHoursByReason = effectivePrimary
     .filter((period) => period.period_type === 'DOWNTIME')
     .reduce<Record<string, number>>((totals, period) => {
       const reason = period.reason_code?.trim() || 'UNSPECIFIED';
@@ -103,22 +125,18 @@ export function computeJourneyLifecycleMetrics(input: MetricInput): JourneyLifec
       return totals;
     }, {});
 
-  const rentals = effective
+  const rentals = effectivePrimary
     .filter((period) => period.period_type === 'RENTAL')
     .sort((left, right) => left.startMs - right.startMs);
 
   const rentalHours = hoursByType.RENTAL ?? 0;
   const downtimeHours = hoursByType.DOWNTIME ?? 0;
-  const workshopHours = hoursByType.WORKSHOP ?? 0;
   const availableHours = hoursByType.AVAILABLE ?? 0;
-  const transportHours = hoursByType.TRANSPORT ?? 0;
-  const measuredOperationalHours = roundHours(
-    rentalHours + downtimeHours + workshopHours + availableHours + transportHours,
-  );
+  const measuredOperationalHours = roundHours(rentalHours + downtimeHours + availableHours);
 
-  const operationalPeriods = effective.filter((period) => OPERATIONAL_TYPES.has(period.period_type));
-  const overlappingOperationalPeriods = hasOverlap(operationalPeriods);
-  const utilizationPct = measuredOperationalHours > 0 && !overlappingOperationalPeriods
+  const primaryOperationalPeriods = effectivePrimary.filter((period) => PRIMARY_OPERATIONAL_TYPES.has(period.period_type));
+  const overlappingPrimaryPeriods = hasOverlap(primaryOperationalPeriods);
+  const utilizationPct = measuredOperationalHours > 0 && !overlappingPrimaryPeriods
     ? roundPct((rentalHours / measuredOperationalHours) * 100)
     : null;
 
@@ -153,13 +171,18 @@ export function computeJourneyLifecycleMetrics(input: MetricInput): JourneyLifec
     rentalCount: rentals.length,
     rentalHours,
     downtimeHours,
-    workshopHours,
+    workshopHours: activityHoursByType.WORKSHOP ?? 0,
+    serviceHours: activityHoursByType.SERVICE ?? 0,
+    waitingPartsHours: activityHoursByType.WAITING_PARTS ?? 0,
+    transportHours: activityHoursByType.TRANSPORT ?? 0,
+    administrationHours: activityHoursByType.ADMINISTRATION ?? 0,
+    missingEquipmentHours: activityHoursByType.MISSING_EQUIPMENT ?? 0,
     availableHours,
-    transportHours,
     measuredOperationalHours,
     utilizationPct,
-    overlappingOperationalPeriods,
+    overlappingPrimaryPeriods,
     downtimeHoursByReason,
+    activityHoursByType,
     firstRentalAt,
     nybilToFirstRentalHours: hoursBetween(lifecycleStartAt, firstRentalAt),
     lastRentalReturnAt,

--- a/migrations/20260821113000_split_vehicle_state_and_activity_periods.sql
+++ b/migrations/20260821113000_split_vehicle_state_and_activity_periods.sql
@@ -1,0 +1,732 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- The vehicle journey has one primary operational state at a time. Workshop,
+-- transport, waiting for parts etc. are activities/causes inside downtime and
+-- must not be counted as competing vehicle states.
+do $$
+begin
+  if exists (
+    select 1
+    from public.vehicle_journey_periods
+    where period_type in ('WORKSHOP', 'TRANSPORT')
+  ) then
+    raise exception 'Cannot split journey time model while WORKSHOP/TRANSPORT primary periods exist';
+  end if;
+end;
+$$;
+
+alter table public.vehicle_journey_periods
+  drop constraint if exists vehicle_journey_periods_period_type_check;
+
+alter table public.vehicle_journey_periods
+  add constraint vehicle_journey_periods_period_type_check
+  check (period_type in ('PREPARATION', 'AVAILABLE', 'RENTAL', 'DOWNTIME', 'SALU', 'OTHER'));
+
+drop index if exists public.vehicle_journey_periods_one_open_type_uidx;
+
+create unique index if not exists vehicle_journey_periods_one_open_state_uidx
+  on public.vehicle_journey_periods (regnr)
+  where ended_at is null;
+
+create table public.vehicle_journey_activity_periods (
+  activity_period_id uuid primary key default gen_random_uuid(),
+  parent_period_id uuid not null references public.vehicle_journey_periods(period_id) on delete restrict,
+  regnr text not null check (length(trim(regnr)) > 0),
+  activity_type text not null
+    check (activity_type in (
+      'WORKSHOP',
+      'SERVICE',
+      'WAITING_PARTS',
+      'TRANSPORT',
+      'ADMINISTRATION',
+      'MISSING_EQUIPMENT',
+      'OTHER'
+    )),
+  started_at timestamptz not null,
+  ended_at timestamptz,
+  reason_text text,
+  source_system text not null default 'INCHECKAD' check (length(trim(source_system)) > 0),
+  source_entity text,
+  source_record_id text,
+  source_event_id uuid references public.vehicle_journey_events(event_id) on delete restrict,
+  metadata jsonb not null default '{}'::jsonb check (jsonb_typeof(metadata) = 'object'),
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  check (ended_at is null or ended_at >= started_at)
+);
+
+create index vehicle_journey_activity_periods_regnr_time_idx
+  on public.vehicle_journey_activity_periods (regnr, started_at desc);
+create index vehicle_journey_activity_periods_parent_time_idx
+  on public.vehicle_journey_activity_periods (parent_period_id, started_at desc);
+create unique index vehicle_journey_activity_periods_one_open_type_uidx
+  on public.vehicle_journey_activity_periods (parent_period_id, activity_type)
+  where ended_at is null;
+
+alter table public.vehicle_journey_activity_periods enable row level security;
+revoke all on public.vehicle_journey_activity_periods from public, anon, authenticated;
+grant select, insert, update, delete on public.vehicle_journey_activity_periods to service_role;
+
+create or replace function public.start_vehicle_journey_activity_period(
+  p_activity_period_id uuid,
+  p_parent_period_id uuid,
+  p_regnr text,
+  p_activity_type text,
+  p_started_at timestamptz,
+  p_reason_text text,
+  p_source_system text,
+  p_source_entity text,
+  p_source_record_id text,
+  p_actor_id uuid,
+  p_actor_source text,
+  p_actor_email text,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_parent public.vehicle_journey_periods%rowtype;
+  v_event_id uuid;
+  v_activity public.vehicle_journey_activity_periods%rowtype;
+begin
+  if p_activity_type not in (
+    'WORKSHOP', 'SERVICE', 'WAITING_PARTS', 'TRANSPORT',
+    'ADMINISTRATION', 'MISSING_EQUIPMENT', 'OTHER'
+  ) then
+    raise exception 'Invalid journey activity type' using errcode = '22023';
+  end if;
+
+  if length(trim(coalesce(p_source_system, ''))) = 0 then
+    raise exception 'Source system is required' using errcode = '22023';
+  end if;
+
+  if p_actor_source not in ('SYSTEM', 'MANUELL', 'EXTERNAL') then
+    raise exception 'Invalid actor source' using errcode = '22023';
+  end if;
+
+  if pg_catalog.jsonb_typeof(coalesce(p_metadata, '{}'::jsonb)) <> 'object' then
+    raise exception 'Activity metadata must be an object' using errcode = '22023';
+  end if;
+
+  select *
+  into v_parent
+  from public.vehicle_journey_periods
+  where period_id = p_parent_period_id
+    and regnr = p_regnr
+  for update;
+
+  if not found then
+    raise exception 'Parent downtime period not found for vehicle' using errcode = 'P0002';
+  end if;
+
+  if v_parent.period_type <> 'DOWNTIME' then
+    raise exception 'Journey activities require a DOWNTIME parent' using errcode = 'P0001';
+  end if;
+
+  if v_parent.ended_at is not null then
+    raise exception 'Cannot start activity in a closed downtime period' using errcode = 'P0001';
+  end if;
+
+  if p_started_at < v_parent.started_at then
+    raise exception 'Activity cannot start before parent downtime' using errcode = '22007';
+  end if;
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    p_regnr,
+    'ACTIVITY_PERIOD_STARTED',
+    'vehicle-activity:' || p_activity_period_id::text || ':ACTIVITY_PERIOD_STARTED',
+    p_started_at,
+    trim(p_source_system),
+    nullif(trim(coalesce(p_source_entity, '')), ''),
+    nullif(trim(coalesce(p_source_record_id, '')), ''),
+    p_actor_id,
+    p_actor_source,
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'activityPeriodId', p_activity_period_id,
+      'parentPeriodId', p_parent_period_id,
+      'activityType', p_activity_type,
+      'startedAt', p_started_at,
+      'reasonText', nullif(trim(coalesce(p_reason_text, '')), '')
+    )
+  )
+  returning event_id into v_event_id;
+
+  insert into public.vehicle_journey_activity_periods (
+    activity_period_id,
+    parent_period_id,
+    regnr,
+    activity_type,
+    started_at,
+    reason_text,
+    source_system,
+    source_entity,
+    source_record_id,
+    source_event_id,
+    metadata,
+    created_by
+  ) values (
+    p_activity_period_id,
+    p_parent_period_id,
+    p_regnr,
+    p_activity_type,
+    p_started_at,
+    nullif(trim(coalesce(p_reason_text, '')), ''),
+    trim(p_source_system),
+    nullif(trim(coalesce(p_source_entity, '')), ''),
+    nullif(trim(coalesce(p_source_record_id, '')), ''),
+    v_event_id,
+    coalesce(p_metadata, '{}'::jsonb),
+    p_actor_id
+  )
+  returning * into v_activity;
+
+  return pg_catalog.jsonb_build_object(
+    'activity_period_id', v_activity.activity_period_id,
+    'parent_period_id', v_activity.parent_period_id,
+    'activity_type', v_activity.activity_type,
+    'started_at', v_activity.started_at,
+    'ended_at', v_activity.ended_at,
+    'reason_text', v_activity.reason_text,
+    'source_system', v_activity.source_system,
+    'source_event_id', v_activity.source_event_id,
+    'metadata', v_activity.metadata,
+    'created_at', v_activity.created_at,
+    'updated_at', v_activity.updated_at
+  );
+end;
+$$;
+
+create or replace function public.close_vehicle_journey_activity_period(
+  p_activity_period_id uuid,
+  p_regnr text,
+  p_ended_at timestamptz,
+  p_source_system text,
+  p_source_entity text,
+  p_source_record_id text,
+  p_actor_id uuid,
+  p_actor_source text,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_activity public.vehicle_journey_activity_periods%rowtype;
+  v_parent public.vehicle_journey_periods%rowtype;
+  v_duration_hours numeric;
+begin
+  select *
+  into v_activity
+  from public.vehicle_journey_activity_periods
+  where activity_period_id = p_activity_period_id
+    and regnr = p_regnr
+  for update;
+
+  if not found then
+    raise exception 'Journey activity not found for vehicle' using errcode = 'P0002';
+  end if;
+
+  if v_activity.ended_at is not null then
+    raise exception 'Journey activity is already closed' using errcode = 'P0001';
+  end if;
+
+  select *
+  into v_parent
+  from public.vehicle_journey_periods
+  where period_id = v_activity.parent_period_id
+  for update;
+
+  if not found then
+    raise exception 'Parent downtime period not found' using errcode = 'P0002';
+  end if;
+
+  if p_ended_at < v_activity.started_at then
+    raise exception 'Activity end cannot be before activity start' using errcode = '22007';
+  end if;
+
+  if v_parent.ended_at is not null and p_ended_at > v_parent.ended_at then
+    raise exception 'Activity cannot end after parent downtime' using errcode = '22007';
+  end if;
+
+  update public.vehicle_journey_activity_periods
+  set ended_at = p_ended_at,
+      updated_at = pg_catalog.now()
+  where activity_period_id = p_activity_period_id
+  returning * into v_activity;
+
+  v_duration_hours := pg_catalog.round(
+    (extract(epoch from (p_ended_at - v_activity.started_at)) / 3600.0)::numeric,
+    1
+  );
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    p_regnr,
+    'ACTIVITY_PERIOD_ENDED',
+    'vehicle-activity:' || p_activity_period_id::text || ':ACTIVITY_PERIOD_ENDED',
+    p_ended_at,
+    trim(p_source_system),
+    nullif(trim(coalesce(p_source_entity, '')), ''),
+    nullif(trim(coalesce(p_source_record_id, '')), ''),
+    p_actor_id,
+    p_actor_source,
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'activityPeriodId', v_activity.activity_period_id,
+      'parentPeriodId', v_activity.parent_period_id,
+      'activityType', v_activity.activity_type,
+      'startedAt', v_activity.started_at,
+      'endedAt', p_ended_at,
+      'durationHours', v_duration_hours,
+      'reasonText', v_activity.reason_text
+    )
+  );
+
+  return pg_catalog.jsonb_build_object(
+    'activity_period_id', v_activity.activity_period_id,
+    'parent_period_id', v_activity.parent_period_id,
+    'activity_type', v_activity.activity_type,
+    'started_at', v_activity.started_at,
+    'ended_at', v_activity.ended_at,
+    'reason_text', v_activity.reason_text,
+    'source_system', v_activity.source_system,
+    'source_event_id', v_activity.source_event_id,
+    'metadata', v_activity.metadata,
+    'created_at', v_activity.created_at,
+    'updated_at', v_activity.updated_at,
+    'durationHours', v_duration_hours
+  );
+end;
+$$;
+
+create or replace function public.transition_vehicle_journey_state(
+  p_period_id uuid,
+  p_regnr text,
+  p_period_type text,
+  p_started_at timestamptz,
+  p_reason_code text,
+  p_reason_text text,
+  p_source_system text,
+  p_source_entity text,
+  p_source_record_id text,
+  p_actor_id uuid,
+  p_actor_source text,
+  p_actor_email text,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_current public.vehicle_journey_periods%rowtype;
+  v_new public.vehicle_journey_periods%rowtype;
+  v_start_event_id uuid;
+  v_duration_hours numeric;
+  v_activity record;
+begin
+  if p_period_type not in ('PREPARATION', 'AVAILABLE', 'RENTAL', 'DOWNTIME', 'SALU', 'OTHER') then
+    raise exception 'Invalid vehicle journey state' using errcode = '22023';
+  end if;
+
+  if p_period_type = 'DOWNTIME' then
+    if p_reason_code not in (
+      'DAMAGE', 'WORKSHOP', 'SERVICE', 'WAITING_PARTS',
+      'MISSING_EQUIPMENT', 'TRANSPORT', 'ADMINISTRATION', 'OTHER'
+    ) then
+      raise exception 'Downtime requires a valid reason' using errcode = '22023';
+    end if;
+    if p_reason_code = 'OTHER' and length(trim(coalesce(p_reason_text, ''))) = 0 then
+      raise exception 'Other downtime requires a comment' using errcode = '22023';
+    end if;
+  end if;
+
+  if length(trim(coalesce(p_source_system, ''))) = 0 then
+    raise exception 'Source system is required' using errcode = '22023';
+  end if;
+
+  if p_actor_source not in ('SYSTEM', 'MANUELL', 'EXTERNAL') then
+    raise exception 'Invalid actor source' using errcode = '22023';
+  end if;
+
+  if pg_catalog.jsonb_typeof(coalesce(p_metadata, '{}'::jsonb)) <> 'object' then
+    raise exception 'Period metadata must be an object' using errcode = '22023';
+  end if;
+
+  select *
+  into v_current
+  from public.vehicle_journey_periods
+  where regnr = p_regnr
+    and ended_at is null
+  for update;
+
+  if found then
+    if p_started_at < v_current.started_at then
+      raise exception 'Transition time cannot be before current state start' using errcode = '22007';
+    end if;
+
+    if v_current.period_type = p_period_type
+      and coalesce(v_current.reason_code, '') = coalesce(p_reason_code, '')
+      and coalesce(v_current.reason_text, '') = coalesce(nullif(trim(coalesce(p_reason_text, '')), ''), '') then
+      raise exception 'Vehicle is already in requested state' using errcode = 'P0001';
+    end if;
+
+    if v_current.period_type = 'DOWNTIME' then
+      for v_activity in
+        select activity_period_id
+        from public.vehicle_journey_activity_periods
+        where parent_period_id = v_current.period_id
+          and ended_at is null
+        order by started_at, activity_period_id
+        for update
+      loop
+        perform public.close_vehicle_journey_activity_period(
+          v_activity.activity_period_id,
+          p_regnr,
+          p_started_at,
+          p_source_system,
+          p_source_entity,
+          p_source_record_id,
+          p_actor_id,
+          p_actor_source,
+          p_actor_email
+        );
+      end loop;
+    end if;
+
+    update public.vehicle_journey_periods
+    set ended_at = p_started_at,
+        updated_at = pg_catalog.now()
+    where period_id = v_current.period_id;
+
+    v_duration_hours := pg_catalog.round(
+      (extract(epoch from (p_started_at - v_current.started_at)) / 3600.0)::numeric,
+      1
+    );
+
+    insert into public.vehicle_journey_events (
+      regnr,
+      event_type,
+      event_key,
+      occurred_at,
+      source_system,
+      source_entity,
+      source_record_id,
+      actor_id,
+      actor_source,
+      actor_email,
+      payload
+    ) values (
+      p_regnr,
+      'PERIOD_ENDED',
+      'vehicle-period:' || v_current.period_id::text || ':PERIOD_ENDED',
+      p_started_at,
+      trim(p_source_system),
+      nullif(trim(coalesce(p_source_entity, '')), ''),
+      nullif(trim(coalesce(p_source_record_id, '')), ''),
+      p_actor_id,
+      p_actor_source,
+      p_actor_email,
+      pg_catalog.jsonb_build_object(
+        'periodType', v_current.period_type,
+        'startedAt', v_current.started_at,
+        'endedAt', p_started_at,
+        'durationHours', v_duration_hours,
+        'reasonCode', v_current.reason_code,
+        'reasonText', v_current.reason_text,
+        'transitionedTo', p_period_type
+      )
+    );
+  end if;
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    p_regnr,
+    'PERIOD_STARTED',
+    'vehicle-period:' || p_period_id::text || ':PERIOD_STARTED',
+    p_started_at,
+    trim(p_source_system),
+    nullif(trim(coalesce(p_source_entity, '')), ''),
+    nullif(trim(coalesce(p_source_record_id, '')), ''),
+    p_actor_id,
+    p_actor_source,
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'periodType', p_period_type,
+      'startedAt', p_started_at,
+      'reasonCode', p_reason_code,
+      'reasonText', nullif(trim(coalesce(p_reason_text, '')), ''),
+      'transitionedFromPeriodId', case when v_current.period_id is null then null else v_current.period_id end
+    )
+  )
+  returning event_id into v_start_event_id;
+
+  insert into public.vehicle_journey_periods (
+    period_id,
+    regnr,
+    period_type,
+    started_at,
+    reason_code,
+    reason_text,
+    source_system,
+    source_entity,
+    source_record_id,
+    source_event_id,
+    metadata,
+    created_by
+  ) values (
+    p_period_id,
+    p_regnr,
+    p_period_type,
+    p_started_at,
+    p_reason_code,
+    nullif(trim(coalesce(p_reason_text, '')), ''),
+    trim(p_source_system),
+    nullif(trim(coalesce(p_source_entity, '')), ''),
+    nullif(trim(coalesce(p_source_record_id, '')), ''),
+    v_start_event_id,
+    coalesce(p_metadata, '{}'::jsonb),
+    p_actor_id
+  )
+  returning * into v_new;
+
+  return pg_catalog.jsonb_build_object(
+    'previousPeriodId', case when v_current.period_id is null then null else v_current.period_id end,
+    'period', pg_catalog.jsonb_build_object(
+      'period_id', v_new.period_id,
+      'period_type', v_new.period_type,
+      'started_at', v_new.started_at,
+      'ended_at', v_new.ended_at,
+      'reason_code', v_new.reason_code,
+      'reason_text', v_new.reason_text,
+      'source_system', v_new.source_system,
+      'source_event_id', v_new.source_event_id,
+      'metadata', v_new.metadata,
+      'created_at', v_new.created_at,
+      'updated_at', v_new.updated_at
+    )
+  );
+end;
+$$;
+
+-- Keep the legacy start RPC callable while making its semantics match the new
+-- one-state model. Existing callers therefore cannot reopen parallel states.
+create or replace function public.start_vehicle_journey_period(
+  p_period_id uuid,
+  p_regnr text,
+  p_period_type text,
+  p_started_at timestamptz,
+  p_reason_code text,
+  p_reason_text text,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_result jsonb;
+begin
+  v_result := public.transition_vehicle_journey_state(
+    p_period_id,
+    p_regnr,
+    p_period_type,
+    p_started_at,
+    p_reason_code,
+    p_reason_text,
+    'VAGNKORT',
+    'vehicle_journey_periods',
+    p_period_id::text,
+    p_actor_id,
+    'MANUELL',
+    p_actor_email,
+    '{"createdVia":"VAGNKORT"}'::jsonb
+  );
+  return v_result -> 'period';
+end;
+$$;
+
+-- Closing a DOWNTIME state directly also closes any still-open child
+-- activities at the same timestamp, so a child can never outlive its parent.
+create or replace function public.close_vehicle_journey_period(
+  p_period_id uuid,
+  p_regnr text,
+  p_ended_at timestamptz,
+  p_actor_id uuid,
+  p_actor_email text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_period public.vehicle_journey_periods%rowtype;
+  v_duration_hours numeric;
+  v_activity record;
+begin
+  select *
+  into v_period
+  from public.vehicle_journey_periods
+  where period_id = p_period_id
+    and regnr = p_regnr
+  for update;
+
+  if not found then
+    raise exception 'Period not found for vehicle' using errcode = 'P0002';
+  end if;
+
+  if v_period.ended_at is not null then
+    raise exception 'Period is already closed' using errcode = 'P0001';
+  end if;
+
+  if p_ended_at < v_period.started_at then
+    raise exception 'End time cannot be before start time' using errcode = '22007';
+  end if;
+
+  if v_period.period_type = 'DOWNTIME' then
+    for v_activity in
+      select activity_period_id
+      from public.vehicle_journey_activity_periods
+      where parent_period_id = v_period.period_id
+        and ended_at is null
+      order by started_at, activity_period_id
+      for update
+    loop
+      perform public.close_vehicle_journey_activity_period(
+        v_activity.activity_period_id,
+        p_regnr,
+        p_ended_at,
+        'VAGNKORT',
+        'vehicle_journey_periods',
+        p_period_id::text,
+        p_actor_id,
+        'MANUELL',
+        p_actor_email
+      );
+    end loop;
+  end if;
+
+  update public.vehicle_journey_periods
+  set ended_at = p_ended_at,
+      updated_at = pg_catalog.now()
+  where period_id = p_period_id
+  returning * into v_period;
+
+  v_duration_hours := pg_catalog.round(
+    (extract(epoch from (p_ended_at - v_period.started_at)) / 3600.0)::numeric,
+    1
+  );
+
+  insert into public.vehicle_journey_events (
+    regnr,
+    event_type,
+    event_key,
+    occurred_at,
+    source_system,
+    source_entity,
+    source_record_id,
+    actor_id,
+    actor_source,
+    actor_email,
+    payload
+  ) values (
+    p_regnr,
+    'PERIOD_ENDED',
+    'vehicle-period:' || p_period_id::text || ':PERIOD_ENDED',
+    p_ended_at,
+    'VAGNKORT',
+    'vehicle_journey_periods',
+    p_period_id::text,
+    p_actor_id,
+    'MANUELL',
+    p_actor_email,
+    pg_catalog.jsonb_build_object(
+      'periodType', v_period.period_type,
+      'startedAt', v_period.started_at,
+      'endedAt', p_ended_at,
+      'durationHours', v_duration_hours,
+      'reasonCode', v_period.reason_code,
+      'reasonText', v_period.reason_text
+    )
+  );
+
+  return pg_catalog.jsonb_build_object(
+    'period_id', v_period.period_id,
+    'period_type', v_period.period_type,
+    'started_at', v_period.started_at,
+    'ended_at', v_period.ended_at,
+    'reason_code', v_period.reason_code,
+    'reason_text', v_period.reason_text,
+    'source_system', v_period.source_system,
+    'source_event_id', v_period.source_event_id,
+    'metadata', v_period.metadata,
+    'created_at', v_period.created_at,
+    'updated_at', v_period.updated_at,
+    'durationHours', v_duration_hours
+  );
+end;
+$$;
+
+revoke all on function public.start_vehicle_journey_activity_period(uuid, uuid, text, text, timestamptz, text, text, text, text, uuid, text, text, jsonb)
+  from public, anon, authenticated;
+revoke all on function public.close_vehicle_journey_activity_period(uuid, text, timestamptz, text, text, text, uuid, text, text)
+  from public, anon, authenticated;
+revoke all on function public.transition_vehicle_journey_state(uuid, text, text, timestamptz, text, text, text, text, text, uuid, text, text, jsonb)
+  from public, anon, authenticated;
+
+grant execute on function public.start_vehicle_journey_activity_period(uuid, uuid, text, text, timestamptz, text, text, text, text, uuid, text, text, jsonb)
+  to service_role;
+grant execute on function public.close_vehicle_journey_activity_period(uuid, text, timestamptz, text, text, text, uuid, text, text)
+  to service_role;
+grant execute on function public.transition_vehicle_journey_state(uuid, text, text, timestamptz, text, text, text, text, text, uuid, text, text, jsonb)
+  to service_role;
+
+commit;

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -12,6 +12,7 @@ const documentApi = read('app/api/vehicle-documents/[id]/route.ts');
 const periodControls = read('app/vagnkort/journey-period-controls.tsx');
 const periodApi = read('app/api/vehicle-journey/periods/route.ts');
 const periodMigration = read('migrations/20260820222728_atomic_vehicle_journey_period_events.sql');
+const timeModelMigration = read('migrations/20260821113000_split_vehicle_state_and_activity_periods.sql');
 const metricsPanel = read('app/vagnkort/journey-metrics-panel.tsx');
 const metricsApi = read('app/api/vehicle-journey/metrics/route.ts');
 const saluPanel = read('app/vagnkort/salu-journey-panel.tsx');
@@ -34,8 +35,8 @@ test('Vagnkort reads the authenticated vehicle journey API', () => {
 
 test('Vagnkort surfaces lifecycle metrics and refreshes them with period changes', () => {
   matches(client, [/<JourneyMetricsPanel regnr=\{data\.regnr\} refreshNonce=\{refreshNonce\} \/>/]);
-  matches(metricsPanel, [/\/api\/vehicle-journey\/metrics\?reg=/, /Resans nyckeltal/, /Nyttjandegrad/, /Nybil → första uthyrning/, /Sista retur → SALU/, /Stillestånd per orsak/, /Operativa perioder överlappar/]);
-  matches(metricsApi, [/verifyApiUser\(request\)/, /computeJourneyLifecycleMetrics/]);
+  matches(metricsPanel, [/\/api\/vehicle-journey\/metrics\?reg=/, /Resans nyckeltal/, /Nyttjandegrad/, /Nybil → första uthyrning/, /Sista retur → SALU/, /Stillestånd per huvudorsak/, /Aktiviteter inom stillestånd/, /Huvudperioder överlappar/]);
+  matches(metricsApi, [/verifyApiUser\(request\)/, /computeJourneyLifecycleMetrics/, /vehicle_journey_activity_periods/]);
 });
 
 test('Vagnkort presents SALU as the endpoint with deviations, handling and evidence', () => {
@@ -72,14 +73,17 @@ test('document server API stays authenticated, private and appends a journey eve
   matches(documentApi, [/verifyApiUser\(request\)/, /createSignedUrl/, /300/]);
 });
 
-test('Vagnkort can start and close vehicle journey periods', () => {
+test('Vagnkort treats period controls as one primary vehicle state at a time', () => {
   matches(client, [/<JourneyPeriodControls regnr=/]);
-  matches(periodControls, [/Tillgänglig/, /Uthyrd/, /Stillestånd/, /Verkstad/, /Väntar reservdelar/, /action:\s*'START'/, /action:\s*'CLOSE'/, /\/api\/vehicle-journey\/periods/]);
+  matches(periodControls, [/Tillgänglig/, /Uthyrd/, /Stillestånd/, /Förberedelse/, /ett huvudtillstånd åt gången/, /aktiviteter inom ett stillestånd/, /action:\s*'TRANSITION'/, /action:\s*'CLOSE'/, /\/api\/vehicle-journey\/periods/]);
+  assert.doesNotMatch(periodControls, /\['WORKSHOP', 'Verkstad'\]/);
+  assert.doesNotMatch(periodControls, /\['TRANSPORT', 'Transport'\]/);
 });
 
-test('journey period API validates input and persists period events atomically', () => {
-  matches(periodApi, [/verifyApiUser\(request\)/, /vehicleExists/, /DOWNTIME_REASONS/, /Downtime requires a valid reason/, /rpc\('start_vehicle_journey_period'/, /rpc\('close_vehicle_journey_period'/]);
+test('journey period API validates primary states and activity periods through atomic RPCs', () => {
+  matches(periodApi, [/verifyApiUser\(request\)/, /vehicleExists/, /DOWNTIME_REASONS/, /Downtime requires a valid reason/, /rpc\('transition_vehicle_journey_state'/, /rpc\('close_vehicle_journey_period'/, /rpc\('start_vehicle_journey_activity_period'/, /rpc\('close_vehicle_journey_activity_period'/]);
   matches(periodMigration, [/'PERIOD_STARTED'/, /'PERIOD_ENDED'/, /insert into public\.vehicle_journey_periods/i, /insert into public\.vehicle_journey_events/i, /p_actor_id/]);
+  matches(timeModelMigration, [/vehicle_journey_periods_one_open_state_uidx/, /vehicle_journey_activity_periods/, /ACTIVITY_PERIOD_STARTED/, /ACTIVITY_PERIOD_ENDED/]);
 });
 
 test('Vagnkort can document equipment changes as append-only journey events', () => {

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -76,8 +76,17 @@ test('document server API stays authenticated, private and appends a journey eve
 test('Vagnkort treats period controls as one primary vehicle state at a time', () => {
   matches(client, [/<JourneyPeriodControls regnr=/]);
   matches(periodControls, [/Tillgänglig/, /Uthyrd/, /Stillestånd/, /Förberedelse/, /ett huvudtillstånd åt gången/, /aktiviteter inom ett stillestånd/, /action:\s*'TRANSITION'/, /action:\s*'CLOSE'/, /\/api\/vehicle-journey\/periods/]);
-  assert.doesNotMatch(periodControls, /\['WORKSHOP', 'Verkstad'\]/);
-  assert.doesNotMatch(periodControls, /\['TRANSPORT', 'Transport'\]/);
+
+  const primaryBlock = periodControls.match(/const PRIMARY_PERIOD_TYPES = \[([\s\S]*?)\] as const;/)?.[1] ?? '';
+  assert.match(primaryBlock, /AVAILABLE/);
+  assert.match(primaryBlock, /RENTAL/);
+  assert.match(primaryBlock, /DOWNTIME/);
+  assert.doesNotMatch(primaryBlock, /WORKSHOP/);
+  assert.doesNotMatch(primaryBlock, /TRANSPORT/);
+
+  const reasonBlock = periodControls.match(/const DOWNTIME_REASONS = \[([\s\S]*?)\] as const;/)?.[1] ?? '';
+  assert.match(reasonBlock, /WORKSHOP/);
+  assert.match(reasonBlock, /TRANSPORT/);
 });
 
 test('journey period API validates primary states and activity periods through atomic RPCs', () => {

--- a/tests/vehicle-journey-metrics.test.ts
+++ b/tests/vehicle-journey-metrics.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { computeJourneyLifecycleMetrics } from '../lib/vehicle-journey-metrics';
 
-test('journey lifecycle metrics summarize rental, downtime and workshop time', () => {
+test('journey lifecycle metrics keep primary state time separate from downtime activities', () => {
   const metrics = computeJourneyLifecycleMetrics({
     now: '2026-01-10T00:00:00.000Z',
     lifecycleStartAt: '2026-01-01T00:00:00.000Z',
@@ -11,19 +11,28 @@ test('journey lifecycle metrics summarize rental, downtime and workshop time', (
     periods: [
       { period_type: 'AVAILABLE', started_at: '2026-01-01T00:00:00.000Z', ended_at: '2026-01-02T00:00:00.000Z' },
       { period_type: 'RENTAL', started_at: '2026-01-02T00:00:00.000Z', ended_at: '2026-01-04T00:00:00.000Z' },
-      { period_type: 'DOWNTIME', started_at: '2026-01-04T00:00:00.000Z', ended_at: '2026-01-05T00:00:00.000Z', reason_code: 'DAMAGE' },
-      { period_type: 'WORKSHOP', started_at: '2026-01-05T00:00:00.000Z', ended_at: '2026-01-06T00:00:00.000Z' },
+      { period_type: 'DOWNTIME', started_at: '2026-01-04T00:00:00.000Z', ended_at: '2026-01-06T00:00:00.000Z', reason_code: 'DAMAGE' },
+      { period_type: 'AVAILABLE', started_at: '2026-01-06T00:00:00.000Z', ended_at: '2026-01-07T00:00:00.000Z' },
       { period_type: 'RENTAL', started_at: '2026-01-07T00:00:00.000Z', ended_at: '2026-01-08T00:00:00.000Z' },
+    ],
+    activities: [
+      { activity_type: 'WORKSHOP', started_at: '2026-01-04T12:00:00.000Z', ended_at: '2026-01-05T18:00:00.000Z' },
+      { activity_type: 'WAITING_PARTS', started_at: '2026-01-05T00:00:00.000Z', ended_at: '2026-01-05T12:00:00.000Z' },
+      { activity_type: 'TRANSPORT', started_at: '2026-01-04T06:00:00.000Z', ended_at: '2026-01-04T08:00:00.000Z' },
     ],
   });
 
   assert.equal(metrics.lifecycleHours, 216);
   assert.equal(metrics.rentalCount, 2);
   assert.equal(metrics.rentalHours, 72);
-  assert.equal(metrics.downtimeHours, 24);
-  assert.equal(metrics.workshopHours, 24);
-  assert.equal(metrics.availableHours, 24);
-  assert.equal(metrics.downtimeHoursByReason.DAMAGE, 24);
+  assert.equal(metrics.downtimeHours, 48);
+  assert.equal(metrics.workshopHours, 30);
+  assert.equal(metrics.waitingPartsHours, 12);
+  assert.equal(metrics.transportHours, 2);
+  assert.equal(metrics.availableHours, 48);
+  assert.equal(metrics.measuredOperationalHours, 168);
+  assert.equal(metrics.downtimeHoursByReason.DAMAGE, 48);
+  assert.equal(metrics.activityHoursByType.WORKSHOP, 30);
   assert.equal(metrics.firstRentalAt, '2026-01-02T00:00:00.000Z');
   assert.equal(metrics.nybilToFirstRentalHours, 24);
   assert.equal(metrics.lastRentalReturnAt, '2026-01-08T00:00:00.000Z');
@@ -31,11 +40,11 @@ test('journey lifecycle metrics summarize rental, downtime and workshop time', (
   assert.equal(metrics.betweenRentalGapCount, 1);
   assert.equal(metrics.averageHoursBetweenRentals, 72);
   assert.equal(metrics.longestHoursBetweenRentals, 72);
-  assert.equal(metrics.overlappingOperationalPeriods, false);
-  assert.equal(metrics.utilizationPct, 50);
+  assert.equal(metrics.overlappingPrimaryPeriods, false);
+  assert.equal(metrics.utilizationPct, 42.9);
 });
 
-test('journey lifecycle metrics include an open period up to now', () => {
+test('journey lifecycle metrics include an open primary period up to now', () => {
   const metrics = computeJourneyLifecycleMetrics({
     now: '2026-01-03T00:00:00.000Z',
     lifecycleStartAt: '2026-01-01T00:00:00.000Z',
@@ -50,15 +59,32 @@ test('journey lifecycle metrics include an open period up to now', () => {
   assert.equal(metrics.rentalCount, 1);
 });
 
-test('journey lifecycle metrics avoid misleading utilization when periods overlap', () => {
-  const metrics = computeJourneyLifecycleMetrics({
+test('journey lifecycle metrics reject overlapping primary states but allow overlapping activities', () => {
+  const primaryOverlap = computeJourneyLifecycleMetrics({
     now: '2026-01-03T00:00:00.000Z',
     periods: [
       { period_type: 'RENTAL', started_at: '2026-01-01T00:00:00.000Z', ended_at: '2026-01-02T00:00:00.000Z' },
-      { period_type: 'DOWNTIME', started_at: '2026-01-01T12:00:00.000Z', ended_at: '2026-01-02T12:00:00.000Z', reason_code: 'WORKSHOP' },
+      { period_type: 'DOWNTIME', started_at: '2026-01-01T12:00:00.000Z', ended_at: '2026-01-02T12:00:00.000Z', reason_code: 'DAMAGE' },
     ],
   });
 
-  assert.equal(metrics.overlappingOperationalPeriods, true);
-  assert.equal(metrics.utilizationPct, null);
+  assert.equal(primaryOverlap.overlappingPrimaryPeriods, true);
+  assert.equal(primaryOverlap.utilizationPct, null);
+
+  const activityOverlap = computeJourneyLifecycleMetrics({
+    now: '2026-01-03T00:00:00.000Z',
+    periods: [
+      { period_type: 'DOWNTIME', started_at: '2026-01-01T00:00:00.000Z', ended_at: '2026-01-02T00:00:00.000Z', reason_code: 'DAMAGE' },
+    ],
+    activities: [
+      { activity_type: 'WORKSHOP', started_at: '2026-01-01T04:00:00.000Z', ended_at: '2026-01-01T20:00:00.000Z' },
+      { activity_type: 'WAITING_PARTS', started_at: '2026-01-01T08:00:00.000Z', ended_at: '2026-01-01T12:00:00.000Z' },
+    ],
+  });
+
+  assert.equal(activityOverlap.overlappingPrimaryPeriods, false);
+  assert.equal(activityOverlap.downtimeHours, 24);
+  assert.equal(activityOverlap.workshopHours, 16);
+  assert.equal(activityOverlap.waitingPartsHours, 4);
+  assert.equal(activityOverlap.measuredOperationalHours, 24);
 });

--- a/tests/vehicle-journey-period-atomicity.test.ts
+++ b/tests/vehicle-journey-period-atomicity.test.ts
@@ -8,44 +8,72 @@ const periodApi = readFileSync(
   'utf8',
 );
 
-const migration = readFileSync(
+const foundationMigration = readFileSync(
   join(process.cwd(), 'migrations/20260820222728_atomic_vehicle_journey_period_events.sql'),
   'utf8',
 );
 
-test('journey period API delegates start and close to atomic database RPCs', () => {
-  assert.match(periodApi, /rpc\('start_vehicle_journey_period'/);
+const splitMigration = readFileSync(
+  join(process.cwd(), 'migrations/20260821113000_split_vehicle_state_and_activity_periods.sql'),
+  'utf8',
+);
+
+test('journey period API delegates primary transitions and activity periods to database RPCs', () => {
+  assert.match(periodApi, /rpc\('transition_vehicle_journey_state'/);
   assert.match(periodApi, /rpc\('close_vehicle_journey_period'/);
+  assert.match(periodApi, /rpc\('start_vehicle_journey_activity_period'/);
+  assert.match(periodApi, /rpc\('close_vehicle_journey_activity_period'/);
   assert.doesNotMatch(periodApi, /from\('vehicle_journey_events'\)\.insert/);
   assert.doesNotMatch(periodApi, /from\('vehicle_journey_periods'\)\.insert/);
 });
 
-test('start RPC writes start event and period in one database function', () => {
-  assert.match(migration, /function public\.start_vehicle_journey_period/i);
-  assert.match(migration, /insert into public\.vehicle_journey_events/i);
-  assert.match(migration, /'PERIOD_STARTED'/);
-  assert.match(migration, /insert into public\.vehicle_journey_periods/i);
-  assert.match(migration, /source_event_id/);
-  assert.match(migration, /v_event_id/);
+test('legacy period foundation remains atomic', () => {
+  assert.match(foundationMigration, /function public\.start_vehicle_journey_period/i);
+  assert.match(foundationMigration, /insert into public\.vehicle_journey_events/i);
+  assert.match(foundationMigration, /'PERIOD_STARTED'/);
+  assert.match(foundationMigration, /insert into public\.vehicle_journey_periods/i);
+  assert.match(foundationMigration, /source_event_id/);
 });
 
-test('close RPC locks the period and appends the end event transactionally', () => {
-  assert.match(migration, /function public\.close_vehicle_journey_period/i);
-  assert.match(migration, /for update/i);
-  assert.match(migration, /update public\.vehicle_journey_periods/i);
-  assert.match(migration, /'PERIOD_ENDED'/);
-  assert.match(migration, /End time cannot be before start time/);
+test('new time model allows one open primary state per vehicle', () => {
+  assert.match(splitMigration, /vehicle_journey_periods_one_open_state_uidx/i);
+  assert.match(splitMigration, /on public\.vehicle_journey_periods \(regnr\)/i);
+  assert.match(splitMigration, /where ended_at is null/i);
+  assert.match(splitMigration, /'PREPARATION', 'AVAILABLE', 'RENTAL', 'DOWNTIME', 'SALU', 'OTHER'/i);
+  assert.doesNotMatch(splitMigration, /check \(period_type in \([^;]*'WORKSHOP'[^;]*\)\)/i);
 });
 
-test('database prevents duplicate open periods of the same type under concurrency', () => {
-  assert.match(migration, /create unique index if not exists vehicle_journey_periods_one_open_type_uidx/i);
-  assert.match(migration, /on public\.vehicle_journey_periods \(regnr, period_type\)/i);
-  assert.match(migration, /where ended_at is null/i);
+test('transition RPC closes the previous state and starts the next at the same timestamp', () => {
+  assert.match(splitMigration, /function public\.transition_vehicle_journey_state/i);
+  assert.match(splitMigration, /set ended_at = p_started_at/i);
+  assert.match(splitMigration, /'PERIOD_ENDED'/);
+  assert.match(splitMigration, /'PERIOD_STARTED'/);
+  assert.match(splitMigration, /transitionedTo/i);
 });
 
-test('atomic period RPCs remain service-role only', () => {
-  assert.match(migration, /revoke all on function public\.start_vehicle_journey_period[\s\S]*from public, anon, authenticated/i);
-  assert.match(migration, /revoke all on function public\.close_vehicle_journey_period[\s\S]*from public, anon, authenticated/i);
-  assert.match(migration, /grant execute on function public\.start_vehicle_journey_period[\s\S]*to service_role/i);
-  assert.match(migration, /grant execute on function public\.close_vehicle_journey_period[\s\S]*to service_role/i);
+test('workshop transport and waiting time are child activities under downtime', () => {
+  assert.match(splitMigration, /create table public\.vehicle_journey_activity_periods/i);
+  assert.match(splitMigration, /parent_period_id uuid not null references public\.vehicle_journey_periods/i);
+  assert.match(splitMigration, /Journey activities require a DOWNTIME parent/i);
+  assert.match(splitMigration, /'WORKSHOP'/);
+  assert.match(splitMigration, /'WAITING_PARTS'/);
+  assert.match(splitMigration, /'TRANSPORT'/);
+  assert.match(splitMigration, /'ACTIVITY_PERIOD_STARTED'/);
+  assert.match(splitMigration, /'ACTIVITY_PERIOD_ENDED'/);
+});
+
+test('closing downtime also closes open child activities', () => {
+  assert.match(splitMigration, /if v_period\.period_type = 'DOWNTIME'/i);
+  assert.match(splitMigration, /perform public\.close_vehicle_journey_activity_period/i);
+});
+
+test('time model migrations fail safe before reclassifying existing workshop or transport primary rows', () => {
+  assert.match(splitMigration, /if exists[\s\S]*period_type in \('WORKSHOP', 'TRANSPORT'\)[\s\S]*raise exception/i);
+});
+
+test('time model RPCs remain service-role only', () => {
+  assert.match(splitMigration, /revoke all on function public\.transition_vehicle_journey_state[\s\S]*from public, anon, authenticated/i);
+  assert.match(splitMigration, /revoke all on function public\.start_vehicle_journey_activity_period[\s\S]*from public, anon, authenticated/i);
+  assert.match(splitMigration, /grant execute on function public\.transition_vehicle_journey_state[\s\S]*to service_role/i);
+  assert.match(splitMigration, /grant execute on function public\.start_vehicle_journey_activity_period[\s\S]*to service_role/i);
 });


### PR DESCRIPTION
## Syfte
Korrigerar periodmodellen så att tid i fordonsresan kan beskrivas utan dubbelräkning.

## Arkitektur
En bil har ett **huvudtillstånd åt gången**:

`PREPARATION | AVAILABLE | RENTAL | DOWNTIME | SALU | OTHER`

Aktiviteter som sker **inom ett stillestånd** lagras separat:

`WORKSHOP | SERVICE | WAITING_PARTS | TRANSPORT | ADMINISTRATION | MISSING_EQUIPMENT | OTHER`

Exempel: bilen kan ha 46 h DOWNTIME, varav 28 h WORKSHOP och 12 h WAITING_PARTS. Aktivitetstiden är en del av stilleståndet och adderas inte till bilens totala operativa tid.

## Viktiga kontrakt
- högst ett öppet huvudtillstånd per bil
- atomisk transition stänger föregående huvudperiod och öppnar nästa vid samma tidpunkt
- aktivitet måste ha en DOWNTIME-period som parent
- aktivitet kan inte börja före eller sluta efter sin parent
- när DOWNTIME avslutas stängs öppna child-aktiviteter vid samma tidpunkt
- både huvudperioder och aktiviteter skriver append-only events
- ingen uthyrning härleds från indirekta signaler

## UI / metrics
- Vagnkortets periodkontroll visar nu huvudtillstånd, inte WORKSHOP/TRANSPORT som parallella statusar
- metrics summerar AVAILABLE/RENTAL/DOWNTIME som primär operativ tid
- WORKSHOP m.fl. redovisas separat som aktivitetstid inom stillestånd
- nyttjandegrad dubbelräknar därför inte aktivitetstid

## Säkerhet
- nya tabellen är RLS-skyddad och server-only
- nya RPC:er är security definer med låst search_path och service_role-only

## Production-säkerhet
Migrationen failar medvetet om Production redan innehåller WORKSHOP/TRANSPORT som huvudperioder, så ingen befintlig historik klassificeras om tyst. Ingen backfill görs.

## Avgränsning
Detta PR låser tidskontraktet. Nästa steg är period write-through från auktoritativa källor. Ingen Kista och ingen ekonomisk logik ingår.