### PR TITLE
Index RENTAL canonical RAW foreign key

### DIFF
--- a/migrations/20260823114500_index_rental_operational_source_raw_fk.sql
+++ b/migrations/20260823114500_index_rental_operational_source_raw_fk.sql
@@ -1,0 +1,12 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Cover the FK used when canonical Layer 1 facts point back to immutable RAW
+-- source evidence. This removes the Supabase unindexed-foreign-key advisor
+-- finding without changing source or journey semantics.
+create index if not exists rental_operational_facts_source_raw_row_idx
+  on public.rental_operational_facts (source_raw_row_id);
+
+commit;

--- a/tests/rental-source-raw-fk-index.test.ts
+++ b/tests/rental-source-raw-fk-index.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/20260823114500_index_rental_operational_source_raw_fk.sql'),
+  'utf8',
+);
+
+test('canonical RENTAL fact RAW foreign key has a covering index', () => {
+  assert.match(migration, /create index if not exists rental_operational_facts_source_raw_row_idx/i);
+  assert.match(migration, /on public\.rental_operational_facts \(source_raw_row_id\)/i);
+  assert.doesNotMatch(migration, /alter table|drop table|drop column|update public|delete from public/i);
+});


### PR DESCRIPTION
## Syfte
Stänga Supabase performance-advisorns enda nya RENTAL-fynd efter source-foundationen.

## Ändring
- lägger ett täckande index på `rental_operational_facts(source_raw_row_id)`
- ingen dataändring
- ingen affärssemantik
- ingen journey-write

## Verifiering
Regressionstest låser att migrationen bara adderar indexet och inte ändrar tabell/data.