### PR TITLE
Centralize application authentication boundary

### DIFF
--- a/app/ankomst/page.tsx
+++ b/app/ankomst/page.tsx
@@ -1,13 +1,8 @@
 // app/ankomst/page.tsx
-import LoginGate from '@/components/LoginGate';
 import FormClient from './form-client';
 
 export const dynamic = 'force-dynamic';
 
 export default function AnkomstPage() {
-  return (
-    <LoginGate>
-      <FormClient />
-    </LoginGate>
-  );
+  return <FormClient />;
 }

--- a/app/check/page.tsx
+++ b/app/check/page.tsx
@@ -1,13 +1,8 @@
 // app/check/page.tsx
-import LoginGate from '@/components/LoginGate';
 import FormClient from './form-client';
 
 export const dynamic = 'force-dynamic';
 
 export default function CheckPage() {
-  return (
-    <LoginGate>
-      <FormClient />
-    </LoginGate>
-  );
+  return <FormClient />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
+import AppAuthBoundary from "@/components/AppAuthBoundary";
 
 export const metadata: Metadata = { title: "Incheckad" };
 
@@ -7,7 +8,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="sv">
       <body>
-        {children}
+        <AppAuthBoundary>{children}</AppAuthBoundary>
       </body>
     </html>
   );

--- a/app/media/[...path]/page.tsx
+++ b/app/media/[...path]/page.tsx
@@ -1,12 +1,7 @@
-import LoginGate from '@/components/LoginGate';
 import MediaViewer from './media-viewer';
 
 export const dynamic = 'force-dynamic';
 
 export default function MediaPage() {
-  return (
-    <LoginGate>
-      <MediaViewer />
-    </LoginGate>
-  );
+  return <MediaViewer />;
 }

--- a/app/nybil/page.tsx
+++ b/app/nybil/page.tsx
@@ -1,13 +1,8 @@
 // app/nybil/page.tsx
-import LoginGate from '@/components/LoginGate';
 import FormClient from './form-client';
 
 export const dynamic = 'force-dynamic';
 
 export default function NybilPage() {
-  return (
-    <LoginGate>
-      <FormClient />
-    </LoginGate>
-  );
+  return <FormClient />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import LoginGate from '@/components/LoginGate';
 const currentYear = new Date().getFullYear();
 export const metadata: Metadata = {
   title: 'Incheckad',
@@ -8,28 +7,26 @@ export const metadata: Metadata = {
 const MABI_LOGO_URL = "https://ufioaijcmaujlvmveyra.supabase.co/storage/v1/object/public/MABI%20Syd%20logga/MABI%20Syd%20logga%202.png";
 export default function HomePage() {
   return (
-    <LoginGate>
-      <main className="welcome-main">
-        <div className="background-img" />
+    <main className="welcome-main">
+      <div className="background-img" />
+      
+      <div className="welcome-card">
+        <img src={MABI_LOGO_URL} alt="MABI Syd logga" className="main-logo" />
         
-        <div className="welcome-card">
-          <img src={MABI_LOGO_URL} alt="MABI Syd logga" className="main-logo" />
-          
-          <h1 className="welcome-title">Välkommen!</h1>
-          
-          <div className="btn-group">
-            <a href="/ankomst" className="btn inkommen">Inkommen</a>
-            <a href="/check" className="btn incheckning">Ny incheckning</a>
-            <a href="/nybil" className="btn registrera">Registrera ny bil</a>
-            <a href="/vagnkort" className="btn incheckning">Vagnkort</a>
-          </div>
-          
+        <h1 className="welcome-title">Välkommen!</h1>
+        
+        <div className="btn-group">
+          <a href="/ankomst" className="btn inkommen">Inkommen</a>
+          <a href="/check" className="btn incheckning">Ny incheckning</a>
+          <a href="/nybil" className="btn registrera">Registrera ny bil</a>
+          <a href="/vagnkort" className="btn incheckning">Vagnkort</a>
         </div>
         
-        <footer className="homepage-footer">
-          &copy; {currentYear} Albarone AB &mdash; Alla rättigheter förbehållna
-        </footer>
-      </main>
-    </LoginGate>
+      </div>
+      
+      <footer className="homepage-footer">
+        &copy; {currentYear} Albarone AB &mdash; Alla rättigheter förbehållna
+      </footer>
+    </main>
   );
 }

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,13 +1,8 @@
 // app/status/page.tsx
-import LoginGate from '@/components/LoginGate';
 import FormClient from './form-client';
 
 export const dynamic = 'force-dynamic';
 
 export default function StatusPage() {
-  return (
-    <LoginGate>
-      <FormClient />
-    </LoginGate>
-  );
+  return <FormClient />;
 }

--- a/app/vagnkort/page.tsx
+++ b/app/vagnkort/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import LoginGate from '@/components/LoginGate';
 import VagnkortClient from './vagnkort-client';
 import OperationalStateBanner from './operational-state-banner';
 
@@ -12,9 +11,9 @@ export const metadata: Metadata = {
 
 export default function VagnkortPage() {
   return (
-    <LoginGate>
+    <>
       <OperationalStateBanner />
       <VagnkortClient />
-    </LoginGate>
+    </>
   );
 }

--- a/components/AppAuthBoundary.tsx
+++ b/components/AppAuthBoundary.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import LoginGate from '@/components/LoginGate';
+import { isPublicAppPath } from '@/lib/app-access';
+
+type Props = { children: React.ReactNode };
+
+export default function AppAuthBoundary({ children }: Props) {
+  const pathname = usePathname();
+
+  if (isPublicAppPath(pathname)) {
+    return <>{children}</>;
+  }
+
+  return <LoginGate>{children}</LoginGate>;
+}

--- a/lib/app-access.ts
+++ b/lib/app-access.ts
@@ -1,0 +1,4 @@
+export function isPublicAppPath(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  return pathname === '/public-media' || pathname.startsWith('/public-media/');
+}

--- a/tests/app-access.test.ts
+++ b/tests/app-access.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isPublicAppPath } from '../lib/app-access';
+
+test('only explicit public-media paths bypass the central app auth boundary', () => {
+  assert.equal(isPublicAppPath('/public-media'), true);
+  assert.equal(isPublicAppPath('/public-media/damage/abc'), true);
+
+  for (const path of ['/', '/check', '/check/drafts', '/ankomst', '/status', '/nybil', '/rapport', '/vagnkort', '/media/file']) {
+    assert.equal(isPublicAppPath(path), false, `${path} must remain protected`);
+  }
+});
+
+test('missing pathname is protected by default', () => {
+  assert.equal(isPublicAppPath(null), false);
+  assert.equal(isPublicAppPath(undefined), false);
+  assert.equal(isPublicAppPath(''), false);
+});

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -2,9 +2,11 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { isPublicAppPath } from '../lib/app-access';
 
 const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
 const page = read('app/vagnkort/page.tsx');
+const layout = read('app/layout.tsx');
 const client = read('app/vagnkort/vagnkort-client.tsx');
 const upload = read('app/vagnkort/document-upload.tsx');
 const uploadApi = read('app/api/vehicle-documents/route.ts');
@@ -25,8 +27,11 @@ function matches(source: string, patterns: RegExp[]) {
   for (const pattern of patterns) assert.match(source, pattern);
 }
 
-test('Vagnkort page stays behind the existing LoginGate', () => {
-  matches(page, [/<LoginGate>/, /<VagnkortClient \/>/]);
+test('Vagnkort stays behind the central app auth boundary', () => {
+  assert.equal(isPublicAppPath('/vagnkort'), false);
+  matches(layout, [/<AppAuthBoundary>\{children\}<\/AppAuthBoundary>/]);
+  matches(page, [/<VagnkortClient \/>/]);
+  assert.doesNotMatch(page, /LoginGate/);
 });
 
 test('Vagnkort reads the authenticated vehicle journey API', () => {


### PR DESCRIPTION
## Syfte
Gör inloggningsgrinden central i hela Incheckad i stället för att varje sida måste komma ihåg att montera `LoginGate`.

## Ändringar
- Ny central `AppAuthBoundary` i root layout.
- Alla interna app-routes skyddas som default.
- Endast `/public-media` och dess underpaths är explicit publika.
- Befintliga dubbla `LoginGate`-wrappers tas bort från startsida, Check-in, Ankomst, Status, Nybil, Vagnkort och intern Media.
- Ny ren access-policy `isPublicAppPath` och test som verifierar fail-closed/default-protected beteende.

## Avgränsning
Denna PR ändrar inte nuvarande server-side API-auth, whitelist/employees-modellen, RLS eller roller/mandat. Nästa steg är att flytta kvarvarande direkta browser→Supabase-anrop bakom API och därefter bygga roll/organisationsbaserad authorization.

## Säkerhetsprincip
Ny intern sida ska vara skyddad automatiskt. Offentlig route måste vara uttryckligen undantagen.