### PR TITLE
Route arrival autocomplete through authenticated API

### DIFF
--- a/app/ankomst/form-client.tsx
+++ b/app/ankomst/form-client.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useState, useCallback, useRef, Fragment } from 'react';
 import { ORTER, STATIONER } from '@/lib/constants';
 import { supabase } from '@/lib/supabase';
+import { fetchAllowedPlates } from '@/lib/allowed-plates-client';
 
 // =================================================================
 // 1. DATA & HELPERS
@@ -327,11 +328,13 @@ export default function ArrivalForm() {
   // Load all registrations for autocomplete
   useEffect(() => {
     async function fetchAllRegistrations() {
-      const { data, error } = await supabase.rpc('get_all_allowed_plates').range(0, 4999);
-      if (error) console.error('Could not fetch registrations via RPC:', error);
-      else if (data) setAllRegistrations(data.map((item: any) => item.regnr));
+      try {
+        setAllRegistrations(await fetchAllowedPlates());
+      } catch (error) {
+        console.error('Could not fetch registrations via authenticated API:', error);
+      }
     }
-    fetchAllRegistrations();
+    void fetchAllRegistrations();
   }, []);
 
   // Autocomplete filtering

--- a/tests/arrival-allowed-plates-boundary.test.ts
+++ b/tests/arrival-allowed-plates-boundary.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(join(process.cwd(), 'app/ankomst/form-client.tsx'), 'utf8');
+
+test('arrival autocomplete uses authenticated allowed plates client', () => {
+  assert.match(source, /fetchAllowedPlates\(\)/);
+  assert.doesNotMatch(source, /supabase\.rpc\(['"]get_all_allowed_plates['"]\)/);
+});


### PR DESCRIPTION
## Syfte
Fortsätter AUTH STEG 2 genom att flytta `/ankomst` bort från direkt browser-RPC för registreringslistan.

## Ändringar
- `/ankomst` använder nu gemensamma `fetchAllowedPlates()`.
- Direkt `supabase.rpc('get_all_allowed_plates')` är borttaget från ankomstformuläret.
- Supabase auth-anropet för aktuell inloggad användare lämnas oförändrat.
- Regressionstest blockerar återinförd browser-RPC i `/ankomst`.

## Avgränsning
Ingen övrig ankomstlogik ändras. `/check` och `/status` migreras separat efter denna PR.