### PR TITLE
Enable checkpoint action timer scheduler in Production

### DIFF
--- a/tests/checkpoint-action-timer.test.ts
+++ b/tests/checkpoint-action-timer.test.ts
@@ -79,7 +79,8 @@ test('scheduler is token-protected, supports dry run and delegates to one timer 
   assert.match(scheduler, /rpc\('run_checkpoint_action_timers'/);
   assert.match(scheduler, /p_apply:\s*!dryRun/);
   assert.doesNotMatch(scheduler, /verifyApiUser/);
-  assert.doesNotMatch(vercel, /"path": "\/api\/checkpoint-actions\/scheduler"/);
+  assert.match(vercel, /"path": "\/api\/checkpoint-actions\/scheduler"/);
+  assert.match(vercel, /"schedule": "0 \* \* \* \*"/);
   assert.match(vercel, /"path": "\/api\/salu\/scheduler"/);
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/salu/scheduler",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/checkpoint-actions/scheduler",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Superseded by PR #401, rebased cleanly on current `main` after #400. #401 contains the same intended Production timer cron + regression contract without the stale-base/Vercel-preview problem.