### PR TITLE
Phase 3: Read-only Tower drift history

### DIFF
--- a/app/api/operator-history/route.ts
+++ b/app/api/operator-history/route.ts
@@ -1,0 +1,175 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+type GenericRow = Record<string, unknown>;
+
+type DriftEvent = {
+  occurredAt: string;
+  regnr: string | null;
+  source: 'VEHICLE_JOURNEY' | 'CHECKPOINT_ACTION' | 'HANDOFF';
+  eventType: string;
+  status: string | null;
+  checkpointCode: string | null;
+  sourceSystem: string | null;
+  sourceEntity: string | null;
+  actorSource: string | null;
+  actorEmail: string | null;
+};
+
+const ALLOWED_WINDOWS = new Set([24, 72, 168]);
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+function text(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function jsonObject(value: unknown): GenericRow {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as GenericRow : {};
+}
+
+function iso(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const requestedWindow = Number(new URL(request.url).searchParams.get('hours') ?? '24');
+  const hours = ALLOWED_WINDOWS.has(requestedWindow) ? requestedWindow : 24;
+  const since = new Date(Date.now() - hours * 3_600_000).toISOString();
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[operator-history] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Operator history unavailable' }, { status: 503 });
+  }
+
+  try {
+    const [journeyRes, actionEventsRes, handoffEventsRes] = await Promise.all([
+      admin.from('vehicle_journey_events')
+        .select('regnr,event_type,occurred_at,source_system,source_entity,actor_source,actor_email,payload')
+        .gte('occurred_at', since)
+        .order('occurred_at', { ascending: false })
+        .limit(1500),
+      admin.from('checkpoint_action_events')
+        .select('event_type,status,occurred_at,actor_source,actor_email,checkpoint_id,vehicle_checkpoints!inner(regnr,checkpoint_code)')
+        .gte('occurred_at', since)
+        .order('occurred_at', { ascending: false })
+        .limit(1000),
+      admin.from('handoff_events')
+        .select('event_type,status,occurred_at,actor_source,actor_email,handoffs!inner(regnr,handoff_code)')
+        .gte('occurred_at', since)
+        .order('occurred_at', { ascending: false })
+        .limit(1000),
+    ]);
+
+    const failed = [journeyRes, actionEventsRes, handoffEventsRes].find((response) => response.error);
+    if (failed?.error) throw failed.error;
+
+    const events: DriftEvent[] = [];
+
+    for (const row of (journeyRes.data ?? []) as GenericRow[]) {
+      const occurredAt = iso(row.occurred_at);
+      if (!occurredAt) continue;
+      const payload = jsonObject(row.payload);
+      events.push({
+        occurredAt,
+        regnr: text(row.regnr)?.toUpperCase() ?? null,
+        source: 'VEHICLE_JOURNEY',
+        eventType: text(row.event_type) ?? 'UNKNOWN',
+        status: text(payload.status) ?? text(payload.periodType),
+        checkpointCode: text(payload.checkpointCode),
+        sourceSystem: text(row.source_system),
+        sourceEntity: text(row.source_entity),
+        actorSource: text(row.actor_source),
+        actorEmail: text(row.actor_email),
+      });
+    }
+
+    for (const row of (actionEventsRes.data ?? []) as GenericRow[]) {
+      const occurredAt = iso(row.occurred_at);
+      if (!occurredAt) continue;
+      const checkpoint = jsonObject(row.vehicle_checkpoints);
+      events.push({
+        occurredAt,
+        regnr: text(checkpoint.regnr)?.toUpperCase() ?? null,
+        source: 'CHECKPOINT_ACTION',
+        eventType: text(row.event_type) ?? 'UNKNOWN',
+        status: text(row.status),
+        checkpointCode: text(checkpoint.checkpoint_code),
+        sourceSystem: 'CHECKPOINT_ENGINE',
+        sourceEntity: 'checkpoint_action_events',
+        actorSource: text(row.actor_source),
+        actorEmail: text(row.actor_email),
+      });
+    }
+
+    for (const row of (handoffEventsRes.data ?? []) as GenericRow[]) {
+      const occurredAt = iso(row.occurred_at);
+      if (!occurredAt) continue;
+      const handoff = jsonObject(row.handoffs);
+      events.push({
+        occurredAt,
+        regnr: text(handoff.regnr)?.toUpperCase() ?? null,
+        source: 'HANDOFF',
+        eventType: text(row.event_type) ?? 'UNKNOWN',
+        status: text(row.status),
+        checkpointCode: text(handoff.handoff_code),
+        sourceSystem: 'PROCESS_ENGINE',
+        sourceEntity: 'handoff_events',
+        actorSource: text(row.actor_source),
+        actorEmail: text(row.actor_email),
+      });
+    }
+
+    events.sort((a, b) => Date.parse(b.occurredAt) - Date.parse(a.occurredAt));
+
+    const byType = new Map<string, number>();
+    const vehicles = new Set<string>();
+    let manualEvents = 0;
+    for (const event of events) {
+      byType.set(event.eventType, (byType.get(event.eventType) ?? 0) + 1);
+      if (event.regnr) vehicles.add(event.regnr);
+      if (event.actorSource === 'MANUELL') manualEvents += 1;
+    }
+
+    return NextResponse.json({
+      data: {
+        generatedAt: new Date().toISOString(),
+        hours,
+        since,
+        summary: {
+          events: events.length,
+          vehicles: vehicles.size,
+          manualEvents,
+          systemEvents: events.filter((event) => event.actorSource === 'SYSTEM').length,
+          handoffEvents: events.filter((event) => event.source === 'HANDOFF').length,
+          actionEvents: events.filter((event) => event.source === 'CHECKPOINT_ACTION').length,
+        },
+        eventTypes: [...byType.entries()]
+          .map(([eventType, count]) => ({ eventType, count }))
+          .sort((a, b) => b.count - a.count || a.eventType.localeCompare(b.eventType)),
+        events: events.slice(0, 500),
+      },
+    });
+  } catch (error) {
+    console.error('[operator-history] Read failed:', error);
+    return NextResponse.json({ error: 'Could not load operator history' }, { status: 500 });
+  }
+}

--- a/app/api/operator-history/route.ts
+++ b/app/api/operator-history/route.ts
@@ -14,7 +14,6 @@ type DriftEvent = {
   sourceSystem: string | null;
   sourceEntity: string | null;
   actorSource: string | null;
-  actorEmail: string | null;
 };
 
 const ALLOWED_WINDOWS = new Set([24, 72, 168]);
@@ -63,17 +62,17 @@ export async function GET(request: Request) {
   try {
     const [journeyRes, actionEventsRes, handoffEventsRes] = await Promise.all([
       admin.from('vehicle_journey_events')
-        .select('regnr,event_type,occurred_at,source_system,source_entity,actor_source,actor_email,payload')
+        .select('regnr,event_type,occurred_at,source_system,source_entity,actor_source,payload')
         .gte('occurred_at', since)
         .order('occurred_at', { ascending: false })
         .limit(1500),
       admin.from('checkpoint_action_events')
-        .select('event_type,status,occurred_at,actor_source,actor_email,checkpoint_id,vehicle_checkpoints!inner(regnr,checkpoint_code)')
+        .select('event_type,status,occurred_at,actor_source,checkpoint_id')
         .gte('occurred_at', since)
         .order('occurred_at', { ascending: false })
         .limit(1000),
       admin.from('handoff_events')
-        .select('event_type,status,occurred_at,actor_source,actor_email,handoffs!inner(regnr,handoff_code)')
+        .select('event_type,status,occurred_at,actor_source,handoff_id')
         .gte('occurred_at', since)
         .order('occurred_at', { ascending: false })
         .limit(1000),
@@ -81,6 +80,30 @@ export async function GET(request: Request) {
 
     const failed = [journeyRes, actionEventsRes, handoffEventsRes].find((response) => response.error);
     if (failed?.error) throw failed.error;
+
+    const actionEvents = (actionEventsRes.data ?? []) as GenericRow[];
+    const handoffEvents = (handoffEventsRes.data ?? []) as GenericRow[];
+    const checkpointIds = [...new Set(actionEvents.map((row) => text(row.checkpoint_id)).filter((value): value is string => Boolean(value)))];
+    const handoffIds = [...new Set(handoffEvents.map((row) => text(row.handoff_id)).filter((value): value is string => Boolean(value)))];
+
+    const [checkpointsRes, handoffsRes] = await Promise.all([
+      checkpointIds.length
+        ? admin.from('vehicle_checkpoints').select('checkpoint_id,regnr,checkpoint_code').in('checkpoint_id', checkpointIds)
+        : Promise.resolve({ data: [], error: null }),
+      handoffIds.length
+        ? admin.from('handoffs').select('handoff_id,regnr,handoff_code').in('handoff_id', handoffIds)
+        : Promise.resolve({ data: [], error: null }),
+    ]);
+
+    const relationFailure = [checkpointsRes, handoffsRes].find((response) => response.error);
+    if (relationFailure?.error) throw relationFailure.error;
+
+    const checkpointMap = new Map(
+      ((checkpointsRes.data ?? []) as GenericRow[]).map((row) => [String(row.checkpoint_id), row]),
+    );
+    const handoffMap = new Map(
+      ((handoffsRes.data ?? []) as GenericRow[]).map((row) => [String(row.handoff_id), row]),
+    );
 
     const events: DriftEvent[] = [];
 
@@ -98,14 +121,13 @@ export async function GET(request: Request) {
         sourceSystem: text(row.source_system),
         sourceEntity: text(row.source_entity),
         actorSource: text(row.actor_source),
-        actorEmail: text(row.actor_email),
       });
     }
 
-    for (const row of (actionEventsRes.data ?? []) as GenericRow[]) {
+    for (const row of actionEvents) {
       const occurredAt = iso(row.occurred_at);
       if (!occurredAt) continue;
-      const checkpoint = jsonObject(row.vehicle_checkpoints);
+      const checkpoint = checkpointMap.get(String(row.checkpoint_id)) ?? {};
       events.push({
         occurredAt,
         regnr: text(checkpoint.regnr)?.toUpperCase() ?? null,
@@ -116,14 +138,13 @@ export async function GET(request: Request) {
         sourceSystem: 'CHECKPOINT_ENGINE',
         sourceEntity: 'checkpoint_action_events',
         actorSource: text(row.actor_source),
-        actorEmail: text(row.actor_email),
       });
     }
 
-    for (const row of (handoffEventsRes.data ?? []) as GenericRow[]) {
+    for (const row of handoffEvents) {
       const occurredAt = iso(row.occurred_at);
       if (!occurredAt) continue;
-      const handoff = jsonObject(row.handoffs);
+      const handoff = handoffMap.get(String(row.handoff_id)) ?? {};
       events.push({
         occurredAt,
         regnr: text(handoff.regnr)?.toUpperCase() ?? null,
@@ -134,7 +155,6 @@ export async function GET(request: Request) {
         sourceSystem: 'PROCESS_ENGINE',
         sourceEntity: 'handoff_events',
         actorSource: text(row.actor_source),
-        actorEmail: text(row.actor_email),
       });
     }
 
@@ -143,10 +163,12 @@ export async function GET(request: Request) {
     const byType = new Map<string, number>();
     const vehicles = new Set<string>();
     let manualEvents = 0;
+    let systemEvents = 0;
     for (const event of events) {
       byType.set(event.eventType, (byType.get(event.eventType) ?? 0) + 1);
       if (event.regnr) vehicles.add(event.regnr);
       if (event.actorSource === 'MANUELL') manualEvents += 1;
+      if (event.actorSource === 'SYSTEM') systemEvents += 1;
     }
 
     return NextResponse.json({
@@ -158,7 +180,7 @@ export async function GET(request: Request) {
           events: events.length,
           vehicles: vehicles.size,
           manualEvents,
-          systemEvents: events.filter((event) => event.actorSource === 'SYSTEM').length,
+          systemEvents,
           handoffEvents: events.filter((event) => event.source === 'HANDOFF').length,
           actionEvents: events.filter((event) => event.source === 'CHECKPOINT_ACTION').length,
         },

--- a/app/tower/history/history-client.tsx
+++ b/app/tower/history/history-client.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import styles from './history.module.css';
+
+type DriftEvent = {
+  occurredAt: string;
+  regnr: string | null;
+  source: 'VEHICLE_JOURNEY' | 'CHECKPOINT_ACTION' | 'HANDOFF';
+  eventType: string;
+  status: string | null;
+  checkpointCode: string | null;
+  sourceSystem: string | null;
+  sourceEntity: string | null;
+  actorSource: string | null;
+};
+
+type HistoryData = {
+  generatedAt: string;
+  hours: number;
+  since: string;
+  summary: {
+    events: number;
+    vehicles: number;
+    manualEvents: number;
+    systemEvents: number;
+    handoffEvents: number;
+    actionEvents: number;
+  };
+  eventTypes: Array<{ eventType: string; count: number }>;
+  events: DriftEvent[];
+};
+
+const WINDOWS = [
+  { hours: 24, label: '24 timmar' },
+  { hours: 72, label: '72 timmar' },
+  { hours: 168, label: '7 dagar' },
+] as const;
+
+function formatDate(value: string | null): string {
+  if (!value) return '—';
+  return new Intl.DateTimeFormat('sv-SE', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function sourceLabel(source: DriftEvent['source']): string {
+  if (source === 'VEHICLE_JOURNEY') return 'Fordonsresa';
+  if (source === 'CHECKPOINT_ACTION') return 'Action';
+  return 'Handslag';
+}
+
+async function fetchHistory(hours: number): Promise<HistoryData> {
+  const response = await fetch(`/api/operator-history?hours=${hours}`, { cache: 'no-store' });
+  const payload = await response.json();
+  if (!response.ok) throw new Error(payload?.error ?? 'Kunde inte läsa drifthistorik');
+  return payload.data as HistoryData;
+}
+
+export default function OperatorHistory() {
+  const [hours, setHours] = useState(24);
+  const [data, setData] = useState<HistoryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+
+  const load = useCallback(async (windowHours: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      setData(await fetchHistory(windowHours));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Kunde inte läsa drifthistorik');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load(hours);
+  }, [hours, load]);
+
+  const events = useMemo(() => {
+    const needle = query.trim().toUpperCase();
+    if (!needle) return data?.events ?? [];
+    return (data?.events ?? []).filter((event) =>
+      event.regnr?.includes(needle)
+      || event.eventType.toUpperCase().includes(needle)
+      || event.checkpointCode?.toUpperCase().includes(needle)
+      || event.status?.toUpperCase().includes(needle)
+      || sourceLabel(event.source).toUpperCase().includes(needle),
+    );
+  }, [data, query]);
+
+  return (
+    <main className={styles.shell}>
+      <header className={styles.header}>
+        <div>
+          <div className={styles.eyebrow}>INCHECKAD / DRIFT & EVIDENS</div>
+          <h1>Drifthistorik</h1>
+          <p>Vad har faktiskt registrerats i driften över tid?</p>
+        </div>
+        <div className={styles.actions}>
+          <Link className={styles.secondaryButton} href="/tower">Tower</Link>
+          <Link className={styles.secondaryButton} href="/">Startsida</Link>
+          <button className={styles.primaryButton} type="button" onClick={() => void load(hours)} disabled={loading}>
+            {loading ? 'Uppdaterar…' : 'Uppdatera'}
+          </button>
+        </div>
+      </header>
+
+      <div className={styles.notice}>
+        Read-only vy över redan registrerade händelser. Den skapar ingen ny sanning, ändrar inga processer och gör ingen monetär tolkning.
+      </div>
+
+      {error ? <div className={styles.error}>{error}</div> : null}
+
+      <section className={styles.metrics} aria-label="Driftsummering">
+        <Metric title="Händelser" value={data?.summary.events ?? 0} />
+        <Metric title="Fordon" value={data?.summary.vehicles ?? 0} />
+        <Metric title="System" value={data?.summary.systemEvents ?? 0} />
+        <Metric title="Manuella" value={data?.summary.manualEvents ?? 0} />
+        <Metric title="Handslag" value={data?.summary.handoffEvents ?? 0} />
+        <Metric title="Actions" value={data?.summary.actionEvents ?? 0} />
+      </section>
+
+      <section className={styles.controls}>
+        <label>
+          <span>Tidsfönster</span>
+          <select value={hours} onChange={(event) => setHours(Number(event.target.value))}>
+            {WINDOWS.map((window) => <option key={window.hours} value={window.hours}>{window.label}</option>)}
+          </select>
+        </label>
+        <label>
+          <span>Sök</span>
+          <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Reg.nr, händelse, kontrollpunkt eller status" />
+        </label>
+        <div className={styles.generated}>
+          <span>Senast läst</span>
+          <strong>{data ? formatDate(data.generatedAt) : '—'}</strong>
+        </div>
+      </section>
+
+      <section className={styles.breakdown}>
+        <div>
+          <h2>Händelsetyper</h2>
+          <p>Fördelning i valt tidsfönster.</p>
+        </div>
+        <div className={styles.typeList}>
+          {(data?.eventTypes ?? []).slice(0, 12).map((item) => (
+            <span key={item.eventType}><strong>{item.count}</strong> {item.eventType}</span>
+          ))}
+          {!loading && (data?.eventTypes.length ?? 0) === 0 ? <span>Inga registrerade händelser.</span> : null}
+        </div>
+      </section>
+
+      <section className={styles.tableSection}>
+        <div className={styles.tableHeading}>
+          <div>
+            <h2>Verifierad händelsehistorik</h2>
+            <p>Senaste registrerade händelser först. Vagnkortet är fortsatt individvyn för bilen.</p>
+          </div>
+          <strong>{events.length} rader</strong>
+        </div>
+
+        {loading && !data ? (
+          <div className={styles.empty}>Läser registrerad drift…</div>
+        ) : events.length === 0 ? (
+          <div className={styles.empty}>Inga händelser matchar aktuell vy.</div>
+        ) : (
+          <div className={styles.tableWrap}>
+            <table>
+              <thead>
+                <tr>
+                  <th>Tid</th>
+                  <th>Fordon</th>
+                  <th>Källa</th>
+                  <th>Händelse</th>
+                  <th>Status</th>
+                  <th>Kontrollpunkt / handslag</th>
+                  <th>Aktörstyp</th>
+                  <th />
+                </tr>
+              </thead>
+              <tbody>
+                {events.map((event, index) => (
+                  <tr key={`${event.occurredAt}-${event.eventType}-${event.regnr ?? 'none'}-${index}`}>
+                    <td>{formatDate(event.occurredAt)}</td>
+                    <td><strong className={styles.regnr}>{event.regnr ?? '—'}</strong></td>
+                    <td>
+                      <strong>{sourceLabel(event.source)}</strong>
+                      <span className={styles.subtle}>{event.sourceSystem ?? '—'}</span>
+                    </td>
+                    <td><strong>{event.eventType}</strong></td>
+                    <td>{event.status ?? '—'}</td>
+                    <td>{event.checkpointCode ?? '—'}</td>
+                    <td>{event.actorSource ?? '—'}</td>
+                    <td>{event.regnr ? <Link className={styles.openLink} href={`/vagnkort?reg=${encodeURIComponent(event.regnr)}`}>Öppna →</Link> : null}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function Metric({ title, value }: { title: string; value: number }) {
+  return (
+    <div className={styles.metric}>
+      <span>{title}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}

--- a/app/tower/history/history-client.tsx
+++ b/app/tower/history/history-client.tsx
@@ -79,8 +79,24 @@ export default function OperatorHistory() {
   }, []);
 
   useEffect(() => {
-    void load(hours);
-  }, [hours, load]);
+    let active = true;
+    void fetchHistory(24)
+      .then((next) => {
+        if (!active) return;
+        setData(next);
+        setError(null);
+      })
+      .catch((loadError: unknown) => {
+        if (!active) return;
+        setError(loadError instanceof Error ? loadError.message : 'Kunde inte läsa drifthistorik');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const events = useMemo(() => {
     const needle = query.trim().toUpperCase();
@@ -129,7 +145,14 @@ export default function OperatorHistory() {
       <section className={styles.controls}>
         <label>
           <span>Tidsfönster</span>
-          <select value={hours} onChange={(event) => setHours(Number(event.target.value))}>
+          <select
+            value={hours}
+            onChange={(event) => {
+              const nextHours = Number(event.target.value);
+              setHours(nextHours);
+              void load(nextHours);
+            }}
+          >
             {WINDOWS.map((window) => <option key={window.hours} value={window.hours}>{window.label}</option>)}
           </select>
         </label>

--- a/app/tower/history/history.module.css
+++ b/app/tower/history/history.module.css
@@ -1,0 +1,341 @@
+.shell {
+  min-height: 100vh;
+  background: #f3f4f3;
+  color: #111315;
+  padding: 32px clamp(18px, 4vw, 64px) 64px;
+}
+
+.header,
+.metrics,
+.controls,
+.notice,
+.error,
+.breakdown,
+.tableSection {
+  max-width: 1500px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-end;
+  margin-bottom: 20px;
+}
+
+.header h1 {
+  margin: 3px 0 4px;
+  font-size: clamp(40px, 5vw, 72px);
+  letter-spacing: -.055em;
+  line-height: .95;
+  font-weight: 650;
+}
+
+.header p {
+  margin: 10px 0 0;
+  font-size: 18px;
+  color: #606562;
+}
+
+.eyebrow {
+  font-size: 11px;
+  letter-spacing: .18em;
+  font-weight: 750;
+  color: #737875;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.primaryButton,
+.secondaryButton {
+  border: 1px solid #111315;
+  border-radius: 999px;
+  padding: 11px 18px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 650;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.primaryButton {
+  background: #111315;
+  color: #fff;
+}
+
+.secondaryButton {
+  background: transparent;
+  color: #111315;
+}
+
+.primaryButton:disabled {
+  opacity: .55;
+  cursor: default;
+}
+
+.notice,
+.error {
+  margin-bottom: 18px;
+  padding: 13px 16px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #d5d8d5;
+  font-size: 13px;
+}
+
+.error {
+  border-color: #a12929;
+  color: #8a1f1f;
+}
+
+.metrics {
+  margin-bottom: 18px;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 1px;
+  background: #d5d8d5;
+  border: 1px solid #d5d8d5;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.metric {
+  background: #fff;
+  padding: 18px 20px 20px;
+  min-height: 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.metric span,
+.controls label > span,
+.generated > span {
+  color: #717672;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+}
+
+.metric strong {
+  font-size: 34px;
+  line-height: 1;
+  letter-spacing: -.04em;
+  font-weight: 650;
+}
+
+.controls {
+  margin-bottom: 18px;
+  display: grid;
+  grid-template-columns: minmax(190px, .55fr) minmax(320px, 1.45fr) auto;
+  gap: 12px;
+  align-items: end;
+}
+
+.controls label,
+.generated {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.controls select,
+.controls input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #cfd3cf;
+  background: #fff;
+  border-radius: 9px;
+  padding: 11px 12px;
+  font: inherit;
+  color: #111315;
+  outline: none;
+}
+
+.controls select:focus,
+.controls input:focus {
+  border-color: #111315;
+}
+
+.generated {
+  min-width: 150px;
+  padding-bottom: 9px;
+  text-align: right;
+}
+
+.generated strong {
+  font-size: 13px;
+}
+
+.breakdown,
+.tableSection {
+  background: #fff;
+  border: 1px solid #d8dbd8;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.breakdown {
+  padding: 20px 22px;
+  margin-bottom: 18px;
+  display: grid;
+  grid-template-columns: minmax(220px, .45fr) minmax(0, 1.55fr);
+  gap: 20px;
+}
+
+.breakdown h2,
+.tableHeading h2 {
+  margin: 0 0 4px;
+  font-size: 20px;
+  letter-spacing: -.02em;
+}
+
+.breakdown p,
+.tableHeading p {
+  margin: 0;
+  color: #707572;
+  font-size: 13px;
+}
+
+.typeList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  align-content: flex-start;
+}
+
+.typeList span {
+  border: 1px solid #d8dbd8;
+  border-radius: 999px;
+  padding: 7px 10px;
+  font-size: 11px;
+}
+
+.tableHeading {
+  padding: 20px 22px;
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-end;
+  border-bottom: 1px solid #e1e3e1;
+}
+
+.tableHeading > strong {
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.tableWrap {
+  overflow-x: auto;
+}
+
+.tableWrap table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 1180px;
+}
+
+.tableWrap th {
+  text-align: left;
+  font-size: 10px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: #737875;
+  font-weight: 750;
+  padding: 11px 14px;
+  background: #f8f9f8;
+  border-bottom: 1px solid #e5e7e5;
+}
+
+.tableWrap td {
+  vertical-align: top;
+  padding: 14px;
+  border-bottom: 1px solid #eceeec;
+  font-size: 12px;
+}
+
+.tableWrap tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.tableWrap tbody tr:hover {
+  background: #fafbfa;
+}
+
+.regnr {
+  font-size: 15px;
+  letter-spacing: .025em;
+}
+
+.subtle {
+  display: block;
+  margin-top: 4px;
+  color: #777c78;
+  font-size: 11px;
+}
+
+.openLink {
+  color: #111315;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.openLink:hover {
+  text-decoration: underline;
+}
+
+.empty {
+  padding: 54px 22px;
+  text-align: center;
+  color: #6e736f;
+}
+
+@media (max-width: 1100px) {
+  .metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 800px) {
+  .header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .controls,
+  .breakdown {
+    grid-template-columns: 1fr;
+  }
+
+  .generated {
+    text-align: left;
+  }
+}
+
+@media (max-width: 620px) {
+  .shell {
+    padding: 22px 14px 42px;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .actions {
+    width: 100%;
+  }
+
+  .primaryButton,
+  .secondaryButton {
+    flex: 1;
+    text-align: center;
+  }
+}

--- a/app/tower/history/page.tsx
+++ b/app/tower/history/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+import OperatorHistory from './history-client';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Drifthistorik | Incheckad',
+  description: 'Read-only historik över verifierade operativa händelser',
+};
+
+export default function OperatorHistoryPage() {
+  return <OperatorHistory />;
+}

--- a/app/tower/tower-client.tsx
+++ b/app/tower/tower-client.tsx
@@ -158,6 +158,7 @@ export default function OperatorCockpit() {
         </div>
         <div className={styles.headerActions}>
           <Link className={styles.secondaryButton} href="/">Startsida</Link>
+          <Link className={styles.secondaryButton} href="/tower/history">Drifthistorik</Link>
           <button className={styles.secondaryButton} type="button" onClick={exportCurrentView} disabled={!data || items.length === 0}>
             Exportera CSV
           </button>

--- a/tests/operator-history-contract.test.ts
+++ b/tests/operator-history-contract.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const route = readFileSync('app/api/operator-history/route.ts', 'utf8');
+const client = readFileSync('app/tower/history/history-client.tsx', 'utf8');
+const tower = readFileSync('app/tower/tower-client.tsx', 'utf8');
+
+test('operator history is authenticated and read-only', () => {
+  assert.match(route, /verifyApiUser/);
+  assert.match(route, /vehicle_journey_events/);
+  assert.match(route, /checkpoint_action_events/);
+  assert.match(route, /handoff_events/);
+  assert.doesNotMatch(route, /\.insert\(/);
+  assert.doesNotMatch(route, /\.update\(/);
+  assert.doesNotMatch(route, /\.delete\(/);
+  assert.doesNotMatch(route, /\.rpc\(/);
+});
+
+test('operator history reads existing evidence without exposing actor email', () => {
+  assert.match(route, /actor_source/);
+  assert.doesNotMatch(route, /actor_email/);
+  assert.match(route, /ALLOWED_WINDOWS = new Set\(\[24, 72, 168\]\)/);
+  assert.match(route, /events: events\.slice\(0, 500\)/);
+});
+
+test('history UI states its evidence boundary and links back to operational views', () => {
+  assert.match(client, /Vad har faktiskt registrerats i driften över tid\?/);
+  assert.match(client, /Read-only vy över redan registrerade händelser/);
+  assert.match(client, /gör ingen monetär tolkning/);
+  assert.match(client, /\/vagnkort\?reg=/);
+  assert.match(client, /href="\/tower"/);
+  assert.match(tower, /href="\/tower\/history"/);
+});


### PR DESCRIPTION
## Syfte
Nästa avgränsade steg i Fas 3 efter Tower-exporten: göra redan registrerad operativ evidens läsbar över tid utan att skapa nya snapshots eller en parallell sanning.

## Ändring
- ny autentiserad read-only endpoint `/api/operator-history`
- läser befintliga append-only loggar: `vehicle_journey_events`, `checkpoint_action_events` och `handoff_events`
- normaliserar endast visningsfält för tidslinje och summering
- stöder fasta tidsfönster 24 h, 72 h och 7 dagar
- ny UI-vy `/tower/history` med summering, händelsetyper, sökning och kronologisk historik
- länk från Tower till Drifthistorik
- ingen aktörs-e-post exponeras i read-modelen
- regressionstest låser read-only-gränsen

## Arkitekturgräns
- ingen databasändring
- ingen ny event- eller snapshot-tabell
- ingen insert/update/delete/RPC i historik-endpointen
- ingen mutation av Lager 1
- ingen mutation av Lager 2
- ingen Kistan eller monetär tolkning
- Vagnkortet förblir individvyn; Drifthistorik är endast en operativ evidensvy över redan lagrade händelser

Detta steg svarar på: `Vad har faktiskt registrerats i driften över tid?`