### PR TITLE
L2.4 Establish Layer 1 source trigger adapters

### DIFF
--- a/docs/LAYER2_SOURCE_TRIGGER_ADAPTER_CONTRACT_V1.md
+++ b/docs/LAYER2_SOURCE_TRIGGER_ADAPTER_CONTRACT_V1.md
@@ -1,0 +1,79 @@
+# L2.4 — Layer 1 source-trigger adapters v1
+
+## Syfte
+
+L2.4 kopplar verifierade Layer 1-händelser till Layer 2-processmotorn utan att flytta ägarskap från källan.
+
+Grundregeln är fortsatt:
+
+> källa vet → Incheckad skriver faktum. Källa vet inte → Incheckad vet inte.
+
+Layer 2 får observera ett redan skrivet Layer 1-faktum och materialisera ett separat process-trigger-faktum. Layer 2 får inte skriva om, komplettera eller härleda Layer 1-fakta.
+
+## Objekt
+
+### `source_trigger_adapter_definitions`
+
+Versionsstyrd konfiguration för en uttrycklig koppling:
+
+`Layer 1 source event → Process vN [→ Routine vN]`
+
+En adapter matchar exakt på:
+
+- `source_system`
+- `source_entity`
+- `source_event_type`
+
+Endast `active=true` får materialisera process-trigger-events.
+
+### `process_trigger_events`
+
+Append-only bevis att ett verifierat Layer 1-event matchade en aktiv adapter.
+
+Varje rad innehåller bland annat:
+
+- source journey event-id
+- regnr
+- source system/entity/record/event type/event key/time
+- process code/version
+- optional routine code/version
+- kopia av source payload och actor metadata
+
+Detta är ett Layer 2-faktum om processaktivering, inte ny fordonsstatus.
+
+## Trigger
+
+`vehicle_journey_events_layer2_process_trigger` kör efter INSERT i `vehicle_journey_events`.
+
+Funktionen `materialize_layer2_process_trigger_from_layer1()`:
+
+1. läser den redan etablerade Layer 1-händelsen,
+2. hittar exakta aktiva adapterdefinitioner,
+3. skriver idempotent `process_trigger_events`,
+4. ändrar ingenting i Layer 1.
+
+## Ingen verksamhetsregel uppfinns i v1
+
+L2.4 v1 seedar medvetet **ingen aktiv adapter**.
+
+Revisionsakten kräver att planerad/faktisk starthändelse för varje vertikal först låses som verksamhetsregel. Därför är själva adaptermotorn deploybar nu, medan aktivering av en konkret mapping görs först när den regeln är explicit beslutad.
+
+Detta hindrar exempelvis att RENTAL, AVAILABLE, DOWNTIME eller SÅLD felaktigt börjar starta en Layer 2-process bara för att tekniken kan observera händelsen.
+
+## Säkerhet
+
+- nya tabeller har RLS
+- `anon` och `authenticated` saknar privileges
+- skrivning är service-role/server-only
+- triggerfunktionen är SECURITY DEFINER med `search_path = pg_catalog`
+- `process_trigger_events` är append-only
+
+## Utanför scope
+
+- ingen Layer 1-write
+- ingen automatisk SALU-statusändring
+- ingen ny business mapping utan beslutad regel
+- ingen RBAC/mandatmodell
+- ingen SLA/timer
+- ingen UI/cockpit
+- ingen Kistan

--- a/lib/source-trigger-adapter.ts
+++ b/lib/source-trigger-adapter.ts
@@ -1,0 +1,52 @@
+export type SourceTriggerAdapterDefinition = {
+  adapterCode: string;
+  adapterVersion: number;
+  sourceLayer: 'LAYER1';
+  sourceSystem: string;
+  sourceEntity: string;
+  sourceEventType: string;
+  processCode: string;
+  processVersion: number;
+  routineCode?: string | null;
+  routineVersion?: number | null;
+  active: boolean;
+};
+
+export type Layer1JourneyEvent = {
+  eventId: string;
+  regnr: string;
+  eventType: string;
+  sourceSystem: string;
+  sourceEntity?: string | null;
+};
+
+export function matchesSourceTriggerAdapter(
+  definition: SourceTriggerAdapterDefinition,
+  event: Layer1JourneyEvent,
+): boolean {
+  if (!definition.active) return false;
+
+  const sourceEntity = event.sourceEntity ?? 'vehicle_journey_events';
+
+  return (
+    definition.sourceLayer === 'LAYER1' &&
+    definition.sourceSystem === event.sourceSystem &&
+    definition.sourceEntity === sourceEntity &&
+    definition.sourceEventType === event.eventType
+  );
+}
+
+export function validateSourceTriggerAdapter(
+  definition: SourceTriggerAdapterDefinition,
+): void {
+  const hasRoutineCode = Boolean(definition.routineCode);
+  const hasRoutineVersion = definition.routineVersion != null;
+
+  if (hasRoutineCode !== hasRoutineVersion) {
+    throw new Error('Routine code and version must be configured together');
+  }
+
+  if (definition.adapterVersion <= 0 || definition.processVersion <= 0) {
+    throw new Error('Adapter and process versions must be positive');
+  }
+}

--- a/migrations/20260823183500_add_layer1_source_trigger_adapters_v1.sql
+++ b/migrations/20260823183500_add_layer1_source_trigger_adapters_v1.sql
@@ -1,0 +1,191 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+-- Layer 2.4: Layer 1 source-trigger adapters.
+-- This layer may observe verified Layer 1 journey events and emit Layer 2 trigger facts.
+-- It never mutates Layer 1 facts and never invents a process mapping that has not been configured.
+create table public.source_trigger_adapter_definitions (
+  adapter_code text not null,
+  adapter_version integer not null check (adapter_version > 0),
+  source_layer text not null default 'LAYER1' check (source_layer = 'LAYER1'),
+  source_system text not null check (length(trim(source_system)) between 1 and 120),
+  source_entity text not null check (length(trim(source_entity)) between 1 and 120),
+  source_event_type text not null check (length(trim(source_event_type)) between 1 and 160),
+  process_code text not null,
+  process_version integer not null,
+  routine_code text,
+  routine_version integer,
+  active boolean not null default false,
+  valid_from timestamptz not null default now(),
+  changed_by uuid,
+  changed_at timestamptz not null default now(),
+  primary key (adapter_code, adapter_version),
+  foreign key (process_code, process_version)
+    references public.process_definitions(process_code, process_version)
+    on delete restrict,
+  foreign key (routine_code, routine_version)
+    references public.routine_definitions(routine_code, routine_version)
+    on delete restrict,
+  check (adapter_code ~ '^[A-Z0-9][A-Z0-9_-]{1,79}$'),
+  check ((routine_code is null) = (routine_version is null))
+);
+
+create unique index source_trigger_adapter_one_active_version_uidx
+  on public.source_trigger_adapter_definitions (adapter_code)
+  where active;
+
+create index source_trigger_adapter_match_idx
+  on public.source_trigger_adapter_definitions (
+    source_system,
+    source_entity,
+    source_event_type,
+    active
+  );
+
+create table public.process_trigger_events (
+  process_trigger_event_id uuid primary key default gen_random_uuid(),
+  adapter_code text not null,
+  adapter_version integer not null,
+  source_journey_event_id uuid not null
+    references public.vehicle_journey_events(event_id) on delete restrict,
+  process_code text not null,
+  process_version integer not null,
+  routine_code text,
+  routine_version integer,
+  regnr text not null check (length(trim(regnr)) > 0),
+  source_system text not null,
+  source_entity text not null,
+  source_record_id text,
+  source_event_type text not null,
+  source_event_key text,
+  source_occurred_at timestamptz not null,
+  payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  foreign key (adapter_code, adapter_version)
+    references public.source_trigger_adapter_definitions(adapter_code, adapter_version)
+    on delete restrict,
+  foreign key (process_code, process_version)
+    references public.process_definitions(process_code, process_version)
+    on delete restrict,
+  foreign key (routine_code, routine_version)
+    references public.routine_definitions(routine_code, routine_version)
+    on delete restrict,
+  unique (adapter_code, adapter_version, source_journey_event_id),
+  check ((routine_code is null) = (routine_version is null)),
+  check (jsonb_typeof(payload) = 'object')
+);
+
+create index process_trigger_events_regnr_time_idx
+  on public.process_trigger_events (regnr, source_occurred_at desc);
+create index process_trigger_events_process_idx
+  on public.process_trigger_events (process_code, process_version, source_occurred_at desc);
+
+create or replace function public.reject_process_trigger_event_mutation()
+returns trigger
+language plpgsql
+security invoker
+set search_path = pg_catalog
+as $$
+begin
+  raise exception 'process_trigger_events is append-only; write a new source event instead';
+end;
+$$;
+
+create trigger process_trigger_events_append_only_update
+before update on public.process_trigger_events
+for each row execute function public.reject_process_trigger_event_mutation();
+
+create trigger process_trigger_events_append_only_delete
+before delete on public.process_trigger_events
+for each row execute function public.reject_process_trigger_event_mutation();
+
+create or replace function public.materialize_layer2_process_trigger_from_layer1()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog
+as $$
+declare
+  v_adapter record;
+begin
+  for v_adapter in
+    select d.*
+    from public.source_trigger_adapter_definitions d
+    where d.active
+      and d.source_layer = 'LAYER1'
+      and d.source_system = new.source_system
+      and d.source_entity = coalesce(new.source_entity, 'vehicle_journey_events')
+      and d.source_event_type = new.event_type
+    order by d.adapter_code, d.adapter_version
+  loop
+    insert into public.process_trigger_events (
+      adapter_code,
+      adapter_version,
+      source_journey_event_id,
+      process_code,
+      process_version,
+      routine_code,
+      routine_version,
+      regnr,
+      source_system,
+      source_entity,
+      source_record_id,
+      source_event_type,
+      source_event_key,
+      source_occurred_at,
+      payload
+    ) values (
+      v_adapter.adapter_code,
+      v_adapter.adapter_version,
+      new.event_id,
+      v_adapter.process_code,
+      v_adapter.process_version,
+      v_adapter.routine_code,
+      v_adapter.routine_version,
+      upper(trim(new.regnr)),
+      new.source_system,
+      coalesce(new.source_entity, 'vehicle_journey_events'),
+      new.source_record_id,
+      new.event_type,
+      new.event_key,
+      new.occurred_at,
+      pg_catalog.jsonb_build_object(
+        'sourcePayload', new.payload,
+        'actorId', new.actor_id,
+        'actorSource', new.actor_source,
+        'actorName', new.actor_name,
+        'actorEmail', new.actor_email,
+        'correctionOfEventId', new.correction_of_event_id
+      )
+    )
+    on conflict (adapter_code, adapter_version, source_journey_event_id)
+    do nothing;
+  end loop;
+
+  return new;
+end;
+$$;
+
+create trigger vehicle_journey_events_layer2_process_trigger
+after insert on public.vehicle_journey_events
+for each row execute function public.materialize_layer2_process_trigger_from_layer1();
+
+alter table public.source_trigger_adapter_definitions enable row level security;
+alter table public.process_trigger_events enable row level security;
+
+revoke all on public.source_trigger_adapter_definitions from public, anon, authenticated;
+revoke all on public.process_trigger_events from public, anon, authenticated;
+revoke all on function public.reject_process_trigger_event_mutation() from public, anon, authenticated;
+revoke all on function public.materialize_layer2_process_trigger_from_layer1() from public, anon, authenticated;
+
+grant select, insert, update, delete on public.source_trigger_adapter_definitions to service_role;
+grant select, insert on public.process_trigger_events to service_role;
+grant execute on function public.reject_process_trigger_event_mutation() to service_role;
+grant execute on function public.materialize_layer2_process_trigger_from_layer1() to service_role;
+
+-- Intentionally no active adapter seed in v1.
+-- The revisionsakt explicitly requires each business trigger to be written as a business rule first.
+
+commit;

--- a/tests/source-trigger-adapter.test.ts
+++ b/tests/source-trigger-adapter.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  matchesSourceTriggerAdapter,
+  validateSourceTriggerAdapter,
+  type SourceTriggerAdapterDefinition,
+} from '../lib/source-trigger-adapter';
+
+const baseDefinition: SourceTriggerAdapterDefinition = {
+  adapterCode: 'TEST_LAYER1_TO_PROCESS',
+  adapterVersion: 1,
+  sourceLayer: 'LAYER1',
+  sourceSystem: 'INCHECKAD',
+  sourceEntity: 'vehicle_journey_events',
+  sourceEventType: 'TEST_EVENT',
+  processCode: 'SALU',
+  processVersion: 1,
+  routineCode: 'SALU_CYCLE',
+  routineVersion: 1,
+  active: true,
+};
+
+test('active adapter matches exact Layer 1 source contract', () => {
+  assert.equal(
+    matchesSourceTriggerAdapter(baseDefinition, {
+      eventId: 'event-1',
+      regnr: 'ABC123',
+      eventType: 'TEST_EVENT',
+      sourceSystem: 'INCHECKAD',
+      sourceEntity: 'vehicle_journey_events',
+    }),
+    true,
+  );
+});
+
+test('inactive adapter cannot emit a process trigger', () => {
+  assert.equal(
+    matchesSourceTriggerAdapter(
+      { ...baseDefinition, active: false },
+      {
+        eventId: 'event-1',
+        regnr: 'ABC123',
+        eventType: 'TEST_EVENT',
+        sourceSystem: 'INCHECKAD',
+        sourceEntity: 'vehicle_journey_events',
+      },
+    ),
+    false,
+  );
+});
+
+test('source event type is exact and not inferred', () => {
+  assert.equal(
+    matchesSourceTriggerAdapter(baseDefinition, {
+      eventId: 'event-2',
+      regnr: 'ABC123',
+      eventType: 'OTHER_EVENT',
+      sourceSystem: 'INCHECKAD',
+      sourceEntity: 'vehicle_journey_events',
+    }),
+    false,
+  );
+});
+
+test('routine identity must be configured atomically', () => {
+  assert.throws(
+    () => validateSourceTriggerAdapter({ ...baseDefinition, routineVersion: null }),
+    /configured together/,
+  );
+});
+
+test('process-only adapter is valid when routine is intentionally omitted', () => {
+  assert.doesNotThrow(() =>
+    validateSourceTriggerAdapter({
+      ...baseDefinition,
+      routineCode: null,
+      routineVersion: null,
+    }),
+  );
+});


### PR DESCRIPTION
## Syfte
Etablera ett generiskt, server-only adapterlager från verifierade Layer 1 journey events till Layer 2 process triggers.

## Kontrakt
- Layer 1-fakta observeras men muteras aldrig
- endast exakta, aktiva adapterdefinitioner får materialisera process-trigger-events
- process-trigger-events är append-only och idempotenta per adapter + source journey event
- ingen verksamhetsregel uppfinns i v1

## Viktig avgränsning
Den här PR:n seedar medvetet **ingen aktiv business mapping**. Revisionsakten kräver att varje planerad/faktisk starthändelse först låses som verksamhetsregel. Motorn kan därför deployas utan att RENTAL/AVAILABLE/DOWNTIME/SÅLD eller annan Layer 1-händelse börjar starta processer på antagande.

## Innehåll
- `source_trigger_adapter_definitions`
- `process_trigger_events`
- `materialize_layer2_process_trigger_from_layer1()`
- append-only guard
- TypeScript matcher/validator
- regressionstester
- kontraktsdokumentation

Ingen Layer 1-write. Ingen SALU-state write. Ingen RBAC/SLA/UI/Kistan.