### PR TITLE
Phase 3: Read-only drift metrics from operational evidence

### DIFF
--- a/app/api/operator-metrics/route.ts
+++ b/app/api/operator-metrics/route.ts
@@ -1,0 +1,204 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+type GenericRow = Record<string, unknown>;
+
+const ALLOWED_WINDOWS = new Set([24, 72, 168]);
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+function asDate(value: unknown): Date | null {
+  if (typeof value !== 'string') return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function hoursBetween(start: unknown, end: unknown): number | null {
+  const startDate = asDate(start);
+  const endDate = asDate(end);
+  if (!startDate || !endDate) return null;
+  return Math.max(0, (endDate.getTime() - startDate.getTime()) / 3_600_000);
+}
+
+function rounded(value: number | null): number | null {
+  return value == null ? null : Math.round(value * 100) / 100;
+}
+
+function average(values: number[]): number | null {
+  if (!values.length) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function median(values: number[]): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+function groupCount(rows: GenericRow[], key: string) {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const value = typeof row[key] === 'string' && row[key] ? String(row[key]) : 'UNKNOWN';
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const requestedWindow = Number(new URL(request.url).searchParams.get('hours') ?? '168');
+  const hours = ALLOWED_WINDOWS.has(requestedWindow) ? requestedWindow : 168;
+  const now = new Date();
+  const since = new Date(now.getTime() - hours * 3_600_000).toISOString();
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[operator-metrics] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Operator metrics unavailable' }, { status: 503 });
+  }
+
+  try {
+    const [periodsRes, handoffsRes, actionsRes, checkpointsRes] = await Promise.all([
+      admin.from('vehicle_journey_periods')
+        .select('period_type,started_at,ended_at,reason_code')
+        .gte('started_at', since)
+        .order('started_at', { ascending: false })
+        .limit(5000),
+      admin.from('handoffs')
+        .select('handoff_code,status,created_at,handed_over_at,received_at,accepted_at,completed_at,verified_at,cancelled_at')
+        .gte('created_at', since)
+        .order('created_at', { ascending: false })
+        .limit(5000),
+      admin.from('checkpoint_actions')
+        .select('status,created_at,accepted_at,ready_for_verification_at,verified_at,cancelled_at,deadline_at,blocking')
+        .gte('created_at', since)
+        .order('created_at', { ascending: false })
+        .limit(5000),
+      admin.from('vehicle_checkpoints')
+        .select('checkpoint_code,status,created_at,updated_at,blocking')
+        .gte('created_at', since)
+        .order('created_at', { ascending: false })
+        .limit(5000),
+    ]);
+
+    const failed = [periodsRes, handoffsRes, actionsRes, checkpointsRes].find((response) => response.error);
+    if (failed?.error) throw failed.error;
+
+    const periods = (periodsRes.data ?? []) as GenericRow[];
+    const handoffs = (handoffsRes.data ?? []) as GenericRow[];
+    const actions = (actionsRes.data ?? []) as GenericRow[];
+    const checkpoints = (checkpointsRes.data ?? []) as GenericRow[];
+
+    const periodHours = periods
+      .map((row) => hoursBetween(row.started_at, row.ended_at ?? now.toISOString()))
+      .filter((value): value is number => value != null);
+    const closedPeriodHours = periods
+      .filter((row) => row.ended_at)
+      .map((row) => hoursBetween(row.started_at, row.ended_at))
+      .filter((value): value is number => value != null);
+    const downtimeRows = periods.filter((row) => row.period_type === 'DOWNTIME');
+    const downtimeHours = downtimeRows
+      .map((row) => hoursBetween(row.started_at, row.ended_at ?? now.toISOString()))
+      .filter((value): value is number => value != null);
+
+    const handoffAges = handoffs
+      .map((row) => hoursBetween(row.created_at, row.verified_at ?? row.cancelled_at ?? now.toISOString()))
+      .filter((value): value is number => value != null);
+    const verifiedHandoffDurations = handoffs
+      .filter((row) => row.status === 'VERIFIED')
+      .map((row) => hoursBetween(row.created_at, row.verified_at))
+      .filter((value): value is number => value != null);
+
+    const actionAges = actions
+      .map((row) => hoursBetween(row.created_at, row.verified_at ?? row.cancelled_at ?? now.toISOString()))
+      .filter((value): value is number => value != null);
+    const verifiedActionDurations = actions
+      .filter((row) => row.status === 'VERIFIED')
+      .map((row) => hoursBetween(row.created_at, row.verified_at))
+      .filter((value): value is number => value != null);
+
+    const overdueActions = actions.filter((row) => {
+      if (row.status === 'VERIFIED' || row.status === 'CANCELLED') return false;
+      const deadline = asDate(row.deadline_at);
+      return deadline ? deadline.getTime() < now.getTime() : false;
+    }).length;
+
+    const openHandoffs = handoffs.filter((row) => row.status !== 'VERIFIED' && row.status !== 'CANCELLED').length;
+    const openActions = actions.filter((row) => row.status !== 'VERIFIED' && row.status !== 'CANCELLED').length;
+    const deviations = checkpoints.filter((row) => row.status === 'AVVIKELSE').length;
+    const waiting = checkpoints.filter((row) => row.status === 'VANTAR').length;
+
+    const sample = {
+      periods: periods.length,
+      closedPeriods: periods.filter((row) => Boolean(row.ended_at)).length,
+      downtimePeriods: downtimeRows.length,
+      handoffs: handoffs.length,
+      verifiedHandoffs: handoffs.filter((row) => row.status === 'VERIFIED').length,
+      actions: actions.length,
+      verifiedActions: actions.filter((row) => row.status === 'VERIFIED').length,
+      checkpoints: checkpoints.length,
+    };
+
+    return NextResponse.json({
+      data: {
+        generatedAt: now.toISOString(),
+        hours,
+        since,
+        sample,
+        operational: {
+          openHandoffs,
+          openActions,
+          overdueActions,
+          deviations,
+          waitingCheckpoints: waiting,
+        },
+        leadTimes: {
+          handoffAgeAvgHours: rounded(average(handoffAges)),
+          handoffAgeMedianHours: rounded(median(handoffAges)),
+          verifiedHandoffAvgHours: rounded(average(verifiedHandoffDurations)),
+          actionAgeAvgHours: rounded(average(actionAges)),
+          actionAgeMedianHours: rounded(median(actionAges)),
+          verifiedActionAvgHours: rounded(average(verifiedActionDurations)),
+          closedPeriodAvgHours: rounded(average(closedPeriodHours)),
+          closedPeriodMedianHours: rounded(median(closedPeriodHours)),
+          periodObservedAvgHours: rounded(average(periodHours)),
+          downtimeObservedAvgHours: rounded(average(downtimeHours)),
+        },
+        breakdowns: {
+          periodTypes: groupCount(periods, 'period_type'),
+          handoffStatuses: groupCount(handoffs, 'status'),
+          actionStatuses: groupCount(actions, 'status'),
+          checkpointStatuses: groupCount(checkpoints, 'status'),
+        },
+        interpretation: {
+          minimumReliableSample: 10,
+          handoffLeadTimeReliable: verifiedHandoffDurations.length >= 10,
+          actionLeadTimeReliable: verifiedActionDurations.length >= 10,
+          downtimeLeadTimeReliable: downtimeRows.filter((row) => row.ended_at).length >= 10,
+        },
+      },
+    });
+  } catch (error) {
+    console.error('[operator-metrics] Read failed:', error);
+    return NextResponse.json({ error: 'Could not load operator metrics' }, { status: 500 });
+  }
+}

--- a/app/tower/history/history-client.tsx
+++ b/app/tower/history/history-client.tsx
@@ -120,6 +120,7 @@ export default function OperatorHistory() {
         </div>
         <div className={styles.actions}>
           <Link className={styles.secondaryButton} href="/tower">Tower</Link>
+          <Link className={styles.secondaryButton} href="/tower/metrics">Driftmätning</Link>
           <Link className={styles.secondaryButton} href="/">Startsida</Link>
           <button className={styles.primaryButton} type="button" onClick={() => void load(hours)} disabled={loading}>
             {loading ? 'Uppdaterar…' : 'Uppdatera'}

--- a/app/tower/metrics/metrics-client.tsx
+++ b/app/tower/metrics/metrics-client.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import styles from './metrics.module.css';
+
+type CountItem = { label: string; count: number };
+
+type MetricsData = {
+  generatedAt: string;
+  hours: number;
+  since: string;
+  sample: {
+    periods: number;
+    closedPeriods: number;
+    downtimePeriods: number;
+    handoffs: number;
+    verifiedHandoffs: number;
+    actions: number;
+    verifiedActions: number;
+    checkpoints: number;
+  };
+  operational: {
+    openHandoffs: number;
+    openActions: number;
+    overdueActions: number;
+    deviations: number;
+    waitingCheckpoints: number;
+  };
+  leadTimes: {
+    handoffAgeAvgHours: number | null;
+    handoffAgeMedianHours: number | null;
+    verifiedHandoffAvgHours: number | null;
+    actionAgeAvgHours: number | null;
+    actionAgeMedianHours: number | null;
+    verifiedActionAvgHours: number | null;
+    closedPeriodAvgHours: number | null;
+    closedPeriodMedianHours: number | null;
+    periodObservedAvgHours: number | null;
+    downtimeObservedAvgHours: number | null;
+  };
+  breakdowns: {
+    periodTypes: CountItem[];
+    handoffStatuses: CountItem[];
+    actionStatuses: CountItem[];
+    checkpointStatuses: CountItem[];
+  };
+  interpretation: {
+    minimumReliableSample: number;
+    handoffLeadTimeReliable: boolean;
+    actionLeadTimeReliable: boolean;
+    downtimeLeadTimeReliable: boolean;
+  };
+};
+
+const WINDOWS = [
+  { hours: 24, label: '24 timmar' },
+  { hours: 72, label: '72 timmar' },
+  { hours: 168, label: '7 dagar' },
+] as const;
+
+function formatDate(value: string | null): string {
+  if (!value) return '—';
+  return new Intl.DateTimeFormat('sv-SE', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(value));
+}
+
+function formatHours(value: number | null): string {
+  if (value == null) return 'Ej mätbart ännu';
+  if (value < 24) return `${value.toLocaleString('sv-SE', { maximumFractionDigits: 1 })} h`;
+  return `${(value / 24).toLocaleString('sv-SE', { maximumFractionDigits: 1 })} d`;
+}
+
+async function fetchMetrics(hours: number): Promise<MetricsData> {
+  const response = await fetch(`/api/operator-metrics?hours=${hours}`, { cache: 'no-store' });
+  const payload = await response.json();
+  if (!response.ok) throw new Error(payload?.error ?? 'Kunde inte läsa driftmätning');
+  return payload.data as MetricsData;
+}
+
+export default function OperatorMetrics() {
+  const [hours, setHours] = useState(168);
+  const [data, setData] = useState<MetricsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (windowHours: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      setData(await fetchMetrics(windowHours));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Kunde inte läsa driftmätning');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    void fetchMetrics(168)
+      .then((next) => {
+        if (!active) return;
+        setData(next);
+        setError(null);
+      })
+      .catch((loadError: unknown) => {
+        if (!active) return;
+        setError(loadError instanceof Error ? loadError.message : 'Kunde inte läsa driftmätning');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => { active = false; };
+  }, []);
+
+  return (
+    <main className={styles.shell}>
+      <header className={styles.header}>
+        <div>
+          <div className={styles.eyebrow}>INCHECKAD / DRIFT & EVIDENS</div>
+          <h1>Driftmätning</h1>
+          <p>Vad börjar den verifierade driften faktiskt visa?</p>
+        </div>
+        <div className={styles.actions}>
+          <Link className={styles.secondaryButton} href="/tower">Tower</Link>
+          <Link className={styles.secondaryButton} href="/tower/history">Drifthistorik</Link>
+          <button className={styles.primaryButton} type="button" onClick={() => void load(hours)} disabled={loading}>
+            {loading ? 'Uppdaterar…' : 'Uppdatera'}
+          </button>
+        </div>
+      </header>
+
+      <div className={styles.notice}>
+        Read-only mätning från redan registrerad evidens. Små urval markeras som otillräckliga i stället för att tolkas som säkra slutsatser.
+      </div>
+
+      {error ? <div className={styles.error}>{error}</div> : null}
+
+      <section className={styles.controls}>
+        <label>
+          <span>Tidsfönster</span>
+          <select value={hours} onChange={(event) => {
+            const next = Number(event.target.value);
+            setHours(next);
+            void load(next);
+          }}>
+            {WINDOWS.map((window) => <option key={window.hours} value={window.hours}>{window.label}</option>)}
+          </select>
+        </label>
+        <div className={styles.generated}>
+          <span>Senast läst</span>
+          <strong>{data ? formatDate(data.generatedAt) : '—'}</strong>
+        </div>
+      </section>
+
+      <section className={styles.metrics} aria-label="Operativ mätning">
+        <Metric title="Öppna handslag" value={data?.operational.openHandoffs ?? 0} />
+        <Metric title="Öppna actions" value={data?.operational.openActions ?? 0} />
+        <Metric title="Försenade actions" value={data?.operational.overdueActions ?? 0} emphasis />
+        <Metric title="Avvikelser" value={data?.operational.deviations ?? 0} />
+        <Metric title="Väntar kontroll" value={data?.operational.waitingCheckpoints ?? 0} />
+      </section>
+
+      <section className={styles.grid}>
+        <MeasureCard
+          title="Handslag"
+          primary={formatHours(data?.leadTimes.handoffAgeAvgHours ?? null)}
+          secondary={`Median ålder: ${formatHours(data?.leadTimes.handoffAgeMedianHours ?? null)}`}
+          sample={`Urval ${data?.sample.handoffs ?? 0} · verifierade ${data?.sample.verifiedHandoffs ?? 0}`}
+          reliable={data?.interpretation.handoffLeadTimeReliable ?? false}
+        />
+        <MeasureCard
+          title="Actions"
+          primary={formatHours(data?.leadTimes.actionAgeAvgHours ?? null)}
+          secondary={`Median ålder: ${formatHours(data?.leadTimes.actionAgeMedianHours ?? null)}`}
+          sample={`Urval ${data?.sample.actions ?? 0} · verifierade ${data?.sample.verifiedActions ?? 0}`}
+          reliable={data?.interpretation.actionLeadTimeReliable ?? false}
+        />
+        <MeasureCard
+          title="Downtime"
+          primary={formatHours(data?.leadTimes.downtimeObservedAvgHours ?? null)}
+          secondary="Observerad genomsnittlig varaktighet"
+          sample={`Urval ${data?.sample.downtimePeriods ?? 0}`}
+          reliable={data?.interpretation.downtimeLeadTimeReliable ?? false}
+        />
+        <MeasureCard
+          title="Stängda perioder"
+          primary={formatHours(data?.leadTimes.closedPeriodAvgHours ?? null)}
+          secondary={`Median: ${formatHours(data?.leadTimes.closedPeriodMedianHours ?? null)}`}
+          sample={`Stängda ${data?.sample.closedPeriods ?? 0} av ${data?.sample.periods ?? 0}`}
+          reliable={(data?.sample.closedPeriods ?? 0) >= (data?.interpretation.minimumReliableSample ?? 10)}
+        />
+      </section>
+
+      <section className={styles.breakdowns}>
+        <Breakdown title="Periodtyper" items={data?.breakdowns.periodTypes ?? []} />
+        <Breakdown title="Handslagstatus" items={data?.breakdowns.handoffStatuses ?? []} />
+        <Breakdown title="Actionstatus" items={data?.breakdowns.actionStatuses ?? []} />
+        <Breakdown title="Kontrollpunkter" items={data?.breakdowns.checkpointStatuses ?? []} />
+      </section>
+
+      <section className={styles.readingGuide}>
+        <h2>Tolkning</h2>
+        <p>
+          Mätvärdena beskriver endast det valda tidsfönstrets registrerade evidens. Ett ledtidsmått får status <strong>UNDERLAG FINNS</strong> först när minst {data?.interpretation.minimumReliableSample ?? 10} verifierade utfall finns. Fram till dess visas värdet som observation, inte som verksamhetsnorm eller KPI.
+        </p>
+      </section>
+    </main>
+  );
+}
+
+function Metric({ title, value, emphasis = false }: { title: string; value: number; emphasis?: boolean }) {
+  return (
+    <div className={`${styles.metric} ${emphasis && value > 0 ? styles.metricEmphasis : ''}`}>
+      <span>{title}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function MeasureCard({ title, primary, secondary, sample, reliable }: {
+  title: string;
+  primary: string;
+  secondary: string;
+  sample: string;
+  reliable: boolean;
+}) {
+  return (
+    <article className={styles.measureCard}>
+      <div className={styles.measureTop}>
+        <span>{title}</span>
+        <strong className={reliable ? styles.reliable : styles.insufficient}>{reliable ? 'UNDERLAG FINNS' : 'FÖR LITET URVAL'}</strong>
+      </div>
+      <div className={styles.measureValue}>{primary}</div>
+      <p>{secondary}</p>
+      <small>{sample}</small>
+    </article>
+  );
+}
+
+function Breakdown({ title, items }: { title: string; items: CountItem[] }) {
+  return (
+    <article className={styles.breakdown}>
+      <h2>{title}</h2>
+      {items.length ? items.map((item) => (
+        <div className={styles.breakdownRow} key={item.label}>
+          <span>{item.label}</span>
+          <strong>{item.count}</strong>
+        </div>
+      )) : <p>Ingen registrerad data i valt fönster.</p>}
+    </article>
+  );
+}

--- a/app/tower/metrics/metrics.module.css
+++ b/app/tower/metrics/metrics.module.css
@@ -1,0 +1,315 @@
+.shell {
+  min-height: 100vh;
+  background: #f3f4f3;
+  color: #111315;
+  padding: 32px clamp(18px, 4vw, 64px) 64px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-end;
+  margin: 0 auto 24px;
+  max-width: 1500px;
+}
+
+.header h1 {
+  margin: 3px 0 4px;
+  font-size: clamp(40px, 5vw, 72px);
+  letter-spacing: -0.055em;
+  line-height: .95;
+  font-weight: 650;
+}
+
+.header p {
+  margin: 10px 0 0;
+  font-size: 18px;
+  color: #606562;
+}
+
+.eyebrow {
+  font-size: 11px;
+  letter-spacing: .18em;
+  font-weight: 750;
+  color: #737875;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.primaryButton,
+.secondaryButton {
+  border: 1px solid #111315;
+  border-radius: 999px;
+  padding: 11px 18px;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 650;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.primaryButton {
+  background: #111315;
+  color: #fff;
+}
+
+.secondaryButton {
+  background: transparent;
+  color: #111315;
+}
+
+.primaryButton:disabled {
+  opacity: .55;
+  cursor: default;
+}
+
+.notice,
+.error {
+  max-width: 1500px;
+  margin: 0 auto 18px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #d8dbd8;
+}
+
+.error {
+  border-color: #a12929;
+  color: #8a1f1f;
+}
+
+.controls {
+  max-width: 1500px;
+  margin: 0 auto 18px;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+}
+
+.controls label,
+.generated {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.controls label > span,
+.generated > span {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .07em;
+  color: #727773;
+}
+
+.controls select {
+  min-width: 190px;
+  border: 1px solid #cfd3cf;
+  background: #fff;
+  border-radius: 9px;
+  padding: 11px 12px;
+  font: inherit;
+  color: #111315;
+}
+
+.generated {
+  text-align: right;
+}
+
+.generated strong {
+  font-size: 13px;
+}
+
+.metrics {
+  max-width: 1500px;
+  margin: 0 auto 18px;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 1px;
+  background: #d5d8d5;
+  border: 1px solid #d5d8d5;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.metric {
+  background: #fff;
+  padding: 18px 20px 20px;
+  min-height: 104px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.metric span {
+  color: #717672;
+  font-size: 12px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+
+.metric strong {
+  font-size: 38px;
+  line-height: 1;
+  letter-spacing: -.04em;
+  font-weight: 650;
+}
+
+.metricEmphasis strong {
+  text-decoration: underline;
+  text-decoration-thickness: 3px;
+  text-underline-offset: 4px;
+}
+
+.grid,
+.breakdowns {
+  max-width: 1500px;
+  margin: 0 auto 18px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.measureCard,
+.breakdown,
+.readingGuide {
+  background: #fff;
+  border: 1px solid #d8dbd8;
+  border-radius: 14px;
+}
+
+.measureCard {
+  padding: 20px;
+  min-height: 190px;
+}
+
+.measureTop {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.measureTop > span {
+  font-size: 13px;
+  font-weight: 750;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+
+.reliable,
+.insufficient {
+  font-size: 9px;
+  letter-spacing: .07em;
+  border: 1px solid #111315;
+  border-radius: 999px;
+  padding: 4px 6px;
+  white-space: nowrap;
+}
+
+.insufficient {
+  opacity: .55;
+}
+
+.measureValue {
+  margin-top: 30px;
+  font-size: 32px;
+  font-weight: 650;
+  letter-spacing: -.04em;
+}
+
+.measureCard p {
+  margin: 7px 0 16px;
+  color: #686d69;
+  font-size: 13px;
+}
+
+.measureCard small {
+  color: #777c78;
+}
+
+.breakdown {
+  padding: 20px;
+}
+
+.breakdown h2,
+.readingGuide h2 {
+  margin: 0 0 14px;
+  font-size: 18px;
+  letter-spacing: -.02em;
+}
+
+.breakdown p {
+  color: #737875;
+  font-size: 13px;
+}
+
+.breakdownRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 9px 0;
+  border-top: 1px solid #eceeec;
+  font-size: 13px;
+}
+
+.breakdownRow:first-of-type {
+  border-top: 0;
+}
+
+.readingGuide {
+  max-width: 1500px;
+  margin: 0 auto;
+  padding: 20px 22px;
+}
+
+.readingGuide p {
+  margin: 0;
+  color: #565b57;
+  max-width: 1000px;
+  line-height: 1.55;
+}
+
+@media (max-width: 1100px) {
+  .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .grid,
+  .breakdowns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .shell {
+    padding: 22px 14px 42px;
+  }
+
+  .header,
+  .controls {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .generated {
+    text-align: left;
+  }
+
+  .metrics,
+  .grid,
+  .breakdowns {
+    grid-template-columns: 1fr;
+  }
+
+  .actions {
+    width: 100%;
+  }
+}

--- a/app/tower/metrics/page.tsx
+++ b/app/tower/metrics/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import OperatorMetrics from './metrics-client';
+
+export const metadata: Metadata = {
+  title: 'Driftmätning | Incheckad',
+  description: 'Read-only driftmätning från verifierad operativ evidens',
+};
+
+export default function OperatorMetricsPage() {
+  return <OperatorMetrics />;
+}

--- a/app/tower/tower-client.tsx
+++ b/app/tower/tower-client.tsx
@@ -159,6 +159,7 @@ export default function OperatorCockpit() {
         <div className={styles.headerActions}>
           <Link className={styles.secondaryButton} href="/">Startsida</Link>
           <Link className={styles.secondaryButton} href="/tower/history">Drifthistorik</Link>
+          <Link className={styles.secondaryButton} href="/tower/metrics">Driftmätning</Link>
           <button className={styles.secondaryButton} type="button" onClick={exportCurrentView} disabled={!data || items.length === 0}>
             Exportera CSV
           </button>

--- a/tests/operator-metrics-contract.test.ts
+++ b/tests/operator-metrics-contract.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+const routePath = path.join(process.cwd(), 'app/api/operator-metrics/route.ts');
+const routeSource = fs.readFileSync(routePath, 'utf8');
+
+test('operator metrics requires authenticated API access', () => {
+  assert.match(routeSource, /verifyApiUser\(request\)/);
+});
+
+test('operator metrics stays read-only', () => {
+  assert.doesNotMatch(routeSource, /\.insert\(/);
+  assert.doesNotMatch(routeSource, /\.update\(/);
+  assert.doesNotMatch(routeSource, /\.delete\(/);
+  assert.doesNotMatch(routeSource, /\.rpc\(/);
+});
+
+test('operator metrics reads only existing operational evidence projections', () => {
+  assert.match(routeSource, /vehicle_journey_periods/);
+  assert.match(routeSource, /handoffs/);
+  assert.match(routeSource, /checkpoint_actions/);
+  assert.match(routeSource, /vehicle_checkpoints/);
+});
+
+test('operator metrics exposes sample sufficiency instead of asserting KPI truth from sparse data', () => {
+  assert.match(routeSource, /minimumReliableSample: 10/);
+  assert.match(routeSource, /verifiedHandoffDurations\.length >= 10/);
+  assert.match(routeSource, /verifiedActionDurations\.length >= 10/);
+});


### PR DESCRIPTION
## Syfte
Nästa avgränsade steg i Fas 3 efter Drifthistorik: börja mäta faktisk drift utan att göra sparsamma observationer till KPI-sanning.

## Ändring
- ny autentiserad read-only endpoint `/api/operator-metrics`
- läser befintliga operativa projektioner: `vehicle_journey_periods`, `handoffs`, `checkpoint_actions`, `vehicle_checkpoints`
- fasta tidsfönster 24 h, 72 h och 7 dagar
- visar öppna handslag/actions, försenade actions, avvikelser och väntande kontrollpunkter
- beräknar observerad ålder/ledtid för handslag, actions, perioder och downtime
- visar urvalsstorlek och markerar ledtidsmått som `FÖR LITET URVAL` tills minst 10 verifierade utfall finns
- ny UI-vy `/tower/metrics`
- länkar mellan Tower, Drifthistorik och Driftmätning
- regressionstest låser read-only-gränsen och urvalsregeln

## Arkitekturgräns
- ingen databasändring
- ingen insert/update/delete/RPC
- ingen mutation av Lager 1
- ingen mutation av Lager 2
- ingen Kistan eller monetär tolkning
- inga KPI-mål eller verksamhetsnormer skapas av systemet

Detta steg svarar på: `Vad börjar den verifierade driften faktiskt visa?`