### PR TITLE
Add authenticated Status data client contract

### DIFF
--- a/lib/status-data-client.ts
+++ b/lib/status-data-client.ts
@@ -1,0 +1,27 @@
+export type StatusDataPayload = {
+  nybil: any | null;
+  vehicle: any[];
+  damages: any[];
+  legacyDamages: any[];
+  checkins: any[];
+  arrivals: any[];
+  vehicleEdits: any[];
+  damageComments: any[];
+  checkinDamages: any[];
+};
+
+type StatusDataResponse = {
+  data?: StatusDataPayload;
+  error?: string;
+};
+
+export async function fetchStatusData(regnr: string): Promise<StatusDataPayload> {
+  const response = await fetch(`/api/status-data?regnr=${encodeURIComponent(regnr)}`);
+  const payload = await response.json() as StatusDataResponse;
+
+  if (!response.ok || !payload.data) {
+    throw new Error(payload.error || 'Kunde inte hämta statusdata');
+  }
+
+  return payload.data;
+}

--- a/lib/status-data-client.ts
+++ b/lib/status-data-client.ts
@@ -1,13 +1,13 @@
 export type StatusDataPayload = {
-  nybil: any | null;
-  vehicle: any[];
-  damages: any[];
-  legacyDamages: any[];
-  checkins: any[];
-  arrivals: any[];
-  vehicleEdits: any[];
-  damageComments: any[];
-  checkinDamages: any[];
+  nybil: unknown | null;
+  vehicle: unknown[];
+  damages: unknown[];
+  legacyDamages: unknown[];
+  checkins: unknown[];
+  arrivals: unknown[];
+  vehicleEdits: unknown[];
+  damageComments: unknown[];
+  checkinDamages: unknown[];
 };
 
 type StatusDataResponse = {

--- a/tests/status-data-client.test.ts
+++ b/tests/status-data-client.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const source = fs.readFileSync(path.join(process.cwd(), 'lib/status-data-client.ts'), 'utf8');
+
+test('Status data client uses the authenticated same-origin API', () => {
+  assert.match(source, /fetch\(`\/api\/status-data\?regnr=\$\{encodeURIComponent\(regnr\)\}`\)/);
+  assert.doesNotMatch(source, /supabase\.(from|rpc)\(/);
+});


### PR DESCRIPTION
## Syfte
Förbereder den faktiska `/status`-omkopplingen till den redan mergade authenticated `GET /api/status-data?regnr=...` utan att röra Vagnkortssemantiken i samma steg.

## Ändringar
- nytt `lib/status-data-client.ts`
- same-origin fetch mot `/api/status-data`
- inget Supabase-anrop i klientkontraktet
- statiskt regressionstest för API-gränsen

## Avgränsning
`/status` är ännu inte omkopplad i denna PR. `lib/vehicle-status.ts` innehåller fortfarande den gamla direkta browser-dataläsningen och tas i nästa isolerade steg.