### PR TITLE
Add Status read-model source adapter

### DIFF
--- a/lib/status-read-model-source.ts
+++ b/lib/status-read-model-source.ts
@@ -1,0 +1,46 @@
+import { fetchStatusData } from './status-data-client';
+
+type StatusRow = Record<string, unknown>;
+
+export type StatusReadModelSourceData = {
+  nybil: StatusRow | null;
+  vehicle: StatusRow[];
+  damages: StatusRow[];
+  legacyDamages: StatusRow[];
+  checkins: StatusRow[];
+  arrivals: StatusRow[];
+  vehicleEdits: StatusRow[];
+  damageComments: StatusRow[];
+  checkinDamages: StatusRow[];
+};
+
+function isStatusRow(value: unknown): value is StatusRow {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requireRows(value: unknown[], field: string): StatusRow[] {
+  if (!value.every(isStatusRow)) {
+    throw new Error(`Ogiltig statusdata: ${field}`);
+  }
+  return value;
+}
+
+export async function fetchStatusReadModelSourceData(regnr: string): Promise<StatusReadModelSourceData> {
+  const payload = await fetchStatusData(regnr);
+
+  if (payload.nybil !== null && !isStatusRow(payload.nybil)) {
+    throw new Error('Ogiltig statusdata: nybil');
+  }
+
+  return {
+    nybil: payload.nybil,
+    vehicle: requireRows(payload.vehicle, 'vehicle'),
+    damages: requireRows(payload.damages, 'damages'),
+    legacyDamages: requireRows(payload.legacyDamages, 'legacyDamages'),
+    checkins: requireRows(payload.checkins, 'checkins'),
+    arrivals: requireRows(payload.arrivals, 'arrivals'),
+    vehicleEdits: requireRows(payload.vehicleEdits, 'vehicleEdits'),
+    damageComments: requireRows(payload.damageComments, 'damageComments'),
+    checkinDamages: requireRows(payload.checkinDamages, 'checkinDamages'),
+  };
+}

--- a/tests/status-read-model-source-contract.test.ts
+++ b/tests/status-read-model-source-contract.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const source = fs.readFileSync(path.join(process.cwd(), 'lib/status-read-model-source.ts'), 'utf8');
+
+test('Status read-model source stays behind authenticated status-data client', () => {
+  assert.match(source, /fetchStatusData/);
+  assert.doesNotMatch(source, /from ['"]\.\/supabase['"]/);
+  assert.doesNotMatch(source, /\.from\(/);
+  assert.doesNotMatch(source, /\.rpc\(/);
+});


### PR DESCRIPTION
## Syfte
Tar nästa faktiska steg i `/status`-frikopplingen genom att införa en enda källa för read-modellens rådata ovanpå det redan mergade authenticated `status-data`-API:t.

## Ändringar
- nytt `lib/status-read-model-source.ts`
- läser endast via `fetchStatusData`
- validerar att payloaden innehåller objekt/rader innan read-modellen använder den
- nytt regressionstest som förbjuder Supabase `from/rpc` i adaptern

## Nästa steg
Koppla `lib/vehicle-status.ts` till denna adapter och ta bort dess direkta browser→Supabase-läsningar utan att ändra befintlig Status/Vagnkortssemantik.