### PR TITLE
Phase 3: Export Tower drift evidence

### DIFF
--- a/app/tower/tower-client.tsx
+++ b/app/tower/tower-client.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { buildTowerCsv } from '@/lib/tower-export';
 import styles from './tower.module.css';
 
 type CockpitItem = {
@@ -74,6 +75,10 @@ async function fetchCockpit(): Promise<CockpitData> {
   return payload.data as CockpitData;
 }
 
+function safeFilePart(value: string): string {
+  return value.replaceAll(':', '-').replaceAll('.', '-');
+}
+
 export default function OperatorCockpit() {
   const [data, setData] = useState<CockpitData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -129,6 +134,20 @@ export default function OperatorCockpit() {
     });
   }, [data, station, query]);
 
+  const exportCurrentView = useCallback(() => {
+    if (!data || items.length === 0) return;
+    const csv = buildTowerCsv(items, data.generatedAt);
+    const blob = new Blob([`\uFEFF${csv}`], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `incheckad-tower-${safeFilePart(data.generatedAt)}.csv`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }, [data, items]);
+
   return (
     <main className={styles.shell}>
       <header className={styles.header}>
@@ -139,6 +158,9 @@ export default function OperatorCockpit() {
         </div>
         <div className={styles.headerActions}>
           <Link className={styles.secondaryButton} href="/">Startsida</Link>
+          <button className={styles.secondaryButton} type="button" onClick={exportCurrentView} disabled={!data || items.length === 0}>
+            Exportera CSV
+          </button>
           <button className={styles.primaryButton} type="button" onClick={() => void load()} disabled={loading}>
             {loading ? 'Uppdaterar…' : 'Uppdatera'}
           </button>

--- a/lib/tower-export.ts
+++ b/lib/tower-export.ts
@@ -1,0 +1,57 @@
+export type TowerExportItem = {
+  regnr: string;
+  station: string | null;
+  state: string | null;
+  stateStartedAt: string | null;
+  downtimeReason: string | null;
+  attention: string[];
+  ownerFunctions: string[];
+  actionStatus: string | null;
+  deadlineAt: string | null;
+  overdue: boolean;
+  waitingVerification: boolean;
+  nextSteps: string[];
+};
+
+function csvCell(value: string | number | boolean | null | undefined): string {
+  const text = value == null ? '' : String(value);
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+export function buildTowerCsv(items: TowerExportItem[], generatedAt: string): string {
+  const header = [
+    'generated_at',
+    'regnr',
+    'station',
+    'state',
+    'state_started_at',
+    'downtime_reason',
+    'attention',
+    'owner_functions',
+    'action_status',
+    'deadline_at',
+    'overdue',
+    'waiting_verification',
+    'next_steps',
+  ];
+
+  const rows = items.map((item) => [
+    generatedAt,
+    item.regnr,
+    item.station,
+    item.state,
+    item.stateStartedAt,
+    item.downtimeReason,
+    item.attention.join(' | '),
+    item.ownerFunctions.join(' | '),
+    item.actionStatus,
+    item.deadlineAt,
+    item.overdue,
+    item.waitingVerification,
+    item.nextSteps.join(' | '),
+  ]);
+
+  return [header, ...rows]
+    .map((row) => row.map((value) => csvCell(value)).join(','))
+    .join('\n');
+}

--- a/lib/tower-export.ts
+++ b/lib/tower-export.ts
@@ -13,8 +13,12 @@ export type TowerExportItem = {
   nextSteps: string[];
 };
 
+function neutralizeSpreadsheetFormula(text: string): string {
+  return /^[\t\r\n ]*[=+\-@]/.test(text) ? `'${text}` : text;
+}
+
 function csvCell(value: string | number | boolean | null | undefined): string {
-  const text = value == null ? '' : String(value);
+  const text = value == null ? '' : neutralizeSpreadsheetFormula(String(value));
   return `"${text.replaceAll('"', '""')}"`;
 }
 

--- a/tests/tower-export.test.ts
+++ b/tests/tower-export.test.ts
@@ -48,3 +48,26 @@ test('Tower CSV export escapes quotes and never invents missing values', () => {
   assert.match(csv, /"Väntar på ""del"""/);
   assert.match(csv, /"XYZ789","","",""/);
 });
+
+test('Tower CSV export neutralizes spreadsheet formulas from operational text', () => {
+  const csv = buildTowerCsv([
+    {
+      regnr: 'FORM01',
+      station: 'MALMÖ',
+      state: 'DOWNTIME',
+      stateStartedAt: null,
+      downtimeReason: '=HYPERLINK("https://example.invalid","x")',
+      attention: [],
+      ownerFunctions: ['+SUM(A1:A2)'],
+      actionStatus: null,
+      deadlineAt: null,
+      overdue: false,
+      waitingVerification: false,
+      nextSteps: [' @cmd'],
+    },
+  ], '2026-08-25T02:00:00.000Z');
+
+  assert.match(csv, /"'=HYPERLINK\(""https:\/\/example\.invalid"",""x""\)"/);
+  assert.match(csv, /"'\+SUM\(A1:A2\)"/);
+  assert.match(csv, /"' @cmd"/);
+});

--- a/tests/tower-export.test.ts
+++ b/tests/tower-export.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildTowerCsv } from '../lib/tower-export';
+
+test('Tower CSV export preserves operational evidence fields', () => {
+  const csv = buildTowerCsv([
+    {
+      regnr: 'ABC123',
+      station: 'MALMÖ',
+      state: 'DOWNTIME',
+      stateStartedAt: '2026-08-25T00:00:00.000Z',
+      downtimeReason: 'Skada, vänster dörr',
+      attention: ['DOWNTIME', 'FÖRSENAD'],
+      ownerFunctions: ['BILKONTROLL'],
+      actionStatus: 'IN_PROGRESS',
+      deadlineAt: '2026-08-25T01:00:00.000Z',
+      overdue: true,
+      waitingVerification: false,
+      nextSteps: ['Genomför åtgärd'],
+    },
+  ], '2026-08-25T02:00:00.000Z');
+
+  assert.match(csv, /"generated_at","regnr","station","state"/);
+  assert.match(csv, /"ABC123"/);
+  assert.match(csv, /"DOWNTIME \| FÖRSENAD"/);
+  assert.match(csv, /"Skada, vänster dörr"/);
+  assert.match(csv, /"true","false"/);
+});
+
+test('Tower CSV export escapes quotes and never invents missing values', () => {
+  const csv = buildTowerCsv([
+    {
+      regnr: 'XYZ789',
+      station: null,
+      state: null,
+      stateStartedAt: null,
+      downtimeReason: 'Väntar på "del"',
+      attention: [],
+      ownerFunctions: [],
+      actionStatus: null,
+      deadlineAt: null,
+      overdue: false,
+      waitingVerification: true,
+      nextSteps: [],
+    },
+  ], '2026-08-25T02:00:00.000Z');
+
+  assert.match(csv, /"Väntar på ""del"""/);
+  assert.match(csv, /"XYZ789","","",""/);
+});


### PR DESCRIPTION
## Syfte
Första avgränsade steget efter stängda Lager 1 och Lager 2: samla verklig operativ driftdata utan att ändra någon källa, affärsregel eller processsemantik.

## Ändring
- lägger till CSV-export av den aktuellt filtrerade Tower-vyn
- exporterar endast redan lästa/verifierade operativa fält: fordon, station, tillstånd, starttid, downtime-orsak, blockerare, ansvar, actionstatus, deadline, overdue, väntar verifiering och nästa steg
- exporten sker helt klient-side från Tower-readmodelen
- lägger till ren CSV-serializer och regressionstest för fältbevarande, tomma värden och escaping

## Arkitekturgräns
- ingen databasändring
- ingen write-path
- ingen förändring i Lager 1
- ingen förändring i Lager 2-processkontrakt
- ingen Kistan
- ingen ny sanning eller inferens

Detta är ett drift/evidenssteg: Tower kan nu användas för att ta ut verkliga operativa snapshots för analys innan nästa affärsvertikal eller monetära lager byggs.