### PR TITLE
Support sold filtering in allowed plates API

### DIFF
--- a/app/api/allowed-plates/route.ts
+++ b/app/api/allowed-plates/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: Request) {
     const { data, error } = await admin.rpc('get_all_allowed_plates').range(0, 4999);
     if (error) throw error;
 
-    let plates = (data ?? [])
+    let plates: string[] = (data ?? [])
       .map((row: { regnr?: unknown }) => normalizeRegnr(row.regnr))
       .filter((regnr: string | null): regnr is string => Boolean(regnr));
 
@@ -68,7 +68,7 @@ export async function GET(request: Request) {
         if (value === 'false') soldSet.delete(regnr);
       }
 
-      plates = plates.filter((regnr) => !soldSet.has(regnr));
+      plates = plates.filter((regnr: string) => !soldSet.has(regnr));
     }
 
     return NextResponse.json({ data: plates });

--- a/app/api/allowed-plates/route.ts
+++ b/app/api/allowed-plates/route.ts
@@ -15,6 +15,12 @@ function createAdminClient() {
   });
 }
 
+function normalizeRegnr(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.toUpperCase().replace(/\s/g, '');
+  return normalized || null;
+}
+
 export async function GET(request: Request) {
   const verification = await verifyApiUser(request);
   if (!verification.ok) {
@@ -23,14 +29,49 @@ export async function GET(request: Request) {
 
   try {
     const admin = createAdminClient();
+    const excludeSold = new URL(request.url).searchParams.get('excludeSold') === 'true';
     const { data, error } = await admin.rpc('get_all_allowed_plates').range(0, 4999);
     if (error) throw error;
 
-    return NextResponse.json({
-      data: (data ?? [])
-        .map((row: { regnr?: unknown }) => typeof row.regnr === 'string' ? row.regnr : null)
-        .filter((regnr: string | null): regnr is string => Boolean(regnr)),
-    });
+    let plates = (data ?? [])
+      .map((row: { regnr?: unknown }) => normalizeRegnr(row.regnr))
+      .filter((regnr: string | null): regnr is string => Boolean(regnr));
+
+    if (excludeSold) {
+      const [soldInventoryResponse, soldEditsResponse] = await Promise.all([
+        admin.from('nybil_inventering').select('regnr').eq('is_sold', true),
+        admin
+          .from('vehicle_edits')
+          .select('regnr,new_value,edited_at')
+          .eq('field_name', 'is_sold')
+          .order('edited_at', { ascending: false }),
+      ]);
+
+      if (soldInventoryResponse.error) throw soldInventoryResponse.error;
+      if (soldEditsResponse.error) throw soldEditsResponse.error;
+
+      const soldEditsMap = new Map<string, string>();
+      for (const edit of soldEditsResponse.data ?? []) {
+        const regnr = normalizeRegnr(edit.regnr);
+        if (regnr && !soldEditsMap.has(regnr)) {
+          soldEditsMap.set(regnr, edit.new_value ?? '');
+        }
+      }
+
+      const soldSet = new Set<string>();
+      for (const row of soldInventoryResponse.data ?? []) {
+        const regnr = normalizeRegnr(row.regnr);
+        if (regnr) soldSet.add(regnr);
+      }
+      for (const [regnr, value] of soldEditsMap.entries()) {
+        if (value === 'true') soldSet.add(regnr);
+        if (value === 'false') soldSet.delete(regnr);
+      }
+
+      plates = plates.filter((regnr) => !soldSet.has(regnr));
+    }
+
+    return NextResponse.json({ data: plates });
   } catch (error) {
     console.error('[allowed-plates] Read failed:', error);
     return NextResponse.json({ error: 'Could not load allowed plates' }, { status: 500 });

--- a/lib/allowed-plates-client.ts
+++ b/lib/allowed-plates-client.ts
@@ -3,8 +3,15 @@ export type AllowedPlatesResponse = {
   error?: string;
 };
 
-export async function fetchAllowedPlates(): Promise<string[]> {
-  const response = await fetch('/api/allowed-plates');
+type AllowedPlatesOptions = {
+  excludeSold?: boolean;
+};
+
+export async function fetchAllowedPlates(options: AllowedPlatesOptions = {}): Promise<string[]> {
+  const params = new URLSearchParams();
+  if (options.excludeSold) params.set('excludeSold', 'true');
+  const query = params.toString();
+  const response = await fetch(`/api/allowed-plates${query ? `?${query}` : ''}`);
   const payload = await response.json() as AllowedPlatesResponse;
 
   if (!response.ok) {


### PR DESCRIPTION
## Syfte
Förbereder `/check`-migreringen utan att ändra formulärsemantik.

## Ändringar
- `/api/allowed-plates` kan nu anropas med `excludeSold=true`.
- Servern bevarar dagens check-in-logik för sålda bilar genom att kombinera `nybil_inventering.is_sold` med senaste `vehicle_edits` för `is_sold`.
- `fetchAllowedPlates({ excludeSold: true })` exponerar samma kontrakt till klienten.

## Avgränsning
Ingen formulärkod ändras i denna PR. Nästa PR byter `/check` från browser-RPC och direkta sold-queries till detta serverkontrakt.