### PR TITLE
Check-in: saknad kommentar är business no-op

### DIFF
--- a/migrations/20260821153000_add_checkin_downtime_period_write_through.sql
+++ b/migrations/20260821153000_add_checkin_downtime_period_write_through.sql
@@ -53,6 +53,13 @@ begin
 
   v_reason_text := nullif(trim(coalesce(p_checklist ->> 'rental_unavailable_comment', '')), '');
 
+  -- Missing business information is not a technical write-through failure.
+  -- Without an explicit reason no DOWNTIME fact can be established, so this is
+  -- a deliberate no-op before the technical failure boundary below.
+  if v_reason_text is null then
+    return true;
+  end if;
+
   begin
     if exists (
       select 1
@@ -67,11 +74,6 @@ begin
         and source_record_id = v_source_record_id
         and resolved_at is null;
       return true;
-    end if;
-
-    if v_reason_text is null then
-      raise exception 'Check-in rental_unavailable requires an explicit comment before DOWNTIME can be established'
-        using errcode = '22023';
     end if;
 
     select *

--- a/tests/checkin-downtime-period-write-through.test.ts
+++ b/tests/checkin-downtime-period-write-through.test.ts
@@ -32,9 +32,10 @@ test('explicit unavailable Check-in creates one idempotent DOWNTIME fact with so
   assert.match(migration, /'sourceField', 'checklist\.rental_unavailable'/i);
 });
 
-test('explicit unavailable Check-in requires the operator comment', () => {
-  assert.match(migration, /Check-in rental_unavailable requires an explicit comment before DOWNTIME can be established/i);
-  assert.match(migration, /'OTHER',[\s\S]*v_reason_text/i);
+test('explicit unavailable Check-in without comment is a business no-op before failure logging', () => {
+  assert.match(migration, /v_reason_text := nullif\(trim\(coalesce\(p_checklist ->> 'rental_unavailable_comment', ''\)\), ''\);[\s\S]*if v_reason_text is null then\s+return true;\s+end if;[\s\S]*begin/i);
+  assert.doesNotMatch(migration, /rental_unavailable requires an explicit comment/i);
+  assert.match(migration, /period_write_through_failures/i);
 });
 
 test('existing DOWNTIME is continued and confirmed without splitting the open period', () => {


### PR DESCRIPTION
## Syfte
Rättar endast failure-klassificeringen i #374.

## Ändring
- `rental_unavailable != true` -> oförändrat no-op
- `rental_unavailable=true` + tom/NULL/blank kommentar -> no-op innan exception/failure-spåret
- `rental_unavailable=true` + explicit kommentar -> oförändrad DOWNTIME-logik
- befintlig DOWNTIME -> oförändrad append-only `DOWNTIME_CONFIRMED`

## Viktig avgränsning
Ingen ändring av periodmotorn, ingen backfill, ingen ny valideringsmodell, ingen RENTAL/AVAILABLE/SALU-logik.

`period_write_through_failures` reserveras fortsatt för tekniska fel när ett legitimt faktum faktiskt försöker skrivas.