### PR TITLE
Add RENTAL machine report importer

### DIFF
--- a/app/api/rental-source/import/route.ts
+++ b/app/api/rental-source/import/route.ts
@@ -1,0 +1,214 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+import { parseRentalSourceReport, type ParsedRentalSourceRow } from '@/lib/rental-source-report';
+
+export const runtime = 'nodejs';
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const CHUNK_SIZE = 250;
+const SOURCE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+function getImportAllowedEmails(): Set<string> {
+  return new Set(
+    (process.env.RENTAL_IMPORT_ALLOWED_EMAILS ?? '')
+      .split(',')
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function formString(form: FormData, name: string): string | null {
+  const value = form.get(name);
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized === '' ? null : normalized;
+}
+
+function validateGeneratedAt(value: string | null): string | null {
+  if (value === null) return null;
+  if (!SOURCE_TIMESTAMP_RE.test(value) || Number.isNaN(Date.parse(value))) {
+    throw new Error('sourceGeneratedAt måste vara ISO 8601 med tid och tidszon');
+  }
+  return value;
+}
+
+function toRpcRow(row: ParsedRentalSourceRow) {
+  return {
+    sourceRowNumber: row.sourceRowNumber,
+    raw: row.raw,
+    closeMonth: row.operational.closeMonth,
+    stationNo: row.operational.stationNo,
+    outStation: row.operational.outStation,
+    closeYear: row.operational.closeYear,
+    closedDate: row.operational.closedDate,
+    agreementNo: row.operational.agreementNo,
+    outAt: row.operational.outAt,
+    inAt: row.operational.inAt,
+    regnr: row.operational.regnr,
+  };
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const allowedEmails = getImportAllowedEmails();
+  if (allowedEmails.size === 0) {
+    console.error('[rental-source-import] RENTAL_IMPORT_ALLOWED_EMAILS is not configured');
+    return NextResponse.json({ error: 'Rental import is not configured' }, { status: 503 });
+  }
+  if (!allowedEmails.has(verification.user.email)) {
+    return NextResponse.json({ error: 'Rental import access denied' }, { status: 403 });
+  }
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return NextResponse.json({ error: 'Expected multipart/form-data' }, { status: 400 });
+  }
+
+  const file = form.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'file is required' }, { status: 400 });
+  }
+  if (file.size === 0) {
+    return NextResponse.json({ error: 'file is empty' }, { status: 400 });
+  }
+  if (file.size > MAX_FILE_BYTES) {
+    return NextResponse.json({ error: 'file exceeds 10 MiB import limit' }, { status: 413 });
+  }
+
+  const sourceSystem = formString(form, 'sourceSystem');
+  const reportName = formString(form, 'reportName');
+  if (!sourceSystem || !reportName) {
+    return NextResponse.json({ error: 'sourceSystem and reportName are required' }, { status: 400 });
+  }
+
+  let sourceGeneratedAt: string | null;
+  try {
+    sourceGeneratedAt = validateGeneratedAt(formString(form, 'sourceGeneratedAt'));
+  } catch (error) {
+    return NextResponse.json({ error: error instanceof Error ? error.message : 'Invalid sourceGeneratedAt' }, { status: 400 });
+  }
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  let parsed;
+  try {
+    parsed = parseRentalSourceReport(bytes);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Invalid rental source report' },
+      { status: 422 },
+    );
+  }
+
+  let admin;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[rental-source-import] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Rental import unavailable' }, { status: 503 });
+  }
+
+  const { data: batchId, error: batchError } = await admin.rpc('create_rental_source_import_batch', {
+    p_source_system: sourceSystem,
+    p_source_report_name: reportName,
+    p_source_generated_at: sourceGeneratedAt,
+    p_source_file_name: file.name || null,
+    p_source_file_hash: parsed.sha256,
+    p_row_count: parsed.rows.length,
+    p_metadata: {
+      format: parsed.delimiter === '\t' ? 'TSV' : 'CSV',
+      delimiter: parsed.delimiter,
+      headerCount: parsed.headers.length,
+      headers: parsed.headers,
+      importedBy: verification.user.id,
+    },
+  });
+
+  if (batchError || !batchId) {
+    console.error('[rental-source-import] Failed to create batch:', batchError);
+    return NextResponse.json({ error: 'Failed to create rental import batch' }, { status: 500 });
+  }
+
+  let seen = 0;
+  let accepted = 0;
+  let conflicts = 0;
+  const conflictCodes: Record<string, number> = {};
+
+  for (let offset = 0; offset < parsed.rows.length; offset += CHUNK_SIZE) {
+    const chunk = parsed.rows.slice(offset, offset + CHUNK_SIZE).map(toRpcRow);
+    const { data, error } = await admin.rpc('ingest_rental_source_rows', {
+      p_batch_id: batchId,
+      p_source_system: sourceSystem,
+      p_rows: chunk,
+    });
+
+    if (error || !data || typeof data !== 'object') {
+      console.error('[rental-source-import] Chunk ingestion failed:', { batchId, offset, error });
+      return NextResponse.json(
+        {
+          error: 'Rental import stopped during ingestion; replay the same file to continue safely',
+          batchId,
+          fileHash: parsed.sha256,
+          completedRows: seen,
+        },
+        { status: 500 },
+      );
+    }
+
+    const summary = data as {
+      seen?: number;
+      accepted?: number;
+      conflicts?: number;
+      conflictCodes?: Record<string, number>;
+    };
+    seen += summary.seen ?? 0;
+    accepted += summary.accepted ?? 0;
+    conflicts += summary.conflicts ?? 0;
+    for (const [code, count] of Object.entries(summary.conflictCodes ?? {})) {
+      conflictCodes[code] = (conflictCodes[code] ?? 0) + Number(count || 0);
+    }
+  }
+
+  const response = {
+    batchId,
+    fileHash: parsed.sha256,
+    fileName: file.name,
+    sourceSystem,
+    reportName,
+    sourceGeneratedAt,
+    rows: parsed.rows.length,
+    seen,
+    accepted,
+    conflicts,
+    conflictCodes,
+    extraColumns: parsed.headers.filter(
+      (header) => ![
+        'Avsl. Månad','Stn','Ut Stn','Avsl. År','Avsl. Datum','AvtalsNr','UtDt','InDt','RegNr',
+        'Fordonstyp','Debiterad Klass','Uthyrd Klass','Avtalstyp','Prislista','Företagsnamn','Hyror',
+        'S:a Intäkt','S:a Hyra','S:a Dagar','Snitt Intäkt','Snitt Hyra','Driv medel','S-Skydd Halv',
+        'S-Skydd Hel','Skade kostnad','Tillval','Avgifter','Väg o Miljö','Tillbeh.','Bildeb','Bildeb/ Hyra',
+        'Marg. Hyra 3110','Marg./ Dag 3110',
+      ].includes(header),
+    ),
+  };
+
+  if (conflicts > 0) {
+    return NextResponse.json({ ...response, status: 'SOURCE_CONFLICTS' }, { status: 409 });
+  }
+  return NextResponse.json({ ...response, status: 'IMPORTED' });
+}

--- a/app/api/rental-source/import/route.ts
+++ b/app/api/rental-source/import/route.ts
@@ -1,13 +1,18 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { verifyApiUser } from '@/lib/server-auth';
-import { parseRentalSourceReport, type ParsedRentalSourceRow } from '@/lib/rental-source-report';
+import {
+  RENTAL_BASELINE_HEADERS,
+  parseRentalSourceReport,
+  type ParsedRentalSourceRow,
+} from '@/lib/rental-source-report';
 
 export const runtime = 'nodejs';
 
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const CHUNK_SIZE = 250;
 const SOURCE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+const BASELINE_HEADER_SET = new Set<string>(RENTAL_BASELINE_HEADERS);
 
 function createAdminClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -196,15 +201,7 @@ export async function POST(request: Request) {
     accepted,
     conflicts,
     conflictCodes,
-    extraColumns: parsed.headers.filter(
-      (header) => ![
-        'Avsl. Månad','Stn','Ut Stn','Avsl. År','Avsl. Datum','AvtalsNr','UtDt','InDt','RegNr',
-        'Fordonstyp','Debiterad Klass','Uthyrd Klass','Avtalstyp','Prislista','Företagsnamn','Hyror',
-        'S:a Intäkt','S:a Hyra','S:a Dagar','Snitt Intäkt','Snitt Hyra','Driv medel','S-Skydd Halv',
-        'S-Skydd Hel','Skade kostnad','Tillval','Avgifter','Väg o Miljö','Tillbeh.','Bildeb','Bildeb/ Hyra',
-        'Marg. Hyra 3110','Marg./ Dag 3110',
-      ].includes(header),
-    ),
+    extraColumns: parsed.headers.filter((header) => !BASELINE_HEADER_SET.has(header)),
   };
 
   if (conflicts > 0) {

--- a/lib/rental-source-report.ts
+++ b/lib/rental-source-report.ts
@@ -1,0 +1,260 @@
+import { createHash } from 'node:crypto';
+
+export const RENTAL_BASELINE_HEADERS = [
+  'Avsl. Månad',
+  'Stn',
+  'Ut Stn',
+  'Avsl. År',
+  'Avsl. Datum',
+  'AvtalsNr',
+  'UtDt',
+  'InDt',
+  'RegNr',
+  'Fordonstyp',
+  'Debiterad Klass',
+  'Uthyrd Klass',
+  'Avtalstyp',
+  'Prislista',
+  'Företagsnamn',
+  'Hyror',
+  'S:a Intäkt',
+  'S:a Hyra',
+  'S:a Dagar',
+  'Snitt Intäkt',
+  'Snitt Hyra',
+  'Driv medel',
+  'S-Skydd Halv',
+  'S-Skydd Hel',
+  'Skade kostnad',
+  'Tillval',
+  'Avgifter',
+  'Väg o Miljö',
+  'Tillbeh.',
+  'Bildeb',
+  'Bildeb/ Hyra',
+  'Marg. Hyra 3110',
+  'Marg./ Dag 3110',
+] as const;
+
+export type RentalSourceRow = Record<string, string | null>;
+
+export type RentalOperationalProjection = {
+  closeMonth: string | null;
+  stationNo: string | null;
+  outStation: string | null;
+  closeYear: number | null;
+  closedDate: string | null;
+  agreementNo: string;
+  outAt: string;
+  inAt: string | null;
+  regnr: string;
+};
+
+export type ParsedRentalSourceRow = {
+  sourceRowNumber: number;
+  raw: RentalSourceRow;
+  operational: RentalOperationalProjection;
+};
+
+export type ParsedRentalSourceReport = {
+  delimiter: ',' | ';' | '\t';
+  headers: string[];
+  rows: ParsedRentalSourceRow[];
+  sha256: string;
+};
+
+const REGNR_RE = /^[A-Z]{3}[0-9]{2}[0-9A-Z]$/;
+const ISO_TIMESTAMP_WITH_TIMEZONE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function trimOrNull(value: string | undefined): string | null {
+  const normalized = value?.trim() ?? '';
+  return normalized === '' ? null : normalized;
+}
+
+function normalizeRegnr(value: string): string {
+  return value.toUpperCase().replace(/\s+/g, '');
+}
+
+function assertSourceTimestamp(value: string, field: 'UtDt' | 'InDt', rowNumber: number): string {
+  if (!ISO_TIMESTAMP_WITH_TIMEZONE_RE.test(value) || Number.isNaN(Date.parse(value))) {
+    throw new Error(
+      `Rad ${rowNumber}: ${field} måste vara ISO 8601 med verklig tid och tidszon, t.ex. 2026-08-23T10:15:00+02:00`,
+    );
+  }
+  return value;
+}
+
+function parseCloseYear(value: string | null, rowNumber: number): number | null {
+  if (value === null) return null;
+  if (!/^\d{4}$/.test(value)) {
+    throw new Error(`Rad ${rowNumber}: Avsl. År måste vara fyrsiffrigt år eller tomt`);
+  }
+  return Number(value);
+}
+
+function parseClosedDate(value: string | null, rowNumber: number): string | null {
+  if (value === null) return null;
+  if (ISO_DATE_RE.test(value)) return value;
+  if (ISO_TIMESTAMP_WITH_TIMEZONE_RE.test(value) && !Number.isNaN(Date.parse(value))) {
+    return value.slice(0, 10);
+  }
+  throw new Error(`Rad ${rowNumber}: Avsl. Datum måste vara ISO-datum eller ISO-timestamp med tidszon`);
+}
+
+function detectDelimiter(text: string): ',' | ';' | '\t' {
+  const firstRecordEnd = (() => {
+    let quoted = false;
+    for (let i = 0; i < text.length; i += 1) {
+      const char = text[i];
+      if (char === '"') {
+        if (quoted && text[i + 1] === '"') {
+          i += 1;
+          continue;
+        }
+        quoted = !quoted;
+      } else if (!quoted && (char === '\n' || char === '\r')) {
+        return i;
+      }
+    }
+    return text.length;
+  })();
+
+  const header = text.slice(0, firstRecordEnd);
+  const candidates: Array<[',' | ';' | '\t', number]> = [
+    [',', header.split(',').length],
+    [';', header.split(';').length],
+    ['\t', header.split('\t').length],
+  ];
+  candidates.sort((a, b) => b[1] - a[1]);
+  if (candidates[0][1] < 2) {
+    throw new Error('Maskinrapporten saknar ett tydligt CSV/TSV-avgränsningstecken');
+  }
+  return candidates[0][0];
+}
+
+export function parseDelimited(text: string, delimiter: ',' | ';' | '\t'): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let quoted = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+    if (quoted) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 1;
+        } else {
+          quoted = false;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === '"' && field === '') {
+      quoted = true;
+    } else if (char === delimiter) {
+      row.push(field);
+      field = '';
+    } else if (char === '\n' || char === '\r') {
+      if (char === '\r' && text[i + 1] === '\n') i += 1;
+      row.push(field);
+      field = '';
+      if (row.some((value) => value.trim() !== '')) rows.push(row);
+      row = [];
+    } else {
+      field += char;
+    }
+  }
+
+  if (quoted) throw new Error('Maskinrapporten innehåller ett oavslutat citerat fält');
+  row.push(field);
+  if (row.some((value) => value.trim() !== '')) rows.push(row);
+  return rows;
+}
+
+export function parseRentalSourceReport(input: Uint8Array): ParsedRentalSourceReport {
+  let text: string;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(input);
+  } catch {
+    throw new Error('Maskinrapporten måste vara UTF-8');
+  }
+  text = text.replace(/^\uFEFF/, '');
+  if (text.trim() === '') throw new Error('Maskinrapporten är tom');
+
+  const delimiter = detectDelimiter(text);
+  const records = parseDelimited(text, delimiter);
+  if (records.length < 2) throw new Error('Maskinrapporten innehåller inga datarader');
+
+  const headers = records[0].map((value) => value.trim());
+  if (new Set(headers).size !== headers.length) {
+    throw new Error('Maskinrapporten innehåller dubbla kolumnrubriker');
+  }
+  const missing = RENTAL_BASELINE_HEADERS.filter((header) => !headers.includes(header));
+  if (missing.length > 0) {
+    throw new Error(`Maskinrapporten saknar obligatoriska kolumner: ${missing.join(', ')}`);
+  }
+
+  const agreementNos = new Set<string>();
+  const rows = records.slice(1).map((values, index): ParsedRentalSourceRow => {
+    const rowNumber = index + 2;
+    if (values.length !== headers.length) {
+      throw new Error(`Rad ${rowNumber}: ${values.length} fält men headern har ${headers.length}`);
+    }
+
+    const raw: RentalSourceRow = {};
+    headers.forEach((header, columnIndex) => {
+      const value = values[columnIndex];
+      raw[header] = value === '' ? null : value;
+    });
+
+    const agreementNo = trimOrNull(raw.AvtalsNr ?? undefined);
+    const outAtRaw = trimOrNull(raw.UtDt ?? undefined);
+    const inAtRaw = trimOrNull(raw.InDt ?? undefined);
+    const regnrRaw = trimOrNull(raw.RegNr ?? undefined);
+
+    if (!agreementNo) throw new Error(`Rad ${rowNumber}: AvtalsNr saknas`);
+    if (/^total$/i.test(agreementNo)) throw new Error(`Rad ${rowNumber}: Total-rad får inte finnas i maskinrapporten`);
+    if (agreementNos.has(agreementNo)) throw new Error(`Rad ${rowNumber}: dubbelt AvtalsNr ${agreementNo}`);
+    agreementNos.add(agreementNo);
+
+    if (!outAtRaw) throw new Error(`Rad ${rowNumber}: UtDt saknas`);
+    const outAt = assertSourceTimestamp(outAtRaw, 'UtDt', rowNumber);
+    const inAt = inAtRaw ? assertSourceTimestamp(inAtRaw, 'InDt', rowNumber) : null;
+    if (inAt && Date.parse(inAt) < Date.parse(outAt)) {
+      throw new Error(`Rad ${rowNumber}: InDt ligger före UtDt`);
+    }
+
+    if (!regnrRaw) throw new Error(`Rad ${rowNumber}: RegNr saknas`);
+    const regnr = normalizeRegnr(regnrRaw);
+    if (!REGNR_RE.test(regnr)) throw new Error(`Rad ${rowNumber}: ogiltigt RegNr ${regnrRaw}`);
+
+    return {
+      sourceRowNumber: rowNumber,
+      raw,
+      operational: {
+        closeMonth: trimOrNull(raw['Avsl. Månad'] ?? undefined),
+        stationNo: trimOrNull(raw.Stn ?? undefined),
+        outStation: trimOrNull(raw['Ut Stn'] ?? undefined),
+        closeYear: parseCloseYear(trimOrNull(raw['Avsl. År'] ?? undefined), rowNumber),
+        closedDate: parseClosedDate(trimOrNull(raw['Avsl. Datum'] ?? undefined), rowNumber),
+        agreementNo,
+        outAt,
+        inAt,
+        regnr,
+      },
+    };
+  });
+
+  return {
+    delimiter,
+    headers,
+    rows,
+    sha256: createHash('sha256').update(input).digest('hex'),
+  };
+}

--- a/migrations/20260823123000_add_rental_source_bulk_ingestion_v1.sql
+++ b/migrations/20260823123000_add_rental_source_bulk_ingestion_v1.sql
@@ -1,0 +1,97 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Transport adapter only. Every row still passes through the canonical
+-- ingest_rental_source_row function, which owns RAW immutability, A-I
+-- projection, conflict handling and RENTAL write-through semantics.
+create or replace function public.ingest_rental_source_rows(
+  p_batch_id uuid,
+  p_source_system text,
+  p_rows jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_row jsonb;
+  v_result jsonb;
+  v_seen integer := 0;
+  v_accepted integer := 0;
+  v_conflicts integer := 0;
+  v_conflict_codes jsonb := '{}'::jsonb;
+begin
+  if p_batch_id is null then
+    raise exception 'Rental source batch id is required' using errcode = '22023';
+  end if;
+  if nullif(trim(coalesce(p_source_system, '')), '') is null then
+    raise exception 'Rental source system is required' using errcode = '22023';
+  end if;
+  if p_rows is null or pg_catalog.jsonb_typeof(p_rows) <> 'array' then
+    raise exception 'Rental source rows must be a JSON array' using errcode = '22023';
+  end if;
+  if pg_catalog.jsonb_array_length(p_rows) = 0 then
+    raise exception 'Rental source rows cannot be empty' using errcode = '22023';
+  end if;
+  if pg_catalog.jsonb_array_length(p_rows) > 250 then
+    raise exception 'Rental source chunk exceeds 250 rows' using errcode = '22023';
+  end if;
+
+  for v_row in select value from pg_catalog.jsonb_array_elements(p_rows)
+  loop
+    if pg_catalog.jsonb_typeof(v_row) <> 'object' then
+      raise exception 'Each rental source row must be a JSON object' using errcode = '22023';
+    end if;
+
+    v_seen := v_seen + 1;
+
+    v_result := public.ingest_rental_source_row(
+      p_batch_id,
+      p_source_system,
+      v_row->>'agreementNo',
+      (v_row->>'sourceRowNumber')::integer,
+      v_row->'raw',
+      v_row->>'closeMonth',
+      v_row->>'stationNo',
+      v_row->>'outStation',
+      case when v_row->>'closeYear' is null then null else (v_row->>'closeYear')::integer end,
+      case when v_row->>'closedDate' is null then null else (v_row->>'closedDate')::date end,
+      v_row->>'agreementNo',
+      (v_row->>'outAt')::timestamptz,
+      case when v_row->>'inAt' is null then null else (v_row->>'inAt')::timestamptz end,
+      v_row->>'regnr'
+    );
+
+    if coalesce((v_result->>'projectionAccepted')::boolean, true) then
+      v_accepted := v_accepted + 1;
+    else
+      v_conflicts := v_conflicts + 1;
+      if v_result->>'conflictCode' is not null then
+        v_conflict_codes := pg_catalog.jsonb_set(
+          v_conflict_codes,
+          array[v_result->>'conflictCode'],
+          pg_catalog.to_jsonb(coalesce((v_conflict_codes->>(v_result->>'conflictCode'))::integer, 0) + 1),
+          true
+        );
+      end if;
+    end if;
+  end loop;
+
+  return pg_catalog.jsonb_build_object(
+    'seen', v_seen,
+    'accepted', v_accepted,
+    'conflicts', v_conflicts,
+    'conflictCodes', v_conflict_codes
+  );
+end;
+$$;
+
+revoke all on function public.ingest_rental_source_rows(uuid, text, jsonb)
+  from public, anon, authenticated;
+grant execute on function public.ingest_rental_source_rows(uuid, text, jsonb)
+  to service_role;
+
+commit;

--- a/tests/rental-report-import.test.ts
+++ b/tests/rental-report-import.test.ts
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  RENTAL_BASELINE_HEADERS,
+  parseRentalSourceReport,
+} from '../lib/rental-source-report';
+
+function csvCell(value: string): string {
+  if (/[",;\n\r]/.test(value)) return `"${value.replace(/"/g, '""')}"`;
+  return value;
+}
+
+function buildRow(overrides: Record<string, string> = {}, extra: Record<string, string> = {}) {
+  const defaults: Record<string, string> = {
+    'Avsl. Månad': '',
+    Stn: '0166',
+    'Ut Stn': '0170',
+    'Avsl. År': '',
+    'Avsl. Datum': '',
+    AvtalsNr: '024-166-0006155',
+    UtDt: '2026-08-23T08:15:00+02:00',
+    InDt: '',
+    RegNr: 'ABC12D',
+    Fordonstyp: 'Personbil',
+    'Debiterad Klass': 'A',
+    'Uthyrd Klass': 'A',
+    Avtalstyp: 'Företag',
+    Prislista: 'PL1',
+    Företagsnamn: 'Kund AB',
+    Hyror: '1',
+    'S:a Intäkt': '1250,50',
+    'S:a Hyra': '1000,00',
+    'S:a Dagar': '1',
+    'Snitt Intäkt': '1250,50',
+    'Snitt Hyra': '1000,00',
+    'Driv medel': '0',
+    'S-Skydd Halv': '0',
+    'S-Skydd Hel': '0',
+    'Skade kostnad': '0',
+    Tillval: '0',
+    Avgifter: '0',
+    'Väg o Miljö': '0',
+    'Tillbeh.': '0',
+    Bildeb: '450',
+    'Bildeb/ Hyra': '450',
+    'Marg. Hyra 3110': '550',
+    'Marg./ Dag 3110': '550',
+  };
+  return { ...defaults, ...overrides, ...extra };
+}
+
+function report(rows: Array<Record<string, string>>, extraHeaders: string[] = []): Uint8Array {
+  const headers = [...RENTAL_BASELINE_HEADERS, ...extraHeaders];
+  const lines = [
+    headers.map(csvCell).join(';'),
+    ...rows.map((row) => headers.map((header) => csvCell(row[header] ?? '')).join(';')),
+  ];
+  return new TextEncoder().encode(lines.join('\r\n'));
+}
+
+test('parses the complete rich source and projects only A-I operational fields', () => {
+  const parsed = parseRentalSourceReport(report([
+    buildRow({}, { 'Framtida ekonomifält': '999' }),
+  ], ['Framtida ekonomifält']));
+
+  assert.equal(parsed.rows.length, 1);
+  assert.equal(parsed.rows[0].operational.agreementNo, '024-166-0006155');
+  assert.equal(parsed.rows[0].operational.stationNo, '0166');
+  assert.equal(parsed.rows[0].operational.outStation, '0170');
+  assert.equal(parsed.rows[0].operational.outAt, '2026-08-23T08:15:00+02:00');
+  assert.equal(parsed.rows[0].operational.inAt, null);
+  assert.equal(parsed.rows[0].raw['S:a Intäkt'], '1250,50');
+  assert.equal(parsed.rows[0].raw['Framtida ekonomifält'], '999');
+  assert.ok(parsed.sha256.length === 64);
+});
+
+test('accepts H and E without giving E control over RENTAL timing', () => {
+  const parsed = parseRentalSourceReport(report([
+    buildRow({
+      'Avsl. Månad': '08',
+      'Avsl. År': '2026',
+      'Avsl. Datum': '2026-08-23T12:30:00+02:00',
+      InDt: '2026-08-23T10:45:00+02:00',
+    }),
+  ]));
+
+  assert.equal(parsed.rows[0].operational.inAt, '2026-08-23T10:45:00+02:00');
+  assert.equal(parsed.rows[0].operational.closedDate, '2026-08-23');
+});
+
+test('rejects date-only G because source time may not be invented', () => {
+  assert.throws(
+    () => parseRentalSourceReport(report([buildRow({ UtDt: '2026-08-23' })])),
+    /UtDt måste vara ISO 8601 med verklig tid och tidszon/,
+  );
+});
+
+test('rejects date-only H because source time may not be invented', () => {
+  assert.throws(
+    () => parseRentalSourceReport(report([buildRow({ InDt: '2026-08-23' })])),
+    /InDt måste vara ISO 8601 med verklig tid och tidszon/,
+  );
+});
+
+test('rejects duplicate F before any database write can begin', () => {
+  assert.throws(
+    () => parseRentalSourceReport(report([
+      buildRow(),
+      buildRow({ RegNr: 'DEF34G' }),
+    ])),
+    /dubbelt AvtalsNr/,
+  );
+});
+
+test('rejects Total presentation rows', () => {
+  assert.throws(
+    () => parseRentalSourceReport(report([buildRow({ AvtalsNr: 'Total' })])),
+    /Total-rad får inte finnas/,
+  );
+});
+
+test('rejects incomplete 33-field machine contract', () => {
+  const headers = RENTAL_BASELINE_HEADERS.filter((header) => header !== 'S:a Intäkt');
+  const row = buildRow();
+  const bytes = new TextEncoder().encode([
+    headers.join(';'),
+    headers.map((header) => row[header] ?? '').join(';'),
+  ].join('\n'));
+
+  assert.throws(() => parseRentalSourceReport(bytes), /saknar obligatoriska kolumner: S:a Intäkt/);
+});
+
+test('bulk RPC remains service-role-only and bounded to 250 rows', () => {
+  const migration = readFileSync(
+    join(process.cwd(), 'migrations/20260823123000_add_rental_source_bulk_ingestion_v1.sql'),
+    'utf8',
+  );
+  assert.match(migration, /security definer/i);
+  assert.match(migration, /set search_path = pg_catalog/i);
+  assert.match(migration, /jsonb_array_length\(p_rows\) > 250/i);
+  assert.match(migration, /public\.ingest_rental_source_row/i);
+  assert.match(migration, /revoke all on function public\.ingest_rental_source_rows[\s\S]*public, anon, authenticated/i);
+  assert.match(migration, /grant execute on function public\.ingest_rental_source_rows[\s\S]*service_role/i);
+});
+
+test('HTTP import is deny-by-default and uses authenticated server API boundary', () => {
+  const route = readFileSync(
+    join(process.cwd(), 'app/api/rental-source/import/route.ts'),
+    'utf8',
+  );
+  assert.match(route, /verifyApiUser\(request\)/);
+  assert.match(route, /RENTAL_IMPORT_ALLOWED_EMAILS/);
+  assert.match(route, /allowedEmails\.size === 0/);
+  assert.match(route, /ingest_rental_source_rows/);
+  assert.match(route, /SOURCE_CONFLICTS/);
+  assert.doesNotMatch(route, /AVAILABLE/);
+  assert.doesNotMatch(route, /Kistan/i);
+});


### PR DESCRIPTION
## Syfte
Koppla den låsta gemensamma RENTAL-källan till den redan Production-verifierade RAW → A-I → source-owned RENTAL-kedjan.

## Maskinleverans
- UTF-8 CSV/TSV
- samtliga 33 verifierade basfält krävs
- extra framtida fält tillåts och bevaras i RAW
- en semantisk rad per F / AvtalsNr
- inga Total/subtotal/presentationsrader
- G/H kräver ISO 8601 med verklig tid + tidszon; ingen syntetisk 00:00
- full fil valideras innan första DB-write

## Import
- autentiserad server-route
- separat `RENTAL_IMPORT_ALLOWED_EMAILS`, deny-by-default
- SHA-256 filfingerprint → idempotent batch
- max 10 MiB
- 250-raders chunks till server-only bulk-RPC
- varje rad går fortfarande genom befintliga `ingest_rental_source_row`
- source conflicts returneras tydligt som 409 `SOURCE_CONFLICTS`
- partiellt nätverksfel kan replayas säkert med samma fil

## Ej i scope
- ingen XLSX-parser
- ingen AVAILABLE-inferens
- ingen ny RENTAL-semantik
- ingen Kistan-logik
- ingen import-UI ännu