### PR TITLE
Add authenticated allowed plates client helper

### DIFF
--- a/lib/allowed-plates-client.ts
+++ b/lib/allowed-plates-client.ts
@@ -1,0 +1,15 @@
+export type AllowedPlatesResponse = {
+  data?: string[];
+  error?: string;
+};
+
+export async function fetchAllowedPlates(): Promise<string[]> {
+  const response = await fetch('/api/allowed-plates');
+  const payload = await response.json() as AllowedPlatesResponse;
+
+  if (!response.ok) {
+    throw new Error(payload.error || 'Kunde inte hämta registreringsnummer');
+  }
+
+  return Array.isArray(payload.data) ? payload.data : [];
+}


### PR DESCRIPTION
## Syfte
Fortsätter AUTH STEG 2 genom att lägga ett gemensamt klientkontrakt ovanpå `/api/allowed-plates` innan de tre stora formulären flyttas bort från browser-RPC.

## Ändringar
- Ny `fetchAllowedPlates()` som läser registreringslistan via den autentiserade API-gränsen.
- Central felhantering och svarstyp i stället för att duplicera API-parsning i `/ankomst`, `/check` och `/status`.

## Avgränsning
Denna PR ändrar ännu inte formulären. Nästa små PR flyttar `/ankomst`, därefter `/check` och `/status`, en konsument i taget.