### PR TITLE
L2.1 Establish versioned process and routine contract

### DIFF
--- a/docs/LAYER2_PROCESS_ROUTINE_CONTRACT_V1.md
+++ b/docs/LAYER2_PROCESS_ROUTINE_CONTRACT_V1.md
@@ -1,0 +1,62 @@
+# Layer 2 Process/Routine Contract v1
+
+Status: implementation contract for L2.1.
+
+## Locked boundary
+
+Layer 1 / Fordonsresan remains the factual timeline and source-owned operational state. Layer 2 may react to verified facts but must not infer or rewrite Layer 1 state.
+
+Layer 2 is the process-control layer:
+
+`event -> process -> routine -> checkpoint -> handshake/verification -> passage or deviation -> action -> re-verification -> outcome`
+
+Kistan is outside this contract.
+
+## Why definitions first
+
+The existing checkpoint/action/timer engine already provides reusable primitives for verification, deviation handling, remediation and escalation. L2.1 therefore adds only the missing versioned definition layer for PROCESS and RUTIN.
+
+L2.1 intentionally does **not** create generic mutable `process_instances` or `routine_instances`. Existing source domains remain owners of their current execution state until a later contract defines a safe generic projection without creating two truths.
+
+## First vertical case: SALU
+
+The first vertical case is SALU because its business rules are already documented and implemented in a source-owned domain.
+
+Mapping v1:
+
+- process definition: `SALU` v1
+- routine definition: `SALU_CYCLE` v1
+- owner function: `BILKONTROLL`
+- source entity: `salu_flags`
+- source record identity: `flag_id`
+- subject: `regnr`
+- process start fact: `SALU_FLAG_CREATED`
+- current execution state remains source-owned by `salu_flags.status`
+
+No SALU flags are created, changed or backfilled by this migration.
+
+## Versioning
+
+`process_definitions` and `routine_definitions` are versioned. Historical consumers must reference the exact version that applied to their source execution context. Only one active version per process/routine code is allowed.
+
+## Security
+
+Both definition tables are server-only:
+
+- RLS enabled
+- no browser policies
+- privileges revoked from `public`, `anon` and `authenticated`
+- service role is the intended application access path
+
+## Explicitly not in L2.1
+
+- no generic process instance state
+- no generic routine instance state
+- no handshake model
+- no process passage engine
+- no role/mandate model
+- no Kistan/economic rule
+- no Layer 1 writes
+- no changes to SALU business state
+
+Those capabilities are separate Layer 2 increments and must reuse this definition contract rather than duplicate it.

--- a/lib/process-engine.ts
+++ b/lib/process-engine.ts
@@ -1,0 +1,83 @@
+export const PROCESS_TRIGGER_TYPES = [
+  'SOURCE_EVENT',
+  'SCHEDULED',
+  'MANUAL',
+  'EXTERNAL',
+] as const;
+
+export type ProcessTriggerType = (typeof PROCESS_TRIGGER_TYPES)[number];
+
+export const ROUTINE_ACTIVATION_TYPES = [
+  'PROCESS_START',
+  'PREVIOUS_ROUTINE',
+  'MANUAL',
+  'EXTERNAL',
+] as const;
+
+export type RoutineActivationType = (typeof ROUTINE_ACTIVATION_TYPES)[number];
+
+export type ProcessDefinition = {
+  processCode: string;
+  processVersion: number;
+  domain: string;
+  title: string;
+  ownerFunction: string;
+  triggerType: ProcessTriggerType;
+  triggerConfig: Record<string, unknown>;
+};
+
+export type RoutineDefinition = {
+  routineCode: string;
+  routineVersion: number;
+  processCode: string;
+  processVersion: number;
+  title: string;
+  ownerFunction: string;
+  sequenceOrder: number;
+  activationType: RoutineActivationType;
+  activationConfig: Record<string, unknown>;
+};
+
+const CONTRACT_CODE_RE = /^[A-Z0-9][A-Z0-9_-]{1,79}$/;
+
+export function normalizeProcessContractCode(value: string): string {
+  const normalized = value.trim().toUpperCase();
+  if (!CONTRACT_CODE_RE.test(normalized)) {
+    throw new Error('Invalid process contract code');
+  }
+  return normalized;
+}
+
+export function validateProcessDefinition(definition: ProcessDefinition): void {
+  normalizeProcessContractCode(definition.processCode);
+  normalizeProcessContractCode(definition.domain);
+
+  if (!Number.isInteger(definition.processVersion) || definition.processVersion < 1) {
+    throw new Error('Invalid process version');
+  }
+  if (!definition.title.trim()) throw new Error('Process title is required');
+  if (!definition.ownerFunction.trim()) throw new Error('Process owner function is required');
+  if (!PROCESS_TRIGGER_TYPES.includes(definition.triggerType)) {
+    throw new Error('Invalid process trigger type');
+  }
+}
+
+export function validateRoutineDefinition(definition: RoutineDefinition): void {
+  normalizeProcessContractCode(definition.routineCode);
+  normalizeProcessContractCode(definition.processCode);
+
+  if (!Number.isInteger(definition.routineVersion) || definition.routineVersion < 1) {
+    throw new Error('Invalid routine version');
+  }
+  if (!Number.isInteger(definition.processVersion) || definition.processVersion < 1) {
+    throw new Error('Invalid process version');
+  }
+  if (!Number.isInteger(definition.sequenceOrder) || definition.sequenceOrder < 1) {
+    throw new Error('Invalid routine sequence order');
+  }
+  if (!definition.title.trim()) throw new Error('Routine title is required');
+  if (!definition.ownerFunction.trim()) throw new Error('Routine owner function is required');
+  if (!ROUTINE_ACTIVATION_TYPES.includes(definition.activationType)) {
+    throw new Error('Invalid routine activation type');
+  }
+}

--- a/migrations/20260823153000_add_process_routine_contract_v1.sql
+++ b/migrations/20260823153000_add_process_routine_contract_v1.sql
@@ -1,0 +1,134 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Layer 2.1 establishes only the versioned definition contract for PROCESS -> RUTIN.
+-- It does not create a second mutable process state beside existing domain sources.
+-- SALU remains source-owned by salu_flags; Layer 1 vehicle-journey state is untouched.
+create table public.process_definitions (
+  process_code text not null,
+  process_version integer not null check (process_version > 0),
+  domain text not null check (domain ~ '^[A-Z0-9][A-Z0-9_-]{1,79}$'),
+  title text not null check (length(trim(title)) between 1 and 200),
+  description text,
+  owner_function text not null check (length(trim(owner_function)) between 1 and 120),
+  trigger_type text not null
+    check (trigger_type in ('SOURCE_EVENT', 'SCHEDULED', 'MANUAL', 'EXTERNAL')),
+  trigger_config jsonb not null default '{}'::jsonb,
+  active boolean not null default true,
+  valid_from timestamptz not null default now(),
+  changed_by uuid,
+  changed_at timestamptz not null default now(),
+  primary key (process_code, process_version),
+  check (process_code ~ '^[A-Z0-9][A-Z0-9_-]{1,79}$'),
+  check (jsonb_typeof(trigger_config) = 'object')
+);
+
+create unique index process_definitions_one_active_version_uidx
+  on public.process_definitions (process_code)
+  where active;
+
+create table public.routine_definitions (
+  routine_code text not null,
+  routine_version integer not null check (routine_version > 0),
+  process_code text not null,
+  process_version integer not null,
+  title text not null check (length(trim(title)) between 1 and 200),
+  description text,
+  owner_function text not null check (length(trim(owner_function)) between 1 and 120),
+  sequence_order integer not null check (sequence_order > 0),
+  activation_type text not null
+    check (activation_type in ('PROCESS_START', 'PREVIOUS_ROUTINE', 'MANUAL', 'EXTERNAL')),
+  activation_config jsonb not null default '{}'::jsonb,
+  active boolean not null default true,
+  valid_from timestamptz not null default now(),
+  changed_by uuid,
+  changed_at timestamptz not null default now(),
+  primary key (routine_code, routine_version),
+  foreign key (process_code, process_version)
+    references public.process_definitions(process_code, process_version)
+    on delete restrict,
+  check (routine_code ~ '^[A-Z0-9][A-Z0-9_-]{1,79}$'),
+  check (jsonb_typeof(activation_config) = 'object')
+);
+
+create unique index routine_definitions_one_active_version_uidx
+  on public.routine_definitions (routine_code)
+  where active;
+
+create index routine_definitions_process_idx
+  on public.routine_definitions (process_code, process_version, sequence_order);
+
+-- First vertical case is the already locked SALU domain. This seed describes
+-- the contract only; it does not backfill, mutate or duplicate salu_flags.
+insert into public.process_definitions (
+  process_code,
+  process_version,
+  domain,
+  title,
+  description,
+  owner_function,
+  trigger_type,
+  trigger_config,
+  active
+) values (
+  'SALU',
+  1,
+  'SALU',
+  'SALU',
+  'Bilens slutkontroll och beslutspunkt inom den sammanhängande fordonsresan.',
+  'BILKONTROLL',
+  'SOURCE_EVENT',
+  pg_catalog.jsonb_build_object(
+    'sourceSystem', 'INCHECKAD',
+    'sourceEntity', 'salu_flags',
+    'sourceRecordField', 'flag_id',
+    'subjectField', 'regnr',
+    'eventType', 'SALU_FLAG_CREATED'
+  ),
+  true
+)
+on conflict (process_code, process_version) do nothing;
+
+insert into public.routine_definitions (
+  routine_code,
+  routine_version,
+  process_code,
+  process_version,
+  title,
+  description,
+  owner_function,
+  sequence_order,
+  activation_type,
+  activation_config,
+  active
+) values (
+  'SALU_CYCLE',
+  1,
+  'SALU',
+  1,
+  'SALU-cykel',
+  'Den källägda SALU-cykeln från aktiv flagga till verifierat slutbeslut.',
+  'BILKONTROLL',
+  1,
+  'PROCESS_START',
+  pg_catalog.jsonb_build_object(
+    'sourceEntity', 'salu_flags',
+    'sourceStateField', 'status',
+    'sourceOwner', 'SALU'
+  ),
+  true
+)
+on conflict (routine_code, routine_version) do nothing;
+
+alter table public.process_definitions enable row level security;
+alter table public.routine_definitions enable row level security;
+
+revoke all on public.process_definitions from public, anon, authenticated;
+revoke all on public.routine_definitions from public, anon, authenticated;
+
+grant select, insert, update, delete on public.process_definitions to service_role;
+grant select, insert, update, delete on public.routine_definitions to service_role;
+
+commit;

--- a/tests/process-engine.test.ts
+++ b/tests/process-engine.test.ts
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  normalizeProcessContractCode,
+  validateProcessDefinition,
+  validateRoutineDefinition,
+} from '../lib/process-engine';
+
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/20260823153000_add_process_routine_contract_v1.sql'),
+  'utf8',
+);
+
+test('process and routine codes are normalized and bounded', () => {
+  assert.equal(normalizeProcessContractCode(' salu_cycle '), 'SALU_CYCLE');
+  assert.throws(() => normalizeProcessContractCode('x'), /Invalid process contract code/);
+  assert.throws(() => normalizeProcessContractCode('bad code'), /Invalid process contract code/);
+});
+
+test('process definitions require a version, owner and supported trigger type', () => {
+  assert.doesNotThrow(() => validateProcessDefinition({
+    processCode: 'SALU',
+    processVersion: 1,
+    domain: 'SALU',
+    title: 'SALU',
+    ownerFunction: 'BILKONTROLL',
+    triggerType: 'SOURCE_EVENT',
+    triggerConfig: {},
+  }));
+
+  assert.throws(() => validateProcessDefinition({
+    processCode: 'SALU',
+    processVersion: 0,
+    domain: 'SALU',
+    title: 'SALU',
+    ownerFunction: 'BILKONTROLL',
+    triggerType: 'SOURCE_EVENT',
+    triggerConfig: {},
+  }), /Invalid process version/);
+});
+
+test('routine definitions belong to an explicit process version and sequence', () => {
+  assert.doesNotThrow(() => validateRoutineDefinition({
+    routineCode: 'SALU_CYCLE',
+    routineVersion: 1,
+    processCode: 'SALU',
+    processVersion: 1,
+    title: 'SALU-cykel',
+    ownerFunction: 'BILKONTROLL',
+    sequenceOrder: 1,
+    activationType: 'PROCESS_START',
+    activationConfig: {},
+  }));
+
+  assert.throws(() => validateRoutineDefinition({
+    routineCode: 'SALU_CYCLE',
+    routineVersion: 1,
+    processCode: 'SALU',
+    processVersion: 1,
+    title: 'SALU-cykel',
+    ownerFunction: 'BILKONTROLL',
+    sequenceOrder: 0,
+    activationType: 'PROCESS_START',
+    activationConfig: {},
+  }), /Invalid routine sequence order/);
+});
+
+test('database contract is versioned, server-only and does not create duplicate process state', () => {
+  assert.match(migration, /create table public\.process_definitions/i);
+  assert.match(migration, /primary key \(process_code, process_version\)/i);
+  assert.match(migration, /create table public\.routine_definitions/i);
+  assert.match(migration, /primary key \(routine_code, routine_version\)/i);
+  assert.match(migration, /references public\.process_definitions\(process_code, process_version\)/i);
+  assert.match(migration, /enable row level security/i);
+  assert.match(migration, /revoke all on public\.process_definitions from public, anon, authenticated/i);
+  assert.match(migration, /revoke all on public\.routine_definitions from public, anon, authenticated/i);
+  assert.doesNotMatch(migration, /create table public\.process_instances/i);
+  assert.doesNotMatch(migration, /create table public\.routine_instances/i);
+});
+
+test('first vertical contract reuses the locked SALU source rather than duplicating it', () => {
+  assert.match(migration, /'SALU'[\s\S]*'SOURCE_EVENT'/i);
+  assert.match(migration, /'sourceEntity', 'salu_flags'/i);
+  assert.match(migration, /'sourceRecordField', 'flag_id'/i);
+  assert.match(migration, /'eventType', 'SALU_FLAG_CREATED'/i);
+  assert.match(migration, /'SALU_CYCLE'/i);
+  assert.match(migration, /'sourceOwner', 'SALU'/i);
+  assert.doesNotMatch(migration, /insert into public\.salu_flags/i);
+  assert.doesNotMatch(migration, /update public\.salu_flags/i);
+  assert.doesNotMatch(migration, /vehicle_journey_periods/i);
+});


### PR DESCRIPTION
## Syfte
Etablera det saknade generella definitionslagret för Layer 2: **PROCESS -> RUTIN**, utan att skapa en parallell process-sanning bredvid befintliga source-owned domäner.

## Låst verksamhetsgrund
Första vertikala fallet är **SALU**, enligt befintlig bevismatris och låst SALU-process.

## Ändring
- `process_definitions` med versionsstyrning, owner och trigger-kontrakt
- `routine_definitions` med versionsstyrning, processkoppling, ordning och activation-kontrakt
- SALU v1 seedas som första processdefinition
- `SALU_CYCLE` v1 seedas som första rutindefinition
- båda tabellerna är server-only med RLS och revoke från browserroller
- TypeScript-kontrakt och regressionstester
- dokumenterat Layer 2.1-kontrakt

## Viktig avgränsning
- ingen `process_instances` / `routine_instances`
- ingen ny SALU-state; `salu_flags` fortsätter äga SALU-cykelns verkliga status
- ingen Layer 1-write
- ingen handslagsmodell ännu
- ingen passagemotor ännu
- ingen RBAC/mandatmodell ännu
- ingen Kistan
- ingen backfill

## Varför
Checkpoint/action/timer-motorn finns redan. L2.1 lägger endast den saknade versionerade definitionen ovanpå den motorn och återanvänder SALU som verifierat första vertikalfall utan att duplicera source-of-truth.