### PR TITLE
Close remaining browser Supabase app-data gap

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -71,11 +71,6 @@
       "count": 3
     }
   },
-  "app/rapport/RapportTable.tsx": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 2
-    }
-  },
   "app/rapport/page.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 5

--- a/tests/browser-supabase-app-data-boundary.test.ts
+++ b/tests/browser-supabase-app-data-boundary.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+function collectSourceFiles(root: string): string[] {
+  if (!fs.existsSync(root)) return [];
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+    } else if (/\.(?:ts|tsx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+test('client code does not access Supabase app data directly', () => {
+  const roots = [path.join(process.cwd(), 'app'), path.join(process.cwd(), 'components')];
+  const violations: string[] = [];
+
+  for (const file of roots.flatMap(collectSourceFiles)) {
+    const relative = path.relative(process.cwd(), file);
+    if (relative.startsWith(`app${path.sep}api${path.sep}`)) continue;
+
+    const source = fs.readFileSync(file, 'utf8');
+    if (!/^\s*['"]use client['"];?/m.test(source)) continue;
+
+    if (/\bsupabase\s*\.\s*(?:from|rpc)\s*\(/.test(source)) {
+      violations.push(relative);
+    }
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `Direct browser→Supabase app-data access found in: ${violations.join(', ')}`,
+  );
+});


### PR DESCRIPTION
## Syfte
Slutför browser→Supabase-reauditen efter Status- och Nybil-migreringarna.

## Genomförande
- verifierar att den äldre direkta rapportkomponenten `app/rapport/RapportTable.tsx` redan är borta från aktuell `main`
- tar bort dess kvarvarande föråldrade ESLint-suppression
- lägger ett permanent regressionstest som förbjuder `supabase.from(...)` och `supabase.rpc(...)` i `use client`-kod under `app/` och `components/`
- avsiktliga auth/session- och storage/media-flöden påverkas inte

## Arkitekturprincip
Browser → authenticated same-origin `/api/*` → server-side auth → server-side Supabase/service role för verksamhetsdata.