### PR TITLE
L2.3 Establish passage and blocking contract

### DIFF
--- a/docs/LAYER2_PASSAGE_CONTRACT_V1.md
+++ b/docs/LAYER2_PASSAGE_CONTRACT_V1.md
@@ -1,0 +1,48 @@
+# Layer 2.3 — Passage / blockering v1
+
+## Syfte
+
+Passage avgör om nästa processtillstånd får öppnas. Den är en readiness-gate ovanpå verifierade Layer 2-objekt och får inte skapa eller skriva om verksamhetssanning.
+
+## Princip
+
+En passage är **READY** endast när samtliga aktiva krav är upplösta enligt respektive kontrakt.
+
+- HANDOFF: `VERIFIED` eller legitimt `CANCELLED`
+- CHECKPOINT: `GODKAND` eller `EJ_RELEVANT`
+- saknat kravobjekt blockerar
+- `REQUESTED`, `HANDED_OVER`, `RECEIVED`, `ACCEPTED`, `COMPLETED` blockerar en handoff-baserad passage
+- `VANTAR` och `AVVIKELSE` blockerar en checkpoint-baserad passage
+
+## Arkitektur
+
+`passage_definitions` beskriver den versionerade gaten och dess målstatus.
+
+`passage_requirements` beskriver vilka handoffs/checkpoints som måste vara upplösta.
+
+`evaluate_routine_passage(...)` är read-only och returnerar `ready`, strukturerade blockeringsorsaker och kravstatus.
+
+`assert_routine_passage_ready(...)` är en strikt gate som avbryter om readiness inte är uppfylld.
+
+Ingen funktion i L2.3 muterar `salu_flags`, Layer 1-perioder, checkpoints eller handoffs.
+
+## Första vertikalfall
+
+`SALU_FINAL_ASSESSMENT v1`
+
+Målstatus: `SLUTBEDÖMNING`
+
+Krav:
+1. `SALU_TO_PLANERING v1` upplöst
+2. `SALU_TO_INKOP v1` upplöst
+
+Denna gate säger endast om SALU **får** gå vidare. Den källägda SALU-transitionen förblir separat.
+
+## Avgränsning
+
+- ingen Layer 1-write
+- ingen automatisk SALU-statusändring
+- ingen process/routine instance-modell
+- ingen RBAC/mandatmodell
+- ingen SLA/timer
+- ingen Kistan

--- a/lib/passage-engine.ts
+++ b/lib/passage-engine.ts
@@ -1,0 +1,60 @@
+export type PassageRequirementType = 'HANDOFF' | 'CHECKPOINT';
+
+export type PassageBlocker = {
+  code: 'HANDOFF_MISSING' | 'HANDOFF_UNRESOLVED' | 'CHECKPOINT_MISSING' | 'CHECKPOINT_UNRESOLVED';
+  requirementCode: string;
+  referenceCode: string;
+  status?: string;
+};
+
+export type PassageReadiness = {
+  ready: boolean;
+  reasons: PassageBlocker[];
+};
+
+export function assessPassageReadiness(input: {
+  handoffs?: Array<{ requirementCode: string; referenceCode: string; status?: string | null }>;
+  checkpoints?: Array<{ requirementCode: string; referenceCode: string; status?: string | null }>;
+}): PassageReadiness {
+  const reasons: PassageBlocker[] = [];
+
+  for (const handoff of input.handoffs ?? []) {
+    if (!handoff.status) {
+      reasons.push({
+        code: 'HANDOFF_MISSING',
+        requirementCode: handoff.requirementCode,
+        referenceCode: handoff.referenceCode,
+      });
+      continue;
+    }
+    if (handoff.status !== 'VERIFIED' && handoff.status !== 'CANCELLED') {
+      reasons.push({
+        code: 'HANDOFF_UNRESOLVED',
+        requirementCode: handoff.requirementCode,
+        referenceCode: handoff.referenceCode,
+        status: handoff.status,
+      });
+    }
+  }
+
+  for (const checkpoint of input.checkpoints ?? []) {
+    if (!checkpoint.status) {
+      reasons.push({
+        code: 'CHECKPOINT_MISSING',
+        requirementCode: checkpoint.requirementCode,
+        referenceCode: checkpoint.referenceCode,
+      });
+      continue;
+    }
+    if (checkpoint.status !== 'GODKAND' && checkpoint.status !== 'EJ_RELEVANT') {
+      reasons.push({
+        code: 'CHECKPOINT_UNRESOLVED',
+        requirementCode: checkpoint.requirementCode,
+        referenceCode: checkpoint.referenceCode,
+        status: checkpoint.status,
+      });
+    }
+  }
+
+  return { ready: reasons.length === 0, reasons };
+}

--- a/migrations/20260823174500_add_passage_contract_v1.sql
+++ b/migrations/20260823174500_add_passage_contract_v1.sql
@@ -1,0 +1,245 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Layer 2.3: PASSAGE / BLOCKERING.
+-- Passage is a readiness decision. It does not mutate source-owned business state.
+create table public.passage_definitions (
+  passage_code text not null,
+  passage_version integer not null check (passage_version > 0),
+  routine_code text not null,
+  routine_version integer not null,
+  title text not null check (length(trim(title)) between 1 and 200),
+  description text,
+  target_state text not null check (length(trim(target_state)) between 1 and 120),
+  active boolean not null default true,
+  valid_from timestamptz not null default now(),
+  changed_by uuid,
+  changed_at timestamptz not null default now(),
+  primary key (passage_code, passage_version),
+  foreign key (routine_code, routine_version)
+    references public.routine_definitions(routine_code, routine_version)
+    on delete restrict,
+  check (passage_code ~ '^[A-Z0-9][A-Z0-9_-]{1,79}$')
+);
+
+create unique index passage_definitions_one_active_version_uidx
+  on public.passage_definitions (passage_code)
+  where active;
+
+create table public.passage_requirements (
+  passage_code text not null,
+  passage_version integer not null,
+  requirement_code text not null,
+  requirement_type text not null check (requirement_type in ('HANDOFF','CHECKPOINT')),
+  reference_code text not null,
+  reference_version integer not null check (reference_version > 0),
+  sequence_order integer not null check (sequence_order > 0),
+  active boolean not null default true,
+  primary key (passage_code, passage_version, requirement_code),
+  foreign key (passage_code, passage_version)
+    references public.passage_definitions(passage_code, passage_version)
+    on delete restrict,
+  check (requirement_code ~ '^[A-Z0-9][A-Z0-9_-]{1,79}$'),
+  check (reference_code ~ '^[A-Z0-9][A-Z0-9_-]{1,79}$')
+);
+
+create index passage_requirements_reference_idx
+  on public.passage_requirements (requirement_type, reference_code, reference_version);
+
+create or replace function public.evaluate_routine_passage(
+  p_passage_code text,
+  p_regnr text,
+  p_cycle_key text default null,
+  p_context jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_definition public.passage_definitions%rowtype;
+  v_requirement record;
+  v_status text;
+  v_found boolean;
+  v_ready boolean := true;
+  v_reasons jsonb := '[]'::jsonb;
+  v_requirements jsonb := '[]'::jsonb;
+  v_flag_id text := nullif(p_context ->> 'flagId', '');
+begin
+  if pg_catalog.jsonb_typeof(coalesce(p_context, '{}'::jsonb)) <> 'object' then
+    raise exception 'Passage context must be an object' using errcode = '22023';
+  end if;
+
+  select * into v_definition
+  from public.passage_definitions
+  where passage_code = upper(trim(p_passage_code))
+    and active
+  order by passage_version desc
+  limit 1;
+
+  if not found then
+    raise exception 'Active passage definition not found' using errcode = 'P0002';
+  end if;
+
+  for v_requirement in
+    select *
+    from public.passage_requirements
+    where passage_code = v_definition.passage_code
+      and passage_version = v_definition.passage_version
+      and active
+    order by sequence_order, requirement_code
+  loop
+    v_status := null;
+    v_found := false;
+
+    if v_requirement.requirement_type = 'HANDOFF' then
+      select h.status, true
+        into v_status, v_found
+      from public.handoffs h
+      where h.regnr = upper(trim(p_regnr))
+        and h.handoff_code = v_requirement.reference_code
+        and h.handoff_version = v_requirement.reference_version
+        and (v_flag_id is null or h.metadata ->> 'flagId' = v_flag_id)
+      order by h.created_at desc
+      limit 1;
+
+      if not coalesce(v_found, false) then
+        v_ready := false;
+        v_reasons := v_reasons || pg_catalog.jsonb_build_array(
+          pg_catalog.jsonb_build_object(
+            'code', 'HANDOFF_MISSING',
+            'requirementCode', v_requirement.requirement_code,
+            'referenceCode', v_requirement.reference_code
+          )
+        );
+      elsif v_status not in ('VERIFIED','CANCELLED') then
+        v_ready := false;
+        v_reasons := v_reasons || pg_catalog.jsonb_build_array(
+          pg_catalog.jsonb_build_object(
+            'code', 'HANDOFF_UNRESOLVED',
+            'requirementCode', v_requirement.requirement_code,
+            'referenceCode', v_requirement.reference_code,
+            'status', v_status
+          )
+        );
+      end if;
+
+    elsif v_requirement.requirement_type = 'CHECKPOINT' then
+      select vc.status, true
+        into v_status, v_found
+      from public.vehicle_checkpoints vc
+      where vc.regnr = upper(trim(p_regnr))
+        and vc.checkpoint_code = v_requirement.reference_code
+        and vc.definition_version = v_requirement.reference_version
+        and (p_cycle_key is null or vc.cycle_key = p_cycle_key)
+      order by vc.created_at desc
+      limit 1;
+
+      if not coalesce(v_found, false) then
+        v_ready := false;
+        v_reasons := v_reasons || pg_catalog.jsonb_build_array(
+          pg_catalog.jsonb_build_object(
+            'code', 'CHECKPOINT_MISSING',
+            'requirementCode', v_requirement.requirement_code,
+            'referenceCode', v_requirement.reference_code
+          )
+        );
+      elsif v_status not in ('GODKAND','EJ_RELEVANT') then
+        v_ready := false;
+        v_reasons := v_reasons || pg_catalog.jsonb_build_array(
+          pg_catalog.jsonb_build_object(
+            'code', 'CHECKPOINT_UNRESOLVED',
+            'requirementCode', v_requirement.requirement_code,
+            'referenceCode', v_requirement.reference_code,
+            'status', v_status
+          )
+        );
+      end if;
+    end if;
+
+    v_requirements := v_requirements || pg_catalog.jsonb_build_array(
+      pg_catalog.jsonb_build_object(
+        'requirementCode', v_requirement.requirement_code,
+        'type', v_requirement.requirement_type,
+        'referenceCode', v_requirement.reference_code,
+        'referenceVersion', v_requirement.reference_version,
+        'found', coalesce(v_found, false),
+        'status', v_status
+      )
+    );
+  end loop;
+
+  return pg_catalog.jsonb_build_object(
+    'passageCode', v_definition.passage_code,
+    'passageVersion', v_definition.passage_version,
+    'routineCode', v_definition.routine_code,
+    'targetState', v_definition.target_state,
+    'regnr', upper(trim(p_regnr)),
+    'ready', v_ready,
+    'reasons', v_reasons,
+    'requirements', v_requirements
+  );
+end;
+$$;
+
+create or replace function public.assert_routine_passage_ready(
+  p_passage_code text,
+  p_regnr text,
+  p_cycle_key text default null,
+  p_context jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_result jsonb;
+begin
+  v_result := public.evaluate_routine_passage(p_passage_code, p_regnr, p_cycle_key, p_context);
+  if coalesce((v_result ->> 'ready')::boolean, false) is not true then
+    raise exception 'Passage blocked: %', v_result -> 'reasons' using errcode = 'P0001';
+  end if;
+  return v_result;
+end;
+$$;
+
+-- First vertical passage: SALU may proceed to final assessment only when the
+-- two already-defined blocking handoffs have been resolved. This does not
+-- change salu_flags.status; source-owned transition remains separate.
+insert into public.passage_definitions (
+  passage_code, passage_version, routine_code, routine_version,
+  title, description, target_state, active
+) values (
+  'SALU_FINAL_ASSESSMENT', 1, 'SALU_CYCLE', 1,
+  'SALU till slutbedömning',
+  'Readiness-gate före SALU:s källägda slutbedömning.',
+  'SLUTBEDÖMNING', true
+)
+on conflict (passage_code, passage_version) do nothing;
+
+insert into public.passage_requirements (
+  passage_code, passage_version, requirement_code, requirement_type,
+  reference_code, reference_version, sequence_order, active
+) values
+  ('SALU_FINAL_ASSESSMENT', 1, 'PLANERING_HANDOFF_RESOLVED', 'HANDOFF', 'SALU_TO_PLANERING', 1, 1, true),
+  ('SALU_FINAL_ASSESSMENT', 1, 'INKOP_HANDOFF_RESOLVED', 'HANDOFF', 'SALU_TO_INKOP', 1, 2, true)
+on conflict (passage_code, passage_version, requirement_code) do nothing;
+
+alter table public.passage_definitions enable row level security;
+alter table public.passage_requirements enable row level security;
+
+revoke all on public.passage_definitions from public, anon, authenticated;
+revoke all on public.passage_requirements from public, anon, authenticated;
+revoke all on function public.evaluate_routine_passage(text,text,text,jsonb) from public, anon, authenticated;
+revoke all on function public.assert_routine_passage_ready(text,text,text,jsonb) from public, anon, authenticated;
+
+grant select, insert, update, delete on public.passage_definitions to service_role;
+grant select, insert, update, delete on public.passage_requirements to service_role;
+grant execute on function public.evaluate_routine_passage(text,text,text,jsonb) to service_role;
+grant execute on function public.assert_routine_passage_ready(text,text,text,jsonb) to service_role;
+
+commit;

--- a/tests/passage-engine.test.ts
+++ b/tests/passage-engine.test.ts
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { assessPassageReadiness } from '../lib/passage-engine';
+
+const migration = readFileSync(
+  join(process.cwd(), 'migrations/20260823174500_add_passage_contract_v1.sql'),
+  'utf8',
+);
+
+test('passage stays blocked while a required handoff is missing or unresolved', () => {
+  assert.deepEqual(
+    assessPassageReadiness({
+      handoffs: [
+        { requirementCode: 'A', referenceCode: 'H1', status: null },
+        { requirementCode: 'B', referenceCode: 'H2', status: 'ACCEPTED' },
+      ],
+    }),
+    {
+      ready: false,
+      reasons: [
+        { code: 'HANDOFF_MISSING', requirementCode: 'A', referenceCode: 'H1' },
+        { code: 'HANDOFF_UNRESOLVED', requirementCode: 'B', referenceCode: 'H2', status: 'ACCEPTED' },
+      ],
+    },
+  );
+});
+
+test('verified or cancelled handoffs release their blocking requirement', () => {
+  assert.deepEqual(
+    assessPassageReadiness({
+      handoffs: [
+        { requirementCode: 'A', referenceCode: 'H1', status: 'VERIFIED' },
+        { requirementCode: 'B', referenceCode: 'H2', status: 'CANCELLED' },
+      ],
+    }),
+    { ready: true, reasons: [] },
+  );
+});
+
+test('checkpoint passage accepts GODKAND and EJ_RELEVANT but blocks VANTAR and AVVIKELSE', () => {
+  assert.deepEqual(
+    assessPassageReadiness({
+      checkpoints: [
+        { requirementCode: 'A', referenceCode: 'C1', status: 'GODKAND' },
+        { requirementCode: 'B', referenceCode: 'C2', status: 'EJ_RELEVANT' },
+      ],
+    }),
+    { ready: true, reasons: [] },
+  );
+
+  const blocked = assessPassageReadiness({
+    checkpoints: [
+      { requirementCode: 'A', referenceCode: 'C1', status: 'VANTAR' },
+      { requirementCode: 'B', referenceCode: 'C2', status: 'AVVIKELSE' },
+    ],
+  });
+  assert.equal(blocked.ready, false);
+  assert.equal(blocked.reasons.length, 2);
+});
+
+test('migration defines a read-only readiness gate and does not mutate source-owned SALU state', () => {
+  assert.match(migration, /create table public\.passage_definitions/i);
+  assert.match(migration, /create table public\.passage_requirements/i);
+  assert.match(migration, /function public\.evaluate_routine_passage/i);
+  assert.match(migration, /function public\.assert_routine_passage_ready/i);
+  assert.match(migration, /SALU_FINAL_ASSESSMENT/);
+  assert.match(migration, /SALU_TO_PLANERING/);
+  assert.match(migration, /SALU_TO_INKOP/);
+  assert.doesNotMatch(migration, /update\s+public\.salu_flags/i);
+  assert.doesNotMatch(migration, /insert\s+into\s+public\.salu_flags/i);
+  assert.match(migration, /revoke all on public\.passage_definitions from public, anon, authenticated/i);
+  assert.match(migration, /revoke all on function public\.evaluate_routine_passage/i);
+});


### PR DESCRIPTION
## Syfte
Etablera Layer 2.3 **PASSAGE / BLOCKERING** som en strikt readiness-gate ovanpå befintliga checkpoints och handslag.

## Kontrakt
Passage är ett beslut om nästa steg får öppnas. Den skriver inte verksamhetssanning.

- HANDOFF blockerar tills `VERIFIED` eller legitimt `CANCELLED`
- CHECKPOINT blockerar tills `GODKAND` eller `EJ_RELEVANT`
- saknat kravobjekt blockerar
- strukturerade blockeringsorsaker returneras

## Ändring
- `passage_definitions`
- `passage_requirements`
- `evaluate_routine_passage(...)` read-only readiness
- `assert_routine_passage_ready(...)` strikt gate
- TypeScript helper + regressionstester
- SALU v1: `SALU_FINAL_ASSESSMENT`
  - kräver `SALU_TO_PLANERING v1`
  - kräver `SALU_TO_INKOP v1`

## Viktig avgränsning
- ingen Layer 1-write
- ingen automatisk `salu_flags`-transition
- ingen mutation av checkpoint/handoff-state
- ingen RBAC/mandatmodell ännu
- ingen SLA/timer
- ingen Kistan

L2.3 avgör endast **om** passage är tillåten. Source-owned domän utför själva verksamhetsövergången separat.