### PR TITLE
Fordonsresan: verifierat SÅLD-faktum utan påhittad SALU-period

### DIFF
--- a/migrations/20260821151500_add_sold_fact_write_through.sql
+++ b/migrations/20260821151500_add_sold_fact_write_through.sql
@@ -1,0 +1,169 @@
+begin;
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+create table public.journey_event_write_through_failures (
+  failure_id uuid primary key default gen_random_uuid(),
+  regnr text not null check (length(trim(regnr)) > 0),
+  source_entity text not null check (length(trim(source_entity)) > 0),
+  source_record_id text not null check (length(trim(source_record_id)) > 0),
+  event_type text not null check (length(trim(event_type)) > 0),
+  error_code text,
+  error_message text not null,
+  attempts integer not null default 1 check (attempts > 0),
+  first_failed_at timestamptz not null default now(),
+  last_failed_at timestamptz not null default now(),
+  resolved_at timestamptz,
+  unique (source_entity, source_record_id, event_type)
+);
+create index journey_event_write_through_failures_unresolved_idx on public.journey_event_write_through_failures (last_failed_at, regnr) where resolved_at is null;
+alter table public.journey_event_write_through_failures enable row level security;
+revoke all on public.journey_event_write_through_failures from public, anon, authenticated;
+grant select, insert, update, delete on public.journey_event_write_through_failures to service_role;
+
+create or replace function public.try_write_through_sold_fact(
+  p_edit_id bigint,
+  p_regnr text,
+  p_new_value text,
+  p_old_value text,
+  p_edited_at timestamptz,
+  p_edited_by text,
+  p_batch_id text,
+  p_sold_date text,
+  p_comment text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_regnr text;
+  v_new_value text;
+  v_source_record_id text;
+  v_event_type text;
+  v_event_key text;
+  v_comment text;
+  v_sold_date text;
+  v_correction_of uuid;
+  v_error_code text;
+  v_error_message text;
+begin
+  v_regnr := upper(regexp_replace(coalesce(p_regnr, ''), '\s+', '', 'g'));
+  v_new_value := lower(trim(coalesce(p_new_value, '')));
+  v_source_record_id := p_edit_id::text;
+  v_comment := nullif(trim(coalesce(p_comment, '')), '');
+  v_sold_date := nullif(trim(coalesce(p_sold_date, '')), '');
+
+  if v_regnr = '' or p_edit_id is null then return false; end if;
+  if v_new_value not in ('true', 'false') then return true; end if;
+  if lower(trim(coalesce(p_old_value, ''))) = v_new_value then return true; end if;
+  if v_comment is null then return false; end if;
+
+  v_event_type := case when v_new_value = 'true' then 'VEHICLE_SOLD_RECORDED' else 'VEHICLE_SOLD_CORRECTED' end;
+  v_event_key := 'vehicle-edit:' || v_source_record_id || ':' || v_event_type;
+
+  begin
+    if exists (select 1 from public.vehicle_journey_events where event_key = v_event_key) then
+      update public.journey_event_write_through_failures
+      set resolved_at = coalesce(resolved_at, pg_catalog.now())
+      where source_entity = 'vehicle_edits' and source_record_id = v_source_record_id and event_type = v_event_type and resolved_at is null;
+      return true;
+    end if;
+
+    if v_new_value = 'false' then
+      select event_id into v_correction_of
+      from public.vehicle_journey_events
+      where regnr = v_regnr and event_type = 'VEHICLE_SOLD_RECORDED'
+      order by occurred_at desc, created_at desc
+      limit 1;
+    end if;
+
+    insert into public.vehicle_journey_events (
+      regnr,event_type,event_key,occurred_at,source_system,source_entity,source_record_id,
+      actor_source,actor_email,payload,correction_of_event_id
+    ) values (
+      v_regnr,v_event_type,v_event_key,coalesce(p_edited_at, pg_catalog.now()),'STATUS','vehicle_edits',v_source_record_id,
+      'MANUELL',nullif(trim(coalesce(p_edited_by, '')), ''),
+      pg_catalog.jsonb_build_object(
+        'sourceKind','SALE_STATUS','sourceField','is_sold','oldValue',p_old_value,'newValue',p_new_value,
+        'soldDate',v_sold_date,'comment',v_comment,'batchId',p_batch_id,
+        'recordedAt',coalesce(p_edited_at, pg_catalog.now()),'soldDateHasNoTime',v_sold_date is not null
+      ),
+      v_correction_of
+    );
+
+    update public.journey_event_write_through_failures
+    set resolved_at = coalesce(resolved_at, pg_catalog.now())
+    where source_entity = 'vehicle_edits' and source_record_id = v_source_record_id and event_type = v_event_type and resolved_at is null;
+    return true;
+  exception when others then
+    v_error_code := SQLSTATE;
+    v_error_message := SQLERRM;
+    begin
+      insert into public.journey_event_write_through_failures as failure (
+        regnr,source_entity,source_record_id,event_type,error_code,error_message
+      ) values (
+        coalesce(nullif(v_regnr, ''), 'UNKNOWN'),'vehicle_edits',coalesce(nullif(v_source_record_id, ''), 'UNKNOWN'),
+        v_event_type,v_error_code,pg_catalog.left(v_error_message, 2000)
+      )
+      on conflict (source_entity,source_record_id,event_type)
+      do update set error_code=excluded.error_code,error_message=excluded.error_message,
+        attempts=failure.attempts+1,last_failed_at=pg_catalog.now(),resolved_at=null;
+    exception when others then null; end;
+    return false;
+  end;
+end;
+$$;
+
+create or replace function public.write_through_sold_facts()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_edit record;
+  v_sold_date text;
+  v_comment text;
+begin
+  for v_edit in
+    select id,regnr,new_value,old_value,edited_by,edited_at,batch_id
+    from inserted_vehicle_edits
+    where field_name = 'is_sold' and lower(trim(coalesce(new_value, ''))) in ('true','false')
+    order by id
+  loop
+    select nullif(trim(detail.new_value), '') into v_comment
+    from inserted_vehicle_edits detail
+    where detail.regnr = v_edit.regnr and detail.field_name = 'sold_kommentar'
+      and detail.batch_id is not distinct from v_edit.batch_id
+    order by detail.id desc limit 1;
+
+    select nullif(trim(detail.new_value), '') into v_sold_date
+    from inserted_vehicle_edits detail
+    where detail.regnr = v_edit.regnr and detail.field_name = 'sold_datum'
+      and detail.batch_id is not distinct from v_edit.batch_id
+    order by detail.id desc limit 1;
+
+    perform public.try_write_through_sold_fact(
+      v_edit.id,v_edit.regnr,v_edit.new_value,v_edit.old_value,v_edit.edited_at,v_edit.edited_by,
+      v_edit.batch_id,v_sold_date,v_comment
+    );
+  end loop;
+  return null;
+exception when others then
+  return null;
+end;
+$$;
+
+drop trigger if exists sold_fact_write_through on public.vehicle_edits;
+create trigger sold_fact_write_through
+after insert on public.vehicle_edits
+referencing new table as inserted_vehicle_edits
+for each statement execute function public.write_through_sold_facts();
+
+revoke all on function public.try_write_through_sold_fact(bigint,text,text,text,timestamptz,text,text,text,text) from public,anon,authenticated;
+revoke all on function public.write_through_sold_facts() from public,anon,authenticated;
+grant execute on function public.try_write_through_sold_fact(bigint,text,text,text,timestamptz,text,text,text,text) to service_role;
+grant execute on function public.write_through_sold_facts() to service_role;
+commit;

--- a/tests/sold-fact-write-through.test.ts
+++ b/tests/sold-fact-write-through.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/20260821151500_add_sold_fact_write_through.sql'),
+  'utf8',
+);
+
+test('sale status writes append-only sold fact without inventing a SALU or rental period', () => {
+  assert.match(migration, /VEHICLE_SOLD_RECORDED/);
+  assert.match(migration, /VEHICLE_SOLD_CORRECTED/);
+  assert.match(migration, /insert into public\.vehicle_journey_events/i);
+  assert.doesNotMatch(migration, /transition_vehicle_journey_state/i);
+  assert.doesNotMatch(migration, /'RENTAL'/);
+  assert.doesNotMatch(migration, /'SALU'/);
+});
+
+test('sold date is retained as a business date while event time is the recording timestamp', () => {
+  assert.match(migration, /'soldDate',v_sold_date/i);
+  assert.match(migration, /'recordedAt',coalesce\(p_edited_at, pg_catalog\.now\(\)\)/i);
+  assert.match(migration, /'soldDateHasNoTime',v_sold_date is not null/i);
+});
+
+test('unmark sold is a correcting event linked to latest sold fact', () => {
+  assert.match(migration, /correction_of_event_id/i);
+  assert.match(migration, /event_type = 'VEHICLE_SOLD_RECORDED'/i);
+  assert.match(migration, /v_new_value = 'false'/i);
+});
+
+test('sale fact requires same-batch comment and optional sold date', () => {
+  assert.match(migration, /field_name = 'sold_kommentar'/i);
+  assert.match(migration, /field_name = 'sold_datum'/i);
+  assert.match(migration, /batch_id is not distinct from v_edit\.batch_id/i);
+  assert.match(migration, /if v_comment is null then return false/i);
+});
+
+test('write-through is fail-open and server controlled', () => {
+  assert.match(migration, /journey_event_write_through_failures/i);
+  assert.match(migration, /exception when others then[\s\S]*return false/i);
+  assert.match(migration, /after insert on public\.vehicle_edits/i);
+  assert.match(migration, /security definer[\s\S]*set search_path = pg_catalog/i);
+  assert.match(migration, /revoke all on function public\.try_write_through_sold_fact[\s\S]*from public,anon,authenticated/i);
+  assert.match(migration, /grant execute on function public\.try_write_through_sold_fact[\s\S]*to service_role/i);
+});


### PR DESCRIPTION
## Syfte
Kopplar den explicita användarhandlingen `Markera som SÅLD` till fordonsresans append-only faktalager.

## Semantik
- `is_sold=true` → `VEHICLE_SOLD_RECORDED`
- `is_sold=false` → `VEHICLE_SOLD_CORRECTED`, länkat via `correction_of_event_id` till senaste sold-faktum
- `sold_datum` lagras som affärsdatum i payload
- exakt eventtid är den faktiska registreringstidpunkten (`edited_at`)
- obligatorisk kommentar från samma batch följer med

## Viktig avgränsning
Detta skapar **inte** en `SALU`-period. SALU-flaggan skapas redan T−30 och är planerings-/kontrollsignal, inte bevis att bilen lämnat drift. Det skapar inte heller `RENTAL`.

## Arkitektur
SÅLD är ett verifierat faktum i fordonsresan. Historiken skrivs append-only i `vehicle_journey_events`; en återtagen SÅLD-markering korrigerar historiken i stället för att radera den.

## Fail-open
`vehicle_edits` förblir auktoritativ källa. Fel i journey-write-through loggas i server-only `journey_event_write_through_failures` och får inte rulla tillbaka statusändringen.

## Avgränsning
- ingen historisk backfill
- ingen Kista/ekonomisk logik
- ingen automatisk SALU- eller RENTAL-period