### PR TITLE
Vagnkort: visa verifierat operativt huvudtillstånd

### DIFF
--- a/app/vagnkort/operational-state-banner.tsx
+++ b/app/vagnkort/operational-state-banner.tsx
@@ -54,7 +54,10 @@ export default function OperationalStateBanner() {
         const response = await fetch(`/api/vehicle-journey/operational-state?reg=${encodeURIComponent(regnr)}`);
         const body = (await response.json()) as ApiResponse;
         if (!response.ok) throw new Error(body.error || 'Kunde inte läsa verifierat fordonsläge');
-        if (!cancelled) setLoaded({ regnr, data: body.data ?? null });
+        if (!cancelled) {
+          setLoadedError((current) => current?.regnr === regnr ? null : current);
+          setLoaded({ regnr, data: body.data ?? null });
+        }
       } catch (err) {
         if (!cancelled) {
           setLoadedError({

--- a/app/vagnkort/operational-state-banner.tsx
+++ b/app/vagnkort/operational-state-banner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 
 type OperationalState = {
   knowledgeState: 'VERIFIED' | 'UNKNOWN';
@@ -24,6 +25,8 @@ type OperationalState = {
 };
 
 type ApiResponse = { data?: OperationalState; error?: string };
+type LoadedState = { regnr: string; data: OperationalState | null };
+type LoadedError = { regnr: string; message: string };
 
 function formatDate(value: string | null) {
   if (!value) return '—';
@@ -37,31 +40,33 @@ function sourceLabel(source: string | null, entity: string | null) {
 }
 
 export default function OperationalStateBanner() {
-  const [state, setState] = useState<OperationalState | null>(null);
-  const [regnr, setRegnr] = useState('');
-  const [error, setError] = useState('');
+  const searchParams = useSearchParams();
+  const regnr = (searchParams.get('reg') ?? '').toUpperCase().replace(/\s+/g, '');
+  const [loaded, setLoaded] = useState<LoadedState | null>(null);
+  const [loadedError, setLoadedError] = useState<LoadedError | null>(null);
 
   useEffect(() => {
-    const normalized = (new URLSearchParams(window.location.search).get('reg') ?? '')
-      .toUpperCase()
-      .replace(/\s+/g, '');
-    setRegnr(normalized);
-    if (!normalized) return;
+    if (!regnr) return;
 
     let cancelled = false;
     void (async () => {
       try {
-        const response = await fetch(`/api/vehicle-journey/operational-state?reg=${encodeURIComponent(normalized)}`);
+        const response = await fetch(`/api/vehicle-journey/operational-state?reg=${encodeURIComponent(regnr)}`);
         const body = (await response.json()) as ApiResponse;
         if (!response.ok) throw new Error(body.error || 'Kunde inte läsa verifierat fordonsläge');
-        if (!cancelled) setState(body.data ?? null);
+        if (!cancelled) setLoaded({ regnr, data: body.data ?? null });
       } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : 'Kunde inte läsa verifierat fordonsläge');
+        if (!cancelled) {
+          setLoadedError({
+            regnr,
+            message: err instanceof Error ? err.message : 'Kunde inte läsa verifierat fordonsläge',
+          });
+        }
       }
     })();
 
     return () => { cancelled = true; };
-  }, []);
+  }, [regnr]);
 
   if (!regnr) return null;
 
@@ -74,10 +79,11 @@ export default function OperationalStateBanner() {
     boxShadow: '0 8px 30px rgba(0,0,0,0.08)',
   };
 
-  if (error) {
-    return <section style={{ ...shell, border: '1px solid #d9d9d9' }}><strong>Verifierat fordonsläge kunde inte läsas.</strong><div style={{ marginTop: '.35rem', color: '#666' }}>{error}</div></section>;
+  if (loadedError?.regnr === regnr) {
+    return <section style={{ ...shell, border: '1px solid #d9d9d9' }}><strong>Verifierat fordonsläge kunde inte läsas.</strong><div style={{ marginTop: '.35rem', color: '#666' }}>{loadedError.message}</div></section>;
   }
 
+  const state = loaded?.regnr === regnr ? loaded.data : null;
   if (!state) {
     return <section style={shell}>Läser verifierat fordonsläge…</section>;
   }

--- a/app/vagnkort/operational-state-banner.tsx
+++ b/app/vagnkort/operational-state-banner.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type OperationalState = {
+  knowledgeState: 'VERIFIED' | 'UNKNOWN';
+  currentVerifiedState: string | null;
+  stateStartedAt: string | null;
+  reasonCode: string | null;
+  reasonText: string | null;
+  establishedBySource: string | null;
+  establishedByEntity: string | null;
+  establishedByRecord: string | null;
+  lastConfirmedAt: string | null;
+  confirmationCount: number;
+  latestConfirmationSource: string | null;
+  sale: {
+    state: 'SOLD' | 'NOT_SOLD' | 'UNKNOWN';
+    occurredAt: string | null;
+    sourceSystem: string | null;
+    sourceEntity: string | null;
+    sourceRecordId: string | null;
+  };
+};
+
+type ApiResponse = { data?: OperationalState; error?: string };
+
+function formatDate(value: string | null) {
+  if (!value) return '—';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('sv-SE');
+}
+
+function sourceLabel(source: string | null, entity: string | null) {
+  if (!source && !entity) return '—';
+  return [source, entity].filter(Boolean).join(' / ');
+}
+
+export default function OperationalStateBanner() {
+  const [state, setState] = useState<OperationalState | null>(null);
+  const [regnr, setRegnr] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const normalized = (new URLSearchParams(window.location.search).get('reg') ?? '')
+      .toUpperCase()
+      .replace(/\s+/g, '');
+    setRegnr(normalized);
+    if (!normalized) return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch(`/api/vehicle-journey/operational-state?reg=${encodeURIComponent(normalized)}`);
+        const body = (await response.json()) as ApiResponse;
+        if (!response.ok) throw new Error(body.error || 'Kunde inte läsa verifierat fordonsläge');
+        if (!cancelled) setState(body.data ?? null);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Kunde inte läsa verifierat fordonsläge');
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!regnr) return null;
+
+  const shell: React.CSSProperties = {
+    maxWidth: 1200,
+    margin: '0 auto 1rem',
+    background: '#fff',
+    borderRadius: 14,
+    padding: '1rem 1.1rem',
+    boxShadow: '0 8px 30px rgba(0,0,0,0.08)',
+  };
+
+  if (error) {
+    return <section style={{ ...shell, border: '1px solid #d9d9d9' }}><strong>Verifierat fordonsläge kunde inte läsas.</strong><div style={{ marginTop: '.35rem', color: '#666' }}>{error}</div></section>;
+  }
+
+  if (!state) {
+    return <section style={shell}>Läser verifierat fordonsläge…</section>;
+  }
+
+  if (state.knowledgeState === 'UNKNOWN') {
+    return (
+      <section style={{ ...shell, border: '2px solid #777' }}>
+        <div style={{ fontSize: 12, fontWeight: 800, letterSpacing: '.08em' }}>OPERATIVT HUVUDTILLSTÅND</div>
+        <div style={{ fontSize: 24, fontWeight: 800, marginTop: '.3rem' }}>UNKNOWN</div>
+        <div style={{ marginTop: '.35rem', color: '#555' }}>Ingen verifierad statusförändring finns. Incheckad gissar inte AVAILABLE, RENTAL eller något annat tillstånd.</div>
+        {state.sale.state !== 'UNKNOWN' && <div style={{ marginTop: '.7rem', fontWeight: 700 }}>SÅLD-faktum: {state.sale.state === 'SOLD' ? 'SÅLD' : 'KORRIGERAT / INTE SÅLD'} · {formatDate(state.sale.occurredAt)}</div>}
+      </section>
+    );
+  }
+
+  return (
+    <section style={{ ...shell, border: '2px solid #222' }}>
+      <div style={{ fontSize: 12, fontWeight: 800, letterSpacing: '.08em' }}>VERIFIERAT OPERATIVT HUVUDTILLSTÅND</div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap', marginTop: '.35rem' }}>
+        <div>
+          <div style={{ fontSize: 28, fontWeight: 900 }}>{state.currentVerifiedState}</div>
+          <div style={{ marginTop: '.2rem' }}>Sedan {formatDate(state.stateStartedAt)}</div>
+          {state.reasonText && <div style={{ marginTop: '.2rem' }}>Orsak: <strong>{state.reasonText}</strong>{state.reasonCode ? ` · ${state.reasonCode}` : ''}</div>}
+        </div>
+        <div style={{ minWidth: 260, fontSize: 14 }}>
+          <div>Fastställt genom: <strong>{sourceLabel(state.establishedBySource, state.establishedByEntity)}</strong></div>
+          <div style={{ marginTop: '.25rem' }}>Källpost: {state.establishedByRecord || '—'}</div>
+          <div style={{ marginTop: '.25rem' }}>Bekräftelser: <strong>{state.confirmationCount}</strong></div>
+          {state.lastConfirmedAt && <div style={{ marginTop: '.25rem' }}>Senast bekräftat: {formatDate(state.lastConfirmedAt)}{state.latestConfirmationSource ? ` · ${state.latestConfirmationSource}` : ''}</div>}
+        </div>
+      </div>
+      {state.sale.state !== 'UNKNOWN' && <div style={{ marginTop: '.8rem', paddingTop: '.65rem', borderTop: '1px solid #ddd', fontWeight: 700 }}>Separat terminalt SÅLD-faktum: {state.sale.state === 'SOLD' ? 'SÅLD' : 'KORRIGERAT / INTE SÅLD'} · {formatDate(state.sale.occurredAt)}</div>}
+    </section>
+  );
+}

--- a/app/vagnkort/page.tsx
+++ b/app/vagnkort/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import LoginGate from '@/components/LoginGate';
 import VagnkortClient from './vagnkort-client';
+import OperationalStateBanner from './operational-state-banner';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
 export default function VagnkortPage() {
   return (
     <LoginGate>
+      <OperationalStateBanner />
       <VagnkortClient />
     </LoginGate>
   );


### PR DESCRIPTION
## Syfte
Visar den verifierade operativa read-modelen i Vagnkort utan att skapa eller inferera nya fakta.

## UI-kontrakt
- VERIFIED visar aktuellt verifierat huvudtillstånd, starttid, orsak och källan som fastställde det
- DOWNTIME-bekräftelser visas som antal/senaste bekräftelse från read-modelen
- UNKNOWN visas explicit som kunskapsläge och säger att Incheckad inte gissar AVAILABLE/RENTAL
- SÅLD visas separat som terminalt faktum, aldrig som operativ period

## Avgränsning
Ingen DB-ändring, ingen write-path, ingen ny källsemantik, ingen RENTAL-inferens och ingen Kista.

Stackad ovanpå PR #377 och ska mergas efter read-modelen.