### PR TITLE
Lock Vagnkort primary state writes to authoritative sources

### DIFF
--- a/app/api/vehicle-journey/periods/route.ts
+++ b/app/api/vehicle-journey/periods/route.ts
@@ -5,17 +5,6 @@ import { verifyApiUser } from '@/lib/server-auth';
 const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const PRIMARY_PERIOD_TYPES = [
-  'PREPARATION',
-  'AVAILABLE',
-  'RENTAL',
-  'DOWNTIME',
-  'SALU',
-  'OTHER',
-] as const;
-
-type PrimaryPeriodType = (typeof PRIMARY_PERIOD_TYPES)[number];
-
 const ACTIVITY_TYPES = [
   'WORKSHOP',
   'SERVICE',
@@ -28,36 +17,13 @@ const ACTIVITY_TYPES = [
 
 type ActivityType = (typeof ACTIVITY_TYPES)[number];
 
-const DOWNTIME_REASONS = [
-  'DAMAGE',
-  'WORKSHOP',
-  'SERVICE',
-  'WAITING_PARTS',
-  'MISSING_EQUIPMENT',
-  'TRANSPORT',
-  'ADMINISTRATION',
-  'OTHER',
-] as const;
-
-type DowntimeReason = (typeof DOWNTIME_REASONS)[number];
-
 function cleanRegnr(value: unknown): string {
   return typeof value === 'string' ? value.toUpperCase().replace(/\s+/g, '') : '';
-}
-
-function cleanPrimaryPeriodType(value: unknown): PrimaryPeriodType | null {
-  const periodType = typeof value === 'string' ? value.trim().toUpperCase() : '';
-  return PRIMARY_PERIOD_TYPES.includes(periodType as PrimaryPeriodType) ? periodType as PrimaryPeriodType : null;
 }
 
 function cleanActivityType(value: unknown): ActivityType | null {
   const activityType = typeof value === 'string' ? value.trim().toUpperCase() : '';
   return ACTIVITY_TYPES.includes(activityType as ActivityType) ? activityType as ActivityType : null;
-}
-
-function cleanReasonCode(value: unknown): string | null {
-  if (typeof value !== 'string' || !value.trim()) return null;
-  return value.trim().toUpperCase().replace(/[^A-Z0-9_-]+/g, '_').slice(0, 80) || null;
 }
 
 function cleanReasonText(value: unknown): string | null {
@@ -124,6 +90,16 @@ export async function POST(request: Request) {
   }
 
   const action = typeof body.action === 'string' ? body.action.trim().toUpperCase() : '';
+
+  // Primary operational state is source-controlled. Vagnkort is a read model and
+  // must never manufacture, transition or close AVAILABLE/RENTAL/DOWNTIME/etc.
+  if (action === 'START' || action === 'TRANSITION' || action === 'CLOSE') {
+    return NextResponse.json(
+      { error: 'Primary vehicle state is source-controlled and cannot be changed manually from Vagnkort' },
+      { status: 403 },
+    );
+  }
+
   const regnr = cleanRegnr(body.regnr);
   if (!REGNR_RE.test(regnr)) {
     return NextResponse.json({ error: 'Invalid regnr' }, { status: 400 });
@@ -140,98 +116,6 @@ export async function POST(request: Request) {
   try {
     if (!(await vehicleExists(admin, regnr))) {
       return NextResponse.json({ error: 'Vehicle not found' }, { status: 404 });
-    }
-
-    if (action === 'START' || action === 'TRANSITION') {
-      const periodType = cleanPrimaryPeriodType(body.periodType);
-      if (!periodType) {
-        return NextResponse.json({ error: 'Invalid primary period type' }, { status: 400 });
-      }
-
-      const startedAt = parseTimestamp(body.startedAt, true);
-      if (!startedAt) {
-        return NextResponse.json({ error: 'Invalid start time' }, { status: 400 });
-      }
-
-      const reasonCode = cleanReasonCode(body.reasonCode);
-      const reasonText = cleanReasonText(body.reasonText);
-      if (periodType === 'DOWNTIME') {
-        if (!reasonCode || !DOWNTIME_REASONS.includes(reasonCode as DowntimeReason)) {
-          return NextResponse.json({ error: 'Downtime requires a valid reason' }, { status: 400 });
-        }
-        if (reasonCode === 'OTHER' && !reasonText) {
-          return NextResponse.json({ error: 'Other downtime requires a comment' }, { status: 400 });
-        }
-      }
-
-      const periodId = crypto.randomUUID();
-      const { data: period, error: periodError } = await admin.rpc('transition_vehicle_journey_state', {
-        p_period_id: periodId,
-        p_regnr: regnr,
-        p_period_type: periodType,
-        p_started_at: startedAt,
-        p_reason_code: reasonCode,
-        p_reason_text: reasonText,
-        p_source_system: 'VAGNKORT',
-        p_source_entity: 'vehicle_journey_periods',
-        p_source_record_id: periodId,
-        p_actor_id: verification.user.id,
-        p_actor_source: 'MANUELL',
-        p_actor_email: verification.user.email,
-        p_metadata: { createdVia: 'VAGNKORT' },
-      });
-
-      if (periodError) {
-        const message = rpcErrorMessage(periodError);
-        if (message.includes('already in requested state')) {
-          return NextResponse.json({ error: 'Vehicle is already in requested state' }, { status: 409 });
-        }
-        if (rpcErrorCode(periodError) === '22007') {
-          return NextResponse.json({ error: 'Transition time is before current state start' }, { status: 400 });
-        }
-        console.error('[vehicle-journey-periods] Atomic transition failed:', periodError);
-        return NextResponse.json({ error: 'Could not transition vehicle state' }, { status: 500 });
-      }
-
-      return NextResponse.json({ data: period }, { status: 201 });
-    }
-
-    if (action === 'CLOSE') {
-      const periodId = cleanUuid(body.periodId);
-      if (!periodId) {
-        return NextResponse.json({ error: 'Invalid period id' }, { status: 400 });
-      }
-
-      const endedAt = parseTimestamp(body.endedAt, true);
-      if (!endedAt) {
-        return NextResponse.json({ error: 'Invalid end time' }, { status: 400 });
-      }
-
-      const { data: period, error: periodError } = await admin.rpc('close_vehicle_journey_period', {
-        p_period_id: periodId,
-        p_regnr: regnr,
-        p_ended_at: endedAt,
-        p_actor_id: verification.user.id,
-        p_actor_email: verification.user.email,
-      });
-
-      if (periodError) {
-        const code = rpcErrorCode(periodError);
-        const message = rpcErrorMessage(periodError);
-        if (code === 'P0002' || message.includes('Period not found for vehicle')) {
-          return NextResponse.json({ error: 'Period not found for vehicle' }, { status: 404 });
-        }
-        if (message.includes('Period is already closed')) {
-          return NextResponse.json({ error: 'Period is already closed' }, { status: 409 });
-        }
-        if (code === '22007' || message.includes('End time cannot be before start time')) {
-          return NextResponse.json({ error: 'End time cannot be before start time' }, { status: 400 });
-        }
-        console.error('[vehicle-journey-periods] Atomic close failed:', periodError);
-        return NextResponse.json({ error: 'Could not close period' }, { status: 500 });
-      }
-
-      return NextResponse.json({ data: period });
     }
 
     if (action === 'START_ACTIVITY') {

--- a/app/vagnkort/journey-period-controls.tsx
+++ b/app/vagnkort/journey-period-controls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormEvent, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 type JourneyPeriod = {
   period_id: string;
@@ -18,158 +18,48 @@ type Props = {
   onChanged: () => void;
 };
 
-const PRIMARY_PERIOD_TYPES = [
-  ['AVAILABLE', 'Tillgänglig'],
-  ['RENTAL', 'Uthyrd'],
-  ['DOWNTIME', 'Stillestånd'],
-  ['PREPARATION', 'Förberedelse'],
-  ['SALU', 'SALU'],
-  ['OTHER', 'Övrigt huvudtillstånd'],
-] as const;
-
-const DOWNTIME_REASONS = [
-  ['DAMAGE', 'Skada'],
-  ['WORKSHOP', 'Verkstad'],
-  ['SERVICE', 'Service'],
-  ['WAITING_PARTS', 'Väntar reservdelar'],
-  ['MISSING_EQUIPMENT', 'Saknad utrustning'],
-  ['TRANSPORT', 'Transport'],
-  ['ADMINISTRATION', 'Administration'],
-  ['OTHER', 'Övrigt'],
-] as const;
-
-function localDateTimeValue(date = new Date()) {
-  const shifted = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
-  return shifted.toISOString().slice(0, 16);
+function stateLabel(periodType: string) {
+  switch (periodType) {
+    case 'AVAILABLE': return 'Tillgänglig';
+    case 'RENTAL': return 'Uthyrd';
+    case 'DOWNTIME': return 'Stillestånd';
+    case 'PREPARATION': return 'Förberedelse';
+    case 'SALU': return 'SALU';
+    default: return periodType;
+  }
 }
 
-export default function JourneyPeriodControls({ regnr, openPeriods, onChanged }: Props) {
-  const [periodType, setPeriodType] = useState('AVAILABLE');
-  const [startedAt, setStartedAt] = useState(localDateTimeValue);
-  const [reasonCode, setReasonCode] = useState('DAMAGE');
-  const [reasonText, setReasonText] = useState('');
-  const [busy, setBusy] = useState<string | null>(null);
-  const [message, setMessage] = useState('');
-
+export default function JourneyPeriodControls({ openPeriods }: Props) {
   const currentPrimary = useMemo(
     () => openPeriods.find((period) => period.ended_at === null) ?? null,
     [openPeriods],
   );
 
-  async function transitionPeriod(event: FormEvent) {
-    event.preventDefault();
-    setBusy('transition');
-    setMessage('');
-    try {
-      const response = await fetch('/api/vehicle-journey/periods', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'TRANSITION',
-          regnr,
-          periodType,
-          startedAt: new Date(startedAt).toISOString(),
-          reasonCode: periodType === 'DOWNTIME' ? reasonCode : null,
-          reasonText: periodType === 'DOWNTIME' ? reasonText.trim() || null : null,
-        }),
-      });
-      const body = await response.json() as { error?: string };
-      if (!response.ok) throw new Error(body.error || 'Kunde inte byta huvudtillstånd');
-      setMessage('Bilens huvudtillstånd är uppdaterat. Föregående period avslutades vid samma tidpunkt.');
-      setStartedAt(localDateTimeValue());
-      setReasonText('');
-      onChanged();
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Kunde inte byta huvudtillstånd.');
-    } finally {
-      setBusy(null);
-    }
-  }
-
-  async function closeCurrent(period: JourneyPeriod) {
-    setBusy(period.period_id);
-    setMessage('');
-    try {
-      const response = await fetch('/api/vehicle-journey/periods', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          action: 'CLOSE',
-          regnr,
-          periodId: period.period_id,
-          endedAt: new Date().toISOString(),
-        }),
-      });
-      const body = await response.json() as { error?: string };
-      if (!response.ok) throw new Error(body.error || 'Kunde inte avsluta huvudperioden');
-      setMessage('Huvudperioden är avslutad. Bilen saknar därefter fastställt huvudtillstånd tills nästa period startas.');
-      onChanged();
-    } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Kunde inte avsluta huvudperioden.');
-    } finally {
-      setBusy(null);
-    }
-  }
-
   return (
     <div style={{ display: 'grid', gap: '.9rem' }}>
       <div style={{ background: '#f6f6f6', borderRadius: 8, padding: '.65rem .75rem', fontSize: 13, color: '#555' }}>
-        En bil har ett huvudtillstånd åt gången. Verkstad, service, transport och väntetid är aktiviteter inom ett stillestånd och räknas inte som parallella huvudperioder.
+        Huvudtillståndet är verifierad verksamhetsdata och ändras av den källa som faktiskt vet. Vagnkortet visar läget men skapar eller avslutar inte huvudperioder manuellt.
       </div>
 
-      {currentPrimary && (
+      {currentPrimary ? (
         <div style={{ display: 'grid', gap: '.45rem' }}>
           <strong>Aktuellt huvudtillstånd</strong>
-          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '.75rem', alignItems: 'center', borderTop: '1px solid #eee', paddingTop: '.5rem' }}>
-            <div>
-              <div><strong>{currentPrimary.period_type}</strong></div>
-              <div style={{ fontSize: 13, color: '#666' }}>{new Date(currentPrimary.started_at).toLocaleString('sv-SE')}{currentPrimary.reason_text ? ` · ${currentPrimary.reason_text}` : currentPrimary.reason_code ? ` · ${currentPrimary.reason_code}` : ''}</div>
+          <div style={{ borderTop: '1px solid #eee', paddingTop: '.5rem' }}>
+            <div><strong>{stateLabel(currentPrimary.period_type)}</strong> <span style={{ color: '#777' }}>({currentPrimary.period_type})</span></div>
+            <div style={{ fontSize: 13, color: '#666', marginTop: '.2rem' }}>
+              Sedan {new Date(currentPrimary.started_at).toLocaleString('sv-SE')}
+              {currentPrimary.reason_text ? ` · ${currentPrimary.reason_text}` : currentPrimary.reason_code ? ` · ${currentPrimary.reason_code}` : ''}
             </div>
-            <button type="button" onClick={() => void closeCurrent(currentPrimary)} disabled={Boolean(busy)} style={{ border: 0, borderRadius: 8, background: '#111', color: '#fff', padding: '.55rem .75rem', fontWeight: 700 }}>
-              {busy === currentPrimary.period_id ? 'Avslutar…' : 'Avsluta utan nytt tillstånd'}
-            </button>
+          </div>
+        </div>
+      ) : (
+        <div>
+          <strong>Inget verifierat huvudtillstånd</strong>
+          <div style={{ fontSize: 13, color: '#666', marginTop: '.2rem' }}>
+            Incheckad gissar inte nästa läge. Nästa huvudtillstånd kommer från en verifierad källa.
           </div>
         </div>
       )}
-
-      <form onSubmit={transitionPeriod} style={{ display: 'grid', gap: '.65rem' }}>
-        <strong>{currentPrimary ? 'Byt huvudtillstånd' : 'Starta huvudtillstånd'}</strong>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '.6rem' }}>
-          <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
-            Tillstånd
-            <select value={periodType} onChange={(event) => setPeriodType(event.target.value)} disabled={Boolean(busy)} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
-              {PRIMARY_PERIOD_TYPES.map(([value, label]) => (
-                <option key={value} value={value} disabled={currentPrimary?.period_type === value}>{label}{currentPrimary?.period_type === value ? ' · pågår' : ''}</option>
-              ))}
-            </select>
-          </label>
-          <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
-            Tidpunkt för bytet
-            <input type="datetime-local" value={startedAt} onChange={(event) => setStartedAt(event.target.value)} disabled={Boolean(busy)} required style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
-          </label>
-        </div>
-
-        {periodType === 'DOWNTIME' && (
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '.6rem' }}>
-            <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
-              Huvudorsak
-              <select value={reasonCode} onChange={(event) => setReasonCode(event.target.value)} disabled={Boolean(busy)} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
-                {DOWNTIME_REASONS.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
-              </select>
-            </label>
-            <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
-              Kommentar {reasonCode === 'OTHER' ? '(krävs)' : '(valfri)'}
-              <input value={reasonText} onChange={(event) => setReasonText(event.target.value)} required={reasonCode === 'OTHER'} disabled={Boolean(busy)} placeholder="T.ex. skada, väntar delar eller administrativ spärr" style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
-            </label>
-          </div>
-        )}
-
-        <button type="submit" disabled={Boolean(busy) || currentPrimary?.period_type === periodType} style={{ justifySelf: 'start', border: 0, borderRadius: 8, background: '#111', color: '#fff', padding: '.65rem 1rem', fontWeight: 700 }}>
-          {busy === 'transition' ? 'Sparar…' : currentPrimary ? 'Byt tillstånd' : 'Starta tillstånd'}
-        </button>
-      </form>
-
-      {message && <div style={{ fontSize: 13, color: message.includes('Kunde') || message.includes('Invalid') || message.includes('already') ? '#a00' : '#176b2c' }}>{message}</div>}
     </div>
   );
 }

--- a/tests/vagnkort-ui-contract.test.ts
+++ b/tests/vagnkort-ui-contract.test.ts
@@ -38,7 +38,7 @@ test('Vagnkort reads the authenticated vehicle journey API', () => {
   matches(client, [/fetch\(`\/api\/vehicle-journey\?reg=/, /Bilens digitala pärm/, /Utrustning – Nybil mot nu/, /Tid i resan/, /Dokument/, /Tidslinje/]);
 });
 
-test('Vagnkort surfaces lifecycle metrics and refreshes them with period changes', () => {
+test('Vagnkort surfaces lifecycle metrics and refreshes them with journey changes', () => {
   matches(client, [/<JourneyMetricsPanel regnr=\{data\.regnr\} refreshNonce=\{refreshNonce\} \/>/]);
   matches(metricsPanel, [/\/api\/vehicle-journey\/metrics\?reg=/, /Resans nyckeltal/, /Nyttjandegrad/, /Nybil → första uthyrning/, /Sista retur → SALU/, /Stillestånd per huvudorsak/, /Aktiviteter inom stillestånd/, /Huvudperioder överlappar/]);
   matches(metricsApi, [/verifyApiUser\(request\)/, /computeJourneyLifecycleMetrics/, /vehicle_journey_activity_periods/]);
@@ -78,24 +78,20 @@ test('document server API stays authenticated, private and appends a journey eve
   matches(documentApi, [/verifyApiUser\(request\)/, /createSignedUrl/, /300/]);
 });
 
-test('Vagnkort treats period controls as one primary vehicle state at a time', () => {
+test('Vagnkort primary state UI is read-only and reflects source-controlled truth', () => {
   matches(client, [/<JourneyPeriodControls regnr=/]);
-  matches(periodControls, [/Tillgänglig/, /Uthyrd/, /Stillestånd/, /Förberedelse/, /ett huvudtillstånd åt gången/, /aktiviteter inom ett stillestånd/, /action:\s*'TRANSITION'/, /action:\s*'CLOSE'/, /\/api\/vehicle-journey\/periods/]);
-
-  const primaryBlock = periodControls.match(/const PRIMARY_PERIOD_TYPES = \[([\s\S]*?)\] as const;/)?.[1] ?? '';
-  assert.match(primaryBlock, /AVAILABLE/);
-  assert.match(primaryBlock, /RENTAL/);
-  assert.match(primaryBlock, /DOWNTIME/);
-  assert.doesNotMatch(primaryBlock, /WORKSHOP/);
-  assert.doesNotMatch(primaryBlock, /TRANSPORT/);
-
-  const reasonBlock = periodControls.match(/const DOWNTIME_REASONS = \[([\s\S]*?)\] as const;/)?.[1] ?? '';
-  assert.match(reasonBlock, /WORKSHOP/);
-  assert.match(reasonBlock, /TRANSPORT/);
+  matches(periodControls, [/Huvudtillståndet är verifierad verksamhetsdata/, /Vagnkortet visar läget men skapar eller avslutar inte huvudperioder manuellt/, /Aktuellt huvudtillstånd/, /Inget verifierat huvudtillstånd/, /Incheckad gissar inte nästa läge/]);
+  assert.doesNotMatch(periodControls, /fetch\(/);
+  assert.doesNotMatch(periodControls, /action:\s*'TRANSITION'/);
+  assert.doesNotMatch(periodControls, /action:\s*'CLOSE'/);
+  assert.doesNotMatch(periodControls, /<form/);
+  assert.doesNotMatch(periodControls, /<button/);
 });
 
-test('journey period API validates primary states and activity periods through atomic RPCs', () => {
-  matches(periodApi, [/verifyApiUser\(request\)/, /vehicleExists/, /DOWNTIME_REASONS/, /Downtime requires a valid reason/, /rpc\('transition_vehicle_journey_state'/, /rpc\('close_vehicle_journey_period'/, /rpc\('start_vehicle_journey_activity_period'/, /rpc\('close_vehicle_journey_activity_period'/]);
+test('journey period API blocks manual primary writes but retains authenticated downtime activities', () => {
+  matches(periodApi, [/verifyApiUser\(request\)/, /Primary vehicle state is source-controlled/, /action === 'START'/, /action === 'TRANSITION'/, /action === 'CLOSE'/, /rpc\('start_vehicle_journey_activity_period'/, /rpc\('close_vehicle_journey_activity_period'/]);
+  assert.doesNotMatch(periodApi, /rpc\('transition_vehicle_journey_state'/);
+  assert.doesNotMatch(periodApi, /rpc\('close_vehicle_journey_period'/);
   matches(periodMigration, [/'PERIOD_STARTED'/, /'PERIOD_ENDED'/, /insert into public\.vehicle_journey_periods/i, /insert into public\.vehicle_journey_events/i, /p_actor_id/]);
   matches(timeModelMigration, [/vehicle_journey_periods_one_open_state_uidx/, /vehicle_journey_activity_periods/, /ACTIVITY_PERIOD_STARTED/, /ACTIVITY_PERIOD_ENDED/]);
 });

--- a/tests/vehicle-journey-period-atomicity.test.ts
+++ b/tests/vehicle-journey-period-atomicity.test.ts
@@ -18,9 +18,11 @@ const splitMigration = readFileSync(
   'utf8',
 );
 
-test('journey period API delegates primary transitions and activity periods to database RPCs', () => {
-  assert.match(periodApi, /rpc\('transition_vehicle_journey_state'/);
-  assert.match(periodApi, /rpc\('close_vehicle_journey_period'/);
+test('Vagnkort period API blocks manual primary state writes and keeps downtime activities', () => {
+  assert.match(periodApi, /action === 'START' \|\| action === 'TRANSITION' \|\| action === 'CLOSE'/);
+  assert.match(periodApi, /Primary vehicle state is source-controlled and cannot be changed manually from Vagnkort/);
+  assert.doesNotMatch(periodApi, /rpc\('transition_vehicle_journey_state'/);
+  assert.doesNotMatch(periodApi, /rpc\('close_vehicle_journey_period'/);
   assert.match(periodApi, /rpc\('start_vehicle_journey_activity_period'/);
   assert.match(periodApi, /rpc\('close_vehicle_journey_activity_period'/);
   assert.doesNotMatch(periodApi, /from\('vehicle_journey_events'\)\.insert/);


### PR DESCRIPTION
## Syfte
Stäng den manuella huvudtillståndsvägen i Vagnkortet innan RENTAL-källan kopplas in.

## Verksamhetskontrakt
- Vagnkortet är en läsvy över bilens resa, inte en källa för operativa huvudtillstånd.
- AVAILABLE / RENTAL / DOWNTIME / PREPARATION / SALU ska etableras av den källa som faktiskt vet.
- RENTAL ska senare ägas av avtalskällan: UtDt startar och InDt avslutar.

## Ändring
- gör huvudtillståndssektionen i Vagnkortet read-only
- tar bort manuella Starta/Byt/Avsluta-kontroller
- blockerar API-actions START, TRANSITION och CLOSE med 403
- behåller START_ACTIVITY/CLOSE_ACTIVITY för dokumenterade aktiviteter inom DOWNTIME
- uppdaterar regression guards

## Production-baseline före ändring
Read-only kontroll visade:
- 0 RENTAL-perioder
- 0 RENTAL-perioder från VAGNKORT
- 0 öppna RENTAL-perioder
- 0 vehicle_journey-perioder från VAGNKORT
- 0 period_write_through_failures
- 0 fordon med flera öppna huvudtillstånd

Ingen databas- eller Production-migration ingår i denna PR.