### PR TITLE
Route check-in drafts through authenticated API

### DIFF
--- a/app/api/checkin-drafts/route.ts
+++ b/app/api/checkin-drafts/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing Supabase server configuration');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from('checkin_drafts')
+      .select('regnr, updated_at')
+      .order('updated_at', { ascending: false })
+      .limit(50);
+
+    if (error) throw error;
+
+    return NextResponse.json({ data: data ?? [] });
+  } catch (error) {
+    console.error('[checkin-drafts] Read failed:', error);
+    return NextResponse.json({ error: 'Could not load check-in drafts' }, { status: 500 });
+  }
+}

--- a/app/check/drafts/page.tsx
+++ b/app/check/drafts/page.tsx
@@ -1,9 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
 
 type DraftRow = { regnr: string; updated_at: string };
+
+type DraftResponse = {
+  data?: DraftRow[];
+  error?: string;
+};
 
 export default function DraftsPage() {
   const [drafts, setDrafts] = useState<DraftRow[]>([]);
@@ -11,19 +15,27 @@ export default function DraftsPage() {
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
-      const { data, error } = await supabase
-        .from('checkin_drafts')
-        .select('regnr, updated_at')
-        .order('updated_at', { ascending: false })
-        .limit(50);
 
-      if (!cancelled) {
-        if (error) console.error(error);
-        setDrafts((data as DraftRow[]) || []);
-        setLoading(false);
+    (async () => {
+      try {
+        const response = await fetch('/api/checkin-drafts');
+        const payload = await response.json() as DraftResponse;
+
+        if (!response.ok) {
+          throw new Error(payload.error || 'Kunde inte läsa utkast');
+        }
+
+        if (!cancelled) {
+          setDrafts(payload.data ?? []);
+        }
+      } catch (error) {
+        console.error(error);
+        if (!cancelled) setDrafts([]);
+      } finally {
+        if (!cancelled) setLoading(false);
       }
     })();
+
     return () => { cancelled = true; };
   }, []);
 

--- a/tests/security-boundary.test.ts
+++ b/tests/security-boundary.test.ts
@@ -12,6 +12,7 @@ import { proxy } from '../proxy'
 
 const protectedApiPaths = [
   '/api/checkin-damages',
+  '/api/checkin-drafts',
   '/api/checkpoint-actions',
   '/api/checkpoint-actions/read-model?reg=GEU29F',
   '/api/damage-comments',


### PR DESCRIPTION
## Syfte
Tar bort en konkret direkt browser→Supabase-läsning från `/check/drafts` och flyttar den bakom den centrala autentiserade API-gränsen.

## Ändringar
- Ny `GET /api/checkin-drafts` med `verifyApiUser` och server-side service role.
- `/check/drafts` läser nu via `fetch('/api/checkin-drafts')` i stället för `supabase.from('checkin_drafts')` i browsern.
- Säkerhetsregressionen verifierar att `/api/checkin-drafts` ger 401 utan autentisering.

## Avgränsning
Detta är första konkreta AUTH STEG 2-flytten. Övriga direkta browser→Supabase-anrop lämnas orörda i denna PR och flyttas stegvis för att hålla förändringen liten och verifierbar.