### PR TITLE
Create shared rental source foundation

### DIFF
--- a/docs/RENTAL_SOURCE_CONTRACT_V1.md
+++ b/docs/RENTAL_SOURCE_CONTRACT_V1.md
@@ -1,0 +1,74 @@
+# RENTAL source contract v1
+
+## Purpose
+
+INCHECKAD shall ingest one rich row-level agreement/rental source and preserve the complete source row once. Layer 1, the future economic layer (Kistan), and later analysis may then read separate, explicit projections from the same source truth.
+
+There shall not be one report for Layer 1 and another report for Kistan.
+
+Source system -> complete common report -> RAW -> bounded projections.
+
+## Source row grain
+
+The machine report must contain one semantic agreement/rental row per source record. Human presentation rows such as totals, subtotals, headings and footers are not source records and must not be delivered as data rows.
+
+F / AvtalsNr is the stable `source_record_id` for the agreement/rental row.
+
+The complete delivered row, including operational and economic columns, is stored in `rental_source_rows_raw.raw_payload`. No column is discarded merely because Layer 1 does not currently use it.
+
+## Layer 1 projection: A-I only
+
+Layer 1 may interpret only these source fields:
+
+| Column | Business field | Layer 1 meaning |
+| --- | --- | --- |
+| A | Avsl. Månad | Agreement close month fact |
+| B | Stn | Station number |
+| C | Ut Stn | Depot / out station |
+| D | Avsl. År | Agreement close year fact |
+| E | Avsl. Datum | Agreement is administratively/economically closed |
+| F | AvtalsNr | Stable source record id |
+| G | UtDt | RENTAL starts |
+| H | InDt | Vehicle returned and RENTAL ends |
+| I | RegNr | Vehicle identity in this source |
+
+B and C are machine strings, not numbers, so source values with leading zeroes are preserved.
+
+## RENTAL semantics
+
+The source facts mean exactly:
+
+- G exists, H empty, E empty -> the vehicle is out on an active RENTAL.
+- G + H exist, E empty -> the vehicle has returned; the agreement is not yet closed.
+- G + H + E exist -> the vehicle has returned and the agreement is closed.
+
+**E never ends RENTAL. H ends RENTAL.**
+
+After H, INCHECKAD must not infer `AVAILABLE`. If no other authoritative source establishes a new primary operational state, the operational read model must be `UNKNOWN`.
+
+## Time precision
+
+G and H must carry the source system's real time precision. If the source system knows date and time, the machine report must provide both. INCHECKAD must not invent `00:00` or any other time to turn a date-only source value into a timestamp.
+
+If the source does not know a required time, INCHECKAD does not know it either and the row must be handled as incomplete rather than silently fabricated.
+
+## RAW versus operational projection
+
+`rental_source_rows_raw` stores the full source row as traceable evidence.
+
+`rental_operational_facts` stores only the typed A-I projection used by Layer 1. Its `operational_hash` covers only the Layer 1 projection. A later change to revenue, damage cost, margin or another economic field in RAW must therefore not create an operational state change by itself.
+
+Kistan is not implemented by this contract. When Kistan is built, it shall project its economic facts from the same RAW row instead of creating another rental source integration.
+
+## Scope of foundation v1
+
+This foundation creates source storage and the canonical A-I shape only. It deliberately does not:
+
+- parse a particular Excel/CSV delivery format,
+- create or close a `RENTAL` journey period,
+- infer `AVAILABLE`,
+- calculate economic effects,
+- implement Kistan,
+- overwrite vehicle journey history.
+
+The next stage must add validated, idempotent ingestion before any RENTAL write-through is enabled.

--- a/migrations/20260823012529_create_rental_source_foundation.sql
+++ b/migrations/20260823012529_create_rental_source_foundation.sql
@@ -1,0 +1,100 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- One rich agreement/rental source is ingested once. The full source row is
+-- preserved in RAW so Layer 1 and the future economic layer can project the
+-- same source truth without creating parallel imports.
+create table public.rental_source_import_batches (
+  batch_id uuid primary key default gen_random_uuid(),
+  source_system text not null check (length(trim(source_system)) > 0),
+  source_report_name text not null check (length(trim(source_report_name)) > 0),
+  source_generated_at timestamptz,
+  source_file_name text,
+  source_file_hash text,
+  row_count integer check (row_count is null or row_count >= 0),
+  metadata jsonb not null default '{}'::jsonb check (jsonb_typeof(metadata) = 'object'),
+  created_at timestamptz not null default now()
+);
+
+create unique index rental_source_import_batches_file_uidx
+  on public.rental_source_import_batches (source_system, source_file_hash)
+  where source_file_hash is not null;
+
+create table public.rental_source_rows_raw (
+  raw_row_id uuid primary key default gen_random_uuid(),
+  batch_id uuid not null references public.rental_source_import_batches(batch_id) on delete restrict,
+  source_system text not null check (length(trim(source_system)) > 0),
+  source_record_id text not null check (length(trim(source_record_id)) > 0),
+  source_row_number integer check (source_row_number is null or source_row_number > 0),
+  raw_payload jsonb not null check (jsonb_typeof(raw_payload) = 'object'),
+  raw_payload_hash text,
+  created_at timestamptz not null default now()
+);
+
+create unique index rental_source_rows_raw_batch_row_uidx
+  on public.rental_source_rows_raw (batch_id, source_row_number)
+  where source_row_number is not null;
+
+create index rental_source_rows_raw_source_idx
+  on public.rental_source_rows_raw (source_system, source_record_id, created_at desc);
+
+-- Canonical operational projection for Layer 1 only.
+-- A-I are preserved as typed fields while the entire source row remains in RAW.
+create table public.rental_operational_facts (
+  rental_fact_id uuid primary key default gen_random_uuid(),
+  source_system text not null check (length(trim(source_system)) > 0),
+  source_record_id text not null check (length(trim(source_record_id)) > 0),
+  source_raw_row_id uuid not null references public.rental_source_rows_raw(raw_row_id) on delete restrict,
+
+  -- A: Avsl. Månad
+  close_month text,
+  -- B: Stn. Text is deliberate so leading zeroes are never lost.
+  station_no text,
+  -- C: Ut Stn / depå. Text is deliberate so leading zeroes are never lost.
+  out_station text,
+  -- D: Avsl. År
+  close_year integer,
+  -- E: Avsl. Datum. This is contract close, never RENTAL end.
+  closed_date date,
+  -- F: AvtalsNr / stable source_record_id
+  agreement_no text not null check (length(trim(agreement_no)) > 0),
+  -- G: UtDt / RENTAL start fact
+  out_at timestamptz not null,
+  -- H: InDt / RENTAL end fact when present
+  in_at timestamptz,
+  -- I: RegNr
+  regnr text not null check (length(trim(regnr)) > 0),
+
+  -- Hash only the Layer 1 projection. Economic changes in RAW must not create
+  -- an operational state change merely because the source row was updated.
+  operational_hash text not null check (length(trim(operational_hash)) > 0),
+  first_seen_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  unique (source_system, source_record_id),
+  check (source_record_id = agreement_no),
+  check (in_at is null or in_at >= out_at)
+);
+
+create index rental_operational_facts_regnr_time_idx
+  on public.rental_operational_facts (regnr, out_at desc);
+
+alter table public.rental_source_import_batches enable row level security;
+alter table public.rental_source_rows_raw enable row level security;
+alter table public.rental_operational_facts enable row level security;
+
+revoke all on public.rental_source_import_batches from public, anon, authenticated;
+revoke all on public.rental_source_rows_raw from public, anon, authenticated;
+revoke all on public.rental_operational_facts from public, anon, authenticated;
+
+-- Batches and RAW are append-only source evidence. Canonical facts may be
+-- updated by a later server-side ingestion path as the same agreement gains H/E.
+grant select, insert on public.rental_source_import_batches to service_role;
+grant select, insert on public.rental_source_rows_raw to service_role;
+grant select, insert, update on public.rental_operational_facts to service_role;
+
+commit;

--- a/tests/rental-source-foundation.test.ts
+++ b/tests/rental-source-foundation.test.ts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (path: string) => readFileSync(join(process.cwd(), path), 'utf8');
+const migration = read('migrations/20260823012529_create_rental_source_foundation.sql');
+const contract = read('docs/RENTAL_SOURCE_CONTRACT_V1.md');
+
+test('rental source foundation stores one rich source once and exposes a bounded A-I projection', () => {
+  assert.match(migration, /create table public\.rental_source_import_batches/i);
+  assert.match(migration, /create table public\.rental_source_rows_raw/i);
+  assert.match(migration, /raw_payload jsonb not null/i);
+  assert.match(migration, /create table public\.rental_operational_facts/i);
+
+  for (const column of [
+    'close_month text',
+    'station_no text',
+    'out_station text',
+    'close_year integer',
+    'closed_date date',
+    'agreement_no text not null',
+    'out_at timestamptz not null',
+    'in_at timestamptz',
+    'regnr text not null',
+  ]) {
+    assert.match(migration, new RegExp(column.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
+  }
+});
+
+test('agreement identity, timestamp ordering and operational dedup are explicit', () => {
+  assert.match(migration, /unique \(source_system, source_record_id\)/i);
+  assert.match(migration, /check \(source_record_id = agreement_no\)/i);
+  assert.match(migration, /check \(in_at is null or in_at >= out_at\)/i);
+  assert.match(migration, /operational_hash text not null/i);
+  assert.match(contract, /operational_hash.*only the Layer 1 projection/is);
+});
+
+test('source evidence is server-only and full RAW is preserved for later bounded projections', () => {
+  for (const table of [
+    'rental_source_import_batches',
+    'rental_source_rows_raw',
+    'rental_operational_facts',
+  ]) {
+    assert.match(migration, new RegExp(`alter table public\\.${table} enable row level security`, 'i'));
+    assert.match(migration, new RegExp(`revoke all on public\\.${table} from public, anon, authenticated`, 'i'));
+  }
+  assert.match(migration, /grant select, insert on public\.rental_source_rows_raw to service_role/i);
+  assert.match(contract, /complete delivered row.*stored in `rental_source_rows_raw\.raw_payload`/is);
+  assert.match(contract, /Kistan.*same RAW row/is);
+});
+
+test('Layer 1 contract keeps B and C as text and never uses E as RENTAL end', () => {
+  assert.match(contract, /B and C are machine strings, not numbers/i);
+  assert.match(contract, /E never ends RENTAL\. H ends RENTAL\./i);
+  assert.match(contract, /G exists, H empty, E empty.*active RENTAL/is);
+  assert.match(contract, /G \+ H exist, E empty.*returned/is);
+  assert.match(contract, /G \+ H \+ E exist.*returned and the agreement is closed/is);
+});
+
+test('after H the source contract forbids AVAILABLE inference and invented timestamps', () => {
+  assert.match(contract, /After H, INCHECKAD must not infer `AVAILABLE`/i);
+  assert.match(contract, /operational read model must be `UNKNOWN`/i);
+  assert.match(contract, /must not invent `00:00`/i);
+});
+
+test('foundation has no vehicle journey or Kistan write-through', () => {
+  assert.doesNotMatch(migration, /insert into public\.vehicle_journey_periods/i);
+  assert.doesNotMatch(migration, /update public\.vehicle_journey_periods/i);
+  assert.doesNotMatch(migration, /insert into public\.vehicle_journey_events/i);
+  assert.doesNotMatch(migration, /kistan/i);
+  assert.match(contract, /does not:[\s\S]*create or close a `RENTAL` journey period/i);
+  assert.match(contract, /does not:[\s\S]*implement Kistan/i);
+});
+
+test('machine report contract excludes human totals and footers', () => {
+  assert.match(contract, /totals, subtotals, headings and footers are not source records/i);
+});


### PR DESCRIPTION
## Syfte
Skapa datagrunden för den gemensamma rika hyres-/avtalskällan innan någon RENTAL write-through aktiveras.

## Låst arkitektur
- en komplett källa
- en ingestion
- full källrad bevaras i RAW
- Lager 1 läser endast A–I
- Kistan ska senare läsa ekonomi från samma RAW-rad

## Nya objekt
1. `rental_source_import_batches` – spårbar import/snapshot
2. `rental_source_rows_raw` – full oförändrad källrad som JSONB
3. `rental_operational_facts` – typad A–I-projektion för Lager 1

## A–I
A Avsl. Månad
B Stn (text)
C Ut Stn / depå (text)
D Avsl. År
E Avsl. Datum
F AvtalsNr / stable source_record_id
G UtDt
H InDt
I RegNr

## Semantik
- G startar RENTAL i nästa steg
- H avslutar RENTAL i nästa steg
- E avslutar aldrig RENTAL
- efter H infereras aldrig AVAILABLE
- full source time precision krävs; ingen syntetisk 00:00
- economic-only förändringar får inte förändra Lager 1

## Medvetet utanför denna PR
- ingen Excel/CSV-parser
- ingen journey-write
- ingen RENTAL-period
- ingen AVAILABLE-inferens
- ingen Kista-logik

Production-kontroll före PR visade inga befintliga tabeller med rental/avtal/agreement-namn i public.