### PR TITLE
Route LoginGate authorization through server API

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { verifyApiUser } from '@/lib/server-auth';
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  return NextResponse.json({
+    data: {
+      id: verification.user.id,
+      email: verification.user.email,
+      authorized: true,
+    },
+  });
+}

--- a/components/LoginGate.tsx
+++ b/components/LoginGate.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase';
-import { isWhitelistedEmail } from '@/lib/access-control';
 import { installAuthenticatedApiFetch } from '@/lib/api-auth-client';
 
 type Props = { children: React.ReactNode };
@@ -21,26 +20,20 @@ export default function LoginGate({ children }: Props) {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) { setState('login'); return; }
 
-      const lower = user.email?.toLowerCase() ?? null;
+      try {
+        const response = await fetch('/api/auth/me');
+        if (!response.ok) {
+          await supabase.auth.signOut();
+          setState('denied');
+          return;
+        }
 
-      if (isWhitelistedEmail(lower)) {
         setState('ok');
-        return;
-      }
-
-      const { data, error } = await supabase
-        .from('employees')
-        .select('email,is_active')
-        .eq('email', lower!)
-        .single();
-
-      if (error || !data?.is_active) {
+      } catch (error) {
+        console.error('[LoginGate] Access verification failed:', error);
         await supabase.auth.signOut();
         setState('denied');
-        return;
       }
-
-      setState('ok');
     })();
 
     return uninstallApiAuthFetch;
@@ -83,9 +76,6 @@ export default function LoginGate({ children }: Props) {
       return;
     }
 
-    // Re-run the existing whitelist / employees authorization check using
-    // the newly established Supabase session. This avoids creating a second
-    // authorization path for OTP sign-in.
     window.location.reload();
   };
 
@@ -148,7 +138,7 @@ export default function LoginGate({ children }: Props) {
     );
   }
 
-  if (state === 'denied') return <div className="login-bg"><div className="login-card">Åtkomst nekad (ej vitlistad).</div></div>;
+  if (state === 'denied') return <div className="login-bg"><div className="login-card">Åtkomst nekad.</div></div>;
   if (state === 'checking') return <div className="login-bg"><div className="login-card">Kontrollerar inloggning…</div></div>;
   return <>{children}</>;
 }

--- a/tests/auth-access-boundary.test.ts
+++ b/tests/auth-access-boundary.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { NextRequest } from 'next/server';
+import { proxy } from '../proxy';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+
+test('current-user access endpoint stays behind central API authentication', async () => {
+  const response = await proxy(new NextRequest('http://localhost/api/auth/me'));
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: 'Authentication required' });
+});
+
+test('LoginGate delegates authorization to the server access endpoint', () => {
+  const source = read('components/LoginGate.tsx');
+
+  assert.match(source, /fetch\('\/api\/auth\/me'\)/);
+  assert.doesNotMatch(source, /\.from\(['"]employees['"]\)/);
+  assert.doesNotMatch(source, /isWhitelistedEmail/);
+});
+
+test('current-user endpoint uses the canonical server authorization check', () => {
+  const source = read('app/api/auth/me/route.ts');
+
+  assert.match(source, /verifyApiUser\(request\)/);
+  assert.match(source, /authorized:\s*true/);
+});


### PR DESCRIPTION
## Syfte
Tar bort LoginGates direkta browser→Supabase-läsning mot `employees` och gör serverns befintliga accesskontroll till enda auktorisationsväg för app-inloggningen.

## Ändringar
- Ny `GET /api/auth/me` som använder `verifyApiUser`.
- `LoginGate` använder fortsatt Supabase Auth för session/OTP, men delegerar accessbeslutet till `/api/auth/me`.
- Direkt `supabase.from('employees')` och klientens whitelist-beslut tas bort från LoginGate.
- Regressionstester verifierar att endpointen kräver autentisering och att LoginGate inte längre läser `employees` direkt.

## Avgränsning
Detta ändrar inte själva whitelist/employees-regeln i `server-auth.ts`; det centraliserar endast var den tillämpas. Roller/mandat byggs senare.