### PR TITLE
Tower: expose tank receipt evidence

### DIFF
--- a/app/api/operator-cockpit/route.ts
+++ b/app/api/operator-cockpit/route.ts
@@ -17,6 +17,8 @@ type AttentionItem = {
   overdue: boolean;
   waitingVerification: boolean;
   nextSteps: string[];
+  tankReceipt: { url: string; uploadedAt: string | null } | null;
+  tankReceiptCount: number;
   links: { vagnkort: string };
 };
 
@@ -77,7 +79,7 @@ export async function GET(request: Request) {
   }
 
   try {
-    const [periodsRes, checkpointsRes, checkpointDefsRes, actionsRes, handoffsRes, handoffDefsRes, saluRes, checkinsRes] = await Promise.all([
+    const [periodsRes, checkpointsRes, checkpointDefsRes, actionsRes, handoffsRes, handoffDefsRes, saluRes, checkinsRes, receiptsRes] = await Promise.all([
       admin.from('vehicle_journey_periods')
         .select('period_id,regnr,period_type,started_at,reason_code,reason_text,source_system,source_entity,source_record_id')
         .is('ended_at', null),
@@ -99,9 +101,14 @@ export async function GET(request: Request) {
         .not('completed_at', 'is', null)
         .order('completed_at', { ascending: false })
         .limit(5000),
+      admin.from('vehicle_receipts')
+        .select('regnr,file_url,uploaded_at')
+        .eq('receipt_type', 'tankning')
+        .order('uploaded_at', { ascending: false })
+        .limit(5000),
     ]);
 
-    const responses = [periodsRes, checkpointsRes, checkpointDefsRes, actionsRes, handoffsRes, handoffDefsRes, saluRes, checkinsRes];
+    const responses = [periodsRes, checkpointsRes, checkpointDefsRes, actionsRes, handoffsRes, handoffDefsRes, saluRes, checkinsRes, receiptsRes];
     const failed = responses.find((response) => response.error);
     if (failed?.error) throw failed.error;
 
@@ -113,6 +120,7 @@ export async function GET(request: Request) {
     const handoffDefs = (handoffDefsRes.data ?? []) as GenericRow[];
     const saluFlags = (saluRes.data ?? []) as GenericRow[];
     const checkins = (checkinsRes.data ?? []) as GenericRow[];
+    const receipts = (receiptsRes.data ?? []) as GenericRow[];
 
     const checkpointDefMap = new Map(
       checkpointDefs.map((row) => [`${row.checkpoint_code}:${row.definition_version}`, row]),
@@ -127,6 +135,19 @@ export async function GET(request: Request) {
       const regnr = text(row.regnr)?.toUpperCase();
       const station = text(row.station);
       if (regnr && station && !stationMap.has(regnr)) stationMap.set(regnr, station);
+    }
+
+    const receiptMap = new Map<string, { url: string; uploadedAt: string | null; count: number }>();
+    for (const row of receipts) {
+      const regnr = text(row.regnr)?.toUpperCase();
+      const url = text(row.file_url);
+      if (!regnr || !url) continue;
+      const existing = receiptMap.get(regnr);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        receiptMap.set(regnr, { url, uploadedAt: dateText(row.uploaded_at), count: 1 });
+      }
     }
 
     const openPeriodMap = new Map<string, GenericRow>();
@@ -186,6 +207,7 @@ export async function GET(request: Request) {
       const vehicleActions = openActions.filter((row) => checkpointIds.has(String(row.checkpoint_id)));
       const vehicleHandoffs = openBlockingHandoffs.filter((row) => text(row.regnr)?.toUpperCase() === regnr);
       const vehicleSalu = escalatedSalu.find((row) => text(row.regnr)?.toUpperCase() === regnr);
+      const receipt = receiptMap.get(regnr) ?? null;
 
       const deadlines = vehicleActions
         .map((row) => dateText(row.deadline_at))
@@ -241,6 +263,8 @@ export async function GET(request: Request) {
         overdue,
         waitingVerification,
         nextSteps,
+        tankReceipt: receipt ? { url: receipt.url, uploadedAt: receipt.uploadedAt } : null,
+        tankReceiptCount: receipt?.count ?? 0,
         links: { vagnkort: `/vagnkort?reg=${encodeURIComponent(regnr)}` },
       };
     });

--- a/app/tower/tower-client.tsx
+++ b/app/tower/tower-client.tsx
@@ -18,6 +18,8 @@ type CockpitItem = {
   overdue: boolean;
   waitingVerification: boolean;
   nextSteps: string[];
+  tankReceipt: { url: string; uploadedAt: string | null } | null;
+  tankReceiptCount: number;
   links: { vagnkort: string };
 };
 
@@ -220,6 +222,7 @@ export default function OperatorCockpit() {
                   <th>Ansvar</th>
                   <th>Action / deadline</th>
                   <th>Nästa steg</th>
+                  <th>Evidens</th>
                   <th />
                 </tr>
               </thead>
@@ -252,6 +255,14 @@ export default function OperatorCockpit() {
                     </td>
                     <td>
                       {item.nextSteps.length ? item.nextSteps.map((step) => <span key={step} className={styles.nextStep}>{step}</span>) : '—'}
+                    </td>
+                    <td>
+                      {item.tankReceipt ? (
+                        <>
+                          <a className={styles.openLink} href={item.tankReceipt.url} target="_blank" rel="noopener noreferrer">Tankkvitto →</a>
+                          <span className={styles.subtle}>{formatDate(item.tankReceipt.uploadedAt)}{item.tankReceiptCount > 1 ? ` · ${item.tankReceiptCount} kvitton` : ''}</span>
+                        </>
+                      ) : '—'}
                     </td>
                     <td><Link className={styles.openLink} href={item.links.vagnkort}>Öppna →</Link></td>
                   </tr>

--- a/tests/operator-cockpit-contract.test.ts
+++ b/tests/operator-cockpit-contract.test.ts
@@ -11,6 +11,7 @@ test('operator cockpit is authenticated and read-only', () => {
   assert.doesNotMatch(route, /\.insert\(/);
   assert.doesNotMatch(route, /\.update\(/);
   assert.doesNotMatch(route, /\.delete\(/);
+  assert.doesNotMatch(route, /\.rpc\(/);
 });
 
 test('cockpit answers the locked operational attention questions', () => {
@@ -32,4 +33,15 @@ test('tower links to vagnkort rather than duplicating vehicle history', () => {
   assert.match(route, /\/vagnkort\?reg=/);
   assert.match(client, /Aktuella operativa ärenden/);
   assert.match(client, /Vagnkortet innehåller individresan och evidensen/);
+});
+
+test('tower exposes existing tank receipt evidence without creating a new truth source', () => {
+  assert.match(route, /from\('vehicle_receipts'\)/);
+  assert.match(route, /eq\('receipt_type', 'tankning'\)/);
+  assert.match(route, /select\('regnr,file_url,uploaded_at'\)/);
+  assert.match(route, /tankReceiptCount/);
+  assert.doesNotMatch(route, /uploaded_by_email/);
+  assert.match(client, /Evidens/);
+  assert.match(client, /Tankkvitto/);
+  assert.match(client, /target="_blank"/);
 });


### PR DESCRIPTION
## Syfte
Göra tankkvitton direkt åtkomliga från Tower utan att skapa en ny kvittolösning eller ny sanning.

## Viktig upptäckt
Själva kvittoflödet finns redan i Check-in: när bilen markeras `tankad_nu` kan tankkvitto laddas upp, lagras i `vehicle_receipts` och visas permanent i Vagnkortets dokument/evidensvy. Production har redan verkliga tankkvitton i denna källa.

## Ändring
- Tower läser befintliga `vehicle_receipts` read-only
- endast `receipt_type = tankning`
- senaste tankkvittot exponeras direkt på berörd Tower-rad under `Evidens`
- datum visas och antal kvitton indikeras om bilen har fler än ett
- Vagnkort-länken ligger kvar som permanent individ/evidensvy
- ingen användar-e-post eller annan kvitto-PII läses ut till Tower

## Arkitekturgräns
- ingen databasändring
- ingen ny storage
- ingen mutation av Check-in
- ingen mutation av Lager 1 eller Lager 2
- ingen Kistan eller monetär tolkning
- Tower äger inte kvittot; Tower visar endast en direktlänk till redan registrerad evidens

## Regression
Kontraktstest låser att Operator Cockpit fortsatt är autentiserad och read-only samt att kvittoåtkomsten använder den befintliga evidenskällan.