### PR TITLE
Add authenticated allowed plates API

### DIFF
--- a/app/api/allowed-plates/route.ts
+++ b/app/api/allowed-plates/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing Supabase server configuration');
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin.rpc('get_all_allowed_plates').range(0, 4999);
+    if (error) throw error;
+
+    return NextResponse.json({
+      data: (data ?? [])
+        .map((row: { regnr?: unknown }) => typeof row.regnr === 'string' ? row.regnr : null)
+        .filter((regnr: string | null): regnr is string => Boolean(regnr)),
+    });
+  } catch (error) {
+    console.error('[allowed-plates] Read failed:', error);
+    return NextResponse.json({ error: 'Could not load allowed plates' }, { status: 500 });
+  }
+}

--- a/tests/allowed-plates-api-contract.test.ts
+++ b/tests/allowed-plates-api-contract.test.ts
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { NextRequest } from 'next/server';
+import { proxy } from '../proxy';
+
+test('/api/allowed-plates rejects unauthenticated requests', async () => {
+  const response = await proxy(new NextRequest('http://localhost/api/allowed-plates'));
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: 'Authentication required' });
+});


### PR DESCRIPTION
## Syfte
Förbereder nästa AUTH STEG 2-migrering genom att skapa en server-side väg för registreringslistan som idag fortfarande hämtas via browser-RPC i bland annat `/ankomst`, `/check` och `/status`.

## Ändringar
- Ny `GET /api/allowed-plates` bakom `verifyApiUser`.
- Server-side service role anropar befintliga `get_all_allowed_plates` och returnerar endast registreringsnummer.
- Regressionstest verifierar 401 utan autentisering.

## Viktig avgränsning
Denna PR tar **inte ännu bort** klienternas befintliga `supabase.rpc('get_all_allowed_plates')`. Den etablerar den autentiserade API-kontraktet först, så att konsumenterna kan flyttas en i taget i efterföljande små PR:er utan att blanda serverkontrakt och flera stora formulärändringar samtidigt.