### PR TITLE
Fordonsresan: verifierad operativ read-model

### DIFF
--- a/app/api/vehicle-journey/operational-state/route.ts
+++ b/app/api/vehicle-journey/operational-state/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+import { buildOperationalReadModel } from '@/lib/vehicle-operational-read-model';
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+
+function cleanRegnr(value: string): string {
+  return value.toUpperCase().replace(/\s+/g, '');
+}
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const regnr = cleanRegnr(searchParams.get('reg') ?? searchParams.get('regnr') ?? '');
+  if (!REGNR_RE.test(regnr)) {
+    return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
+  }
+
+  let admin;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[operational-state] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Operational state unavailable' }, { status: 503 });
+  }
+
+  const [periodsResponse, eventsResponse] = await Promise.all([
+    admin
+      .from('vehicle_journey_periods')
+      .select('period_id,period_type,started_at,ended_at,reason_code,reason_text,source_system,source_entity,source_record_id')
+      .eq('regnr', regnr)
+      .is('ended_at', null)
+      .order('started_at', { ascending: false }),
+    admin
+      .from('vehicle_journey_events')
+      .select('event_id,event_type,occurred_at,source_system,source_entity,source_record_id,correction_of_event_id,payload')
+      .eq('regnr', regnr)
+      .in('event_type', ['DOWNTIME_CONFIRMED', 'VEHICLE_SOLD_RECORDED', 'VEHICLE_SOLD_CORRECTED'])
+      .order('occurred_at', { ascending: false }),
+  ]);
+
+  if (periodsResponse.error) {
+    console.error('[operational-state] Period query failed:', periodsResponse.error);
+    return NextResponse.json({ error: 'Failed to load operational period' }, { status: 500 });
+  }
+  if (eventsResponse.error) {
+    console.error('[operational-state] Event query failed:', eventsResponse.error);
+    return NextResponse.json({ error: 'Failed to load operational evidence' }, { status: 500 });
+  }
+
+  const model = buildOperationalReadModel(periodsResponse.data ?? [], eventsResponse.data ?? []);
+
+  return NextResponse.json({
+    data: {
+      regnr,
+      ...model,
+    },
+  });
+}

--- a/lib/vehicle-operational-read-model.ts
+++ b/lib/vehicle-operational-read-model.ts
@@ -1,0 +1,104 @@
+export type OperationalKnowledgeState = 'VERIFIED' | 'UNKNOWN';
+export type SaleKnowledgeState = 'SOLD' | 'NOT_SOLD' | 'UNKNOWN';
+
+export type OperationalPeriodInput = {
+  period_id: string;
+  period_type: string;
+  started_at: string;
+  ended_at: string | null;
+  reason_code: string | null;
+  reason_text: string | null;
+  source_system: string | null;
+  source_entity: string | null;
+  source_record_id: string | null;
+};
+
+export type OperationalEventInput = {
+  event_id: string;
+  event_type: string;
+  occurred_at: string;
+  source_system: string | null;
+  source_entity: string | null;
+  source_record_id: string | null;
+  correction_of_event_id?: string | null;
+  payload?: unknown;
+};
+
+export type OperationalReadModel = {
+  knowledgeState: OperationalKnowledgeState;
+  currentVerifiedState: string | null;
+  stateStartedAt: string | null;
+  reasonCode: string | null;
+  reasonText: string | null;
+  establishedBySource: string | null;
+  establishedByEntity: string | null;
+  establishedByRecord: string | null;
+  lastConfirmedAt: string | null;
+  confirmationCount: number;
+  latestConfirmationSource: string | null;
+  sale: {
+    state: SaleKnowledgeState;
+    occurredAt: string | null;
+    sourceSystem: string | null;
+    sourceEntity: string | null;
+    sourceRecordId: string | null;
+  };
+};
+
+function eventPayload(event: OperationalEventInput): Record<string, unknown> | null {
+  if (!event.payload || typeof event.payload !== 'object' || Array.isArray(event.payload)) return null;
+  return event.payload as Record<string, unknown>;
+}
+
+export function buildOperationalReadModel(
+  periods: OperationalPeriodInput[],
+  events: OperationalEventInput[],
+): OperationalReadModel {
+  const openPeriods = periods
+    .filter((period) => period.ended_at === null)
+    .sort((left, right) => new Date(right.started_at).getTime() - new Date(left.started_at).getTime());
+
+  const current = openPeriods[0] ?? null;
+
+  const confirmations = current
+    ? events
+        .filter((event) => {
+          if (event.event_type !== 'DOWNTIME_CONFIRMED') return false;
+          if (current.period_type !== 'DOWNTIME') return false;
+          const payload = eventPayload(event);
+          const existingPeriodId = typeof payload?.existingPeriodId === 'string' ? payload.existingPeriodId : null;
+          return existingPeriodId === current.period_id;
+        })
+        .sort((left, right) => new Date(right.occurred_at).getTime() - new Date(left.occurred_at).getTime())
+    : [];
+
+  const latestConfirmation = confirmations[0] ?? null;
+
+  const saleEvents = events
+    .filter((event) => event.event_type === 'VEHICLE_SOLD_RECORDED' || event.event_type === 'VEHICLE_SOLD_CORRECTED')
+    .sort((left, right) => new Date(right.occurred_at).getTime() - new Date(left.occurred_at).getTime());
+  const latestSale = saleEvents[0] ?? null;
+
+  return {
+    knowledgeState: current ? 'VERIFIED' : 'UNKNOWN',
+    currentVerifiedState: current?.period_type ?? null,
+    stateStartedAt: current?.started_at ?? null,
+    reasonCode: current?.reason_code ?? null,
+    reasonText: current?.reason_text ?? null,
+    establishedBySource: current?.source_system ?? null,
+    establishedByEntity: current?.source_entity ?? null,
+    establishedByRecord: current?.source_record_id ?? null,
+    lastConfirmedAt: latestConfirmation?.occurred_at ?? null,
+    confirmationCount: confirmations.length,
+    latestConfirmationSource: latestConfirmation?.source_system ?? null,
+    sale: {
+      state: latestSale
+        ? latestSale.event_type === 'VEHICLE_SOLD_RECORDED' ? 'SOLD' : 'NOT_SOLD'
+        : 'UNKNOWN',
+      occurredAt: latestSale?.occurred_at ?? null,
+      sourceSystem: latestSale?.source_system ?? null,
+      sourceEntity: latestSale?.source_entity ?? null,
+      sourceRecordId: latestSale?.source_record_id ?? null,
+    },
+  };
+}

--- a/tests/vehicle-operational-read-model.test.ts
+++ b/tests/vehicle-operational-read-model.test.ts
@@ -1,0 +1,101 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildOperationalReadModel } from '../lib/vehicle-operational-read-model';
+
+test('ingen öppen period ger UNKNOWN och skapar inget antaget tillstånd', () => {
+  const model = buildOperationalReadModel([], []);
+  assert.equal(model.knowledgeState, 'UNKNOWN');
+  assert.equal(model.currentVerifiedState, null);
+  assert.equal(model.stateStartedAt, null);
+  assert.equal(model.confirmationCount, 0);
+  assert.equal(model.sale.state, 'UNKNOWN');
+});
+
+test('öppen verifierad DOWNTIME exponeras med källa och orsak', () => {
+  const model = buildOperationalReadModel([
+    {
+      period_id: 'p1',
+      period_type: 'DOWNTIME',
+      started_at: '2026-08-21T12:32:00Z',
+      ended_at: null,
+      reason_code: 'OTHER',
+      reason_text: 'Punktering',
+      source_system: 'CHECKIN',
+      source_entity: 'checkins',
+      source_record_id: 'c1',
+    },
+  ], []);
+
+  assert.equal(model.knowledgeState, 'VERIFIED');
+  assert.equal(model.currentVerifiedState, 'DOWNTIME');
+  assert.equal(model.stateStartedAt, '2026-08-21T12:32:00Z');
+  assert.equal(model.reasonText, 'Punktering');
+  assert.equal(model.establishedBySource, 'CHECKIN');
+  assert.equal(model.establishedByEntity, 'checkins');
+});
+
+test('DOWNTIME_CONFIRMED räknas endast när eventet pekar på aktuell öppna period', () => {
+  const periods = [{
+    period_id: 'p1',
+    period_type: 'DOWNTIME',
+    started_at: '2026-08-21T12:32:00Z',
+    ended_at: null,
+    reason_code: 'OTHER',
+    reason_text: 'Punktering',
+    source_system: 'CHECKIN',
+    source_entity: 'checkins',
+    source_record_id: 'c1',
+  }];
+
+  const model = buildOperationalReadModel(periods, [
+    {
+      event_id: 'e1',
+      event_type: 'DOWNTIME_CONFIRMED',
+      occurred_at: '2026-08-21T14:00:00Z',
+      source_system: 'CHECKIN',
+      source_entity: 'checkins',
+      source_record_id: 'c2',
+      payload: { existingPeriodId: 'p1' },
+    },
+    {
+      event_id: 'e2',
+      event_type: 'DOWNTIME_CONFIRMED',
+      occurred_at: '2026-08-21T15:00:00Z',
+      source_system: 'CHECKIN',
+      source_entity: 'checkins',
+      source_record_id: 'c3',
+      payload: { existingPeriodId: 'annan-period' },
+    },
+  ]);
+
+  assert.equal(model.confirmationCount, 1);
+  assert.equal(model.lastConfirmedAt, '2026-08-21T14:00:00Z');
+  assert.equal(model.latestConfirmationSource, 'CHECKIN');
+});
+
+test('SÅLD hålls separat från operativ period och korrigering blir NOT_SOLD', () => {
+  const model = buildOperationalReadModel([], [
+    {
+      event_id: 'sold',
+      event_type: 'VEHICLE_SOLD_RECORDED',
+      occurred_at: '2026-08-21T10:00:00Z',
+      source_system: 'STATUS',
+      source_entity: 'vehicle_edits',
+      source_record_id: '1',
+    },
+    {
+      event_id: 'corrected',
+      event_type: 'VEHICLE_SOLD_CORRECTED',
+      occurred_at: '2026-08-21T11:00:00Z',
+      source_system: 'STATUS',
+      source_entity: 'vehicle_edits',
+      source_record_id: '2',
+      correction_of_event_id: 'sold',
+    },
+  ]);
+
+  assert.equal(model.knowledgeState, 'UNKNOWN');
+  assert.equal(model.currentVerifiedState, null);
+  assert.equal(model.sale.state, 'NOT_SOLD');
+  assert.equal(model.sale.occurredAt, '2026-08-21T11:00:00Z');
+});

--- a/tests/vehicle-operational-read-model.test.ts
+++ b/tests/vehicle-operational-read-model.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { buildOperationalReadModel } from '../lib/vehicle-operational-read-model';
 
+// Contract guard: the read model may expose VERIFIED facts or UNKNOWN, never inferred state.
 test('ingen öppen period ger UNKNOWN och skapar inget antaget tillstånd', () => {
   const model = buildOperationalReadModel([], []);
   assert.equal(model.knowledgeState, 'UNKNOWN');


### PR DESCRIPTION
## Syfte
Bygger ett rent server-side read-model-kontrakt ovanpå befintliga verifierade fordonsfakta.

## Kontrakt
- `knowledgeState = VERIFIED | UNKNOWN`
- aktuellt huvudtillstånd kommer endast från en öppen verifierad `vehicle_journey_period`
- ingen inferens av AVAILABLE, RENTAL eller annat tillstånd
- DOWNTIME-bekräftelser räknas endast när `DOWNTIME_CONFIRMED.payload.existingPeriodId` pekar på aktuell öppna DOWNTIME-period
- SÅLD hålls separat från operativ period som append-only terminalt faktum/korrigering

## API
Ny autentiserad route:
`/api/vehicle-journey/operational-state?reg=...`

Returnerar bland annat:
- currentVerifiedState
- stateStartedAt
- reasonCode / reasonText
- establishedBySource / Entity / Record
- lastConfirmedAt / confirmationCount / latestConfirmationSource
- sale.state = SOLD | NOT_SOLD | UNKNOWN

## Avgränsning
Ingen DB-migration, ingen backfill, ingen ny källsemantik, ingen RENTAL, ingen Kista.