### PR TITLE
Preserve allowed plates sold semantics

### DIFF
--- a/app/api/allowed-plates/route.ts
+++ b/app/api/allowed-plates/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: Request) {
     if (error) throw error;
 
     let plates: string[] = (data ?? [])
-      .map((row: { regnr?: unknown }) => normalizeRegnr(row.regnr))
+      .map((row: { regnr?: unknown }) => (typeof row.regnr === 'string' ? row.regnr : null))
       .filter((regnr: string | null): regnr is string => Boolean(regnr));
 
     if (excludeSold) {
@@ -65,10 +65,12 @@ export async function GET(request: Request) {
       }
       for (const [regnr, value] of soldEditsMap.entries()) {
         if (value === 'true') soldSet.add(regnr);
-        if (value === 'false') soldSet.delete(regnr);
       }
 
-      plates = plates.filter((regnr: string) => !soldSet.has(regnr));
+      plates = plates.filter((regnr: string) => {
+        const normalized = normalizeRegnr(regnr);
+        return !normalized || !soldSet.has(normalized);
+      });
     }
 
     return NextResponse.json({ data: plates });

--- a/tests/allowed-plates-source-contract.test.ts
+++ b/tests/allowed-plates-source-contract.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const source = fs.readFileSync(path.join(process.cwd(), 'app/api/allowed-plates/route.ts'), 'utf8');
+
+test('sold inventory cannot be cleared by a false vehicle edit', () => {
+  assert.doesNotMatch(source, /soldSet\.delete\(/);
+});


### PR DESCRIPTION
## Syfte
Rättar semantiken i `/api/allowed-plates?excludeSold=true` innan fler konsumenter migreras.

## Ändringar
- bevarar registreringsnummer från RPC utan att skriva om visningsvärdet
- normaliserar endast vid jämförelse mot sålda fordon
- låter inte ett senare `is_sold=false` i `vehicle_edits` ta bort en bil som redan är markerad såld i `nybil_inventering`
- lägger kontraktstest som förbjuder `soldSet.delete(...)`

## Avgränsning
Ingen UI- eller övrig Status-logik ändras.