### PR TITLE
Enable checkpoint action timer scheduler in Production

### DIFF
--- a/migrations/20260822215000_enable_checkpoint_action_timer_cron.sql
+++ b/migrations/20260822215000_enable_checkpoint_action_timer_cron.sql
@@ -1,0 +1,15 @@
+create extension if not exists pg_cron with schema cron;
+
+do $$
+begin
+  perform cron.unschedule(jobid)
+  from cron.job
+  where jobname = 'checkpoint-action-timers-hourly';
+
+  perform cron.schedule(
+    'checkpoint-action-timers-hourly',
+    '0 * * * *',
+    $cron$select public.run_checkpoint_action_timers(now(), true);$cron$
+  );
+end
+$$;

--- a/tests/checkpoint-action-timer.test.ts
+++ b/tests/checkpoint-action-timer.test.ts
@@ -79,7 +79,8 @@ test('scheduler is token-protected, supports dry run and delegates to one timer 
   assert.match(scheduler, /rpc\('run_checkpoint_action_timers'/);
   assert.match(scheduler, /p_apply:\s*!dryRun/);
   assert.doesNotMatch(scheduler, /verifyApiUser/);
-  assert.doesNotMatch(vercel, /"path": "\/api\/checkpoint-actions\/scheduler"/);
+  assert.match(vercel, /"path": "\/api\/checkpoint-actions\/scheduler"/);
+  assert.match(vercel, /"schedule": "0 \* \* \* \*"/);
   assert.match(vercel, /"path": "\/api\/salu\/scheduler"/);
 });
 

--- a/tests/checkpoint-action-timer.test.ts
+++ b/tests/checkpoint-action-timer.test.ts
@@ -8,6 +8,7 @@ import { proxy } from '../proxy';
 const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
 const contract = read('migrations/20260821070723_add_checkpoint_action_timer_contract.sql');
 const runner = read('migrations/20260821070855_add_checkpoint_action_timer_runner.sql');
+const cronMigration = read('migrations/20260822215000_enable_checkpoint_action_timer_cron.sql');
 const scheduler = read('app/api/checkpoint-actions/scheduler/route.ts');
 const readModel = read('app/api/checkpoint-actions/read-model/route.ts');
 const panel = read('app/vagnkort/checkpoint-actions-panel.tsx');
@@ -72,15 +73,20 @@ test('timer tables and RPCs remain server-only', () => {
   assert.match(runner, /grant execute on function public\.run_checkpoint_action_timers[\s\S]*to service_role/i);
 });
 
-test('scheduler is token-protected, supports dry run and delegates to one timer RPC', () => {
+test('scheduler route is token-protected and Postgres owns the hourly production trigger', () => {
   assert.match(scheduler, /CHECKPOINT_ACTION_SCHEDULER_TOKEN/);
   assert.match(scheduler, /CRON_SECRET/);
   assert.match(scheduler, /dryRun/);
   assert.match(scheduler, /rpc\('run_checkpoint_action_timers'/);
   assert.match(scheduler, /p_apply:\s*!dryRun/);
   assert.doesNotMatch(scheduler, /verifyApiUser/);
-  assert.match(vercel, /"path": "\/api\/checkpoint-actions\/scheduler"/);
-  assert.match(vercel, /"schedule": "0 \* \* \* \*"/);
+
+  assert.match(cronMigration, /create extension if not exists pg_cron/i);
+  assert.match(cronMigration, /checkpoint-action-timers-hourly/);
+  assert.match(cronMigration, /'0 \* \* \* \*'/);
+  assert.match(cronMigration, /run_checkpoint_action_timers\(now\(\), true\)/i);
+
+  assert.doesNotMatch(vercel, /"path": "\/api\/checkpoint-actions\/scheduler"/);
   assert.match(vercel, /"path": "\/api\/salu\/scheduler"/);
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,6 @@
     {
       "path": "/api/salu/scheduler",
       "schedule": "0 6 * * *"
-    },
-    {
-      "path": "/api/checkpoint-actions/scheduler",
-      "schedule": "0 * * * *"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
     {
       "path": "/api/salu/scheduler",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/checkpoint-actions/scheduler",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Syfte
Stänga repo/Production-paritetsluckan för checkpoint action timers ovanpå aktuell `main`.

## Verifierat
- Production har `run_checkpoint_action_timers(...)` och aktiv `DEFAULT` v1 timerregel.
- Vercel-projektet ligger på Hobby-plan, där cron får köras högst dagligen. Timern behöver timkörning, så Vercel Cron är fel exekveringslager här.

## Ändring
- aktiverar `pg_cron` i Postgres via migration
- schemalägger `run_checkpoint_action_timers(now(), true)` varje hel timme
- behåller Vercels befintliga dagliga SALU-cron oförändrad
- låser scheduler-kontraktet i regressionstest

## Semantik
Timern ändrar inte action-workflowstatus. Den uppdaterar timerprojektionen och append-only timer/journey events. `Action completed ≠ checkpoint verifierad` ligger fast.

## Bakgrund
Ersätter PR #399. Den tidigare lösningen använde Vercel hourly cron, vilket Vercel Hobby inte tillåter och därför gav röd Vercel-check.