### PR TITLE
Phase 3: measure tank receipt evidence coverage

### DIFF
--- a/app/api/operator-fuel-evidence/route.ts
+++ b/app/api/operator-fuel-evidence/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const ALLOWED_WINDOWS = new Set([24, 72, 168]);
+
+function createAdminClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing Supabase server configuration');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) {
+    return NextResponse.json({ error: verification.error }, { status: verification.status });
+  }
+
+  const requestedWindow = Number(new URL(request.url).searchParams.get('hours') ?? '168');
+  const hours = ALLOWED_WINDOWS.has(requestedWindow) ? requestedWindow : 168;
+  const now = new Date();
+  const since = new Date(now.getTime() - hours * 3_600_000).toISOString();
+
+  let admin: ReturnType<typeof createAdminClient>;
+  try {
+    admin = createAdminClient();
+  } catch (error) {
+    console.error('[operator-fuel-evidence] Missing server configuration:', error);
+    return NextResponse.json({ error: 'Fuel evidence unavailable' }, { status: 503 });
+  }
+
+  try {
+    const [checkinsRes, receiptsRes] = await Promise.all([
+      admin.from('checkins')
+        .select('id,regnr,completed_at,current_station,station,fuel_level,fuel_liters,fuel_price_per_liter,fuel_currency')
+        .eq('status', 'COMPLETED')
+        .eq('fuel_level', 'tankad_nu')
+        .gte('completed_at', since)
+        .order('completed_at', { ascending: false })
+        .limit(5000),
+      admin.from('vehicle_receipts')
+        .select('checkin_id,regnr,file_url,uploaded_at')
+        .eq('receipt_type', 'tankning')
+        .gte('uploaded_at', since)
+        .order('uploaded_at', { ascending: false })
+        .limit(5000),
+    ]);
+
+    if (checkinsRes.error) throw checkinsRes.error;
+    if (receiptsRes.error) throw receiptsRes.error;
+
+    const receiptsByCheckin = new Map<string, { url: string; uploadedAt: string | null }>();
+    for (const receipt of receiptsRes.data ?? []) {
+      if (!receipt.checkin_id || !receipt.file_url || receiptsByCheckin.has(receipt.checkin_id)) continue;
+      receiptsByCheckin.set(receipt.checkin_id, {
+        url: receipt.file_url,
+        uploadedAt: receipt.uploaded_at ?? null,
+      });
+    }
+
+    const rows = (checkinsRes.data ?? []).map((checkin) => {
+      const receipt = receiptsByCheckin.get(checkin.id) ?? null;
+      const liters = typeof checkin.fuel_liters === 'number' ? checkin.fuel_liters : Number(checkin.fuel_liters);
+      const pricePerLiter = typeof checkin.fuel_price_per_liter === 'number'
+        ? checkin.fuel_price_per_liter
+        : Number(checkin.fuel_price_per_liter);
+      const total = Number.isFinite(liters) && Number.isFinite(pricePerLiter)
+        ? Math.round(liters * pricePerLiter * 100) / 100
+        : null;
+      return {
+        checkinId: checkin.id,
+        regnr: checkin.regnr,
+        completedAt: checkin.completed_at,
+        station: checkin.current_station ?? checkin.station ?? null,
+        liters: Number.isFinite(liters) ? liters : null,
+        pricePerLiter: Number.isFinite(pricePerLiter) ? pricePerLiter : null,
+        currency: checkin.fuel_currency ?? 'SEK',
+        calculatedTotal: total,
+        hasReceipt: Boolean(receipt),
+        receipt,
+        vagnkort: `/vagnkort?reg=${encodeURIComponent(checkin.regnr)}`,
+      };
+    });
+
+    const withReceipt = rows.filter((row) => row.hasReceipt).length;
+    const withoutReceipt = rows.length - withReceipt;
+    const coveragePercent = rows.length ? Math.round((withReceipt / rows.length) * 1000) / 10 : null;
+
+    return NextResponse.json({
+      data: {
+        generatedAt: now.toISOString(),
+        hours,
+        since,
+        summary: {
+          tankedCheckins: rows.length,
+          withReceipt,
+          withoutReceipt,
+          coveragePercent,
+        },
+        interpretation: {
+          receiptIsOptional: true,
+          monetaryInterpretation: false,
+          message: 'Kvittotäckning beskriver dokumenterad evidens, inte kostnadsansvar eller ekonomiskt utfall.',
+        },
+        rows,
+      },
+    });
+  } catch (error) {
+    console.error('[operator-fuel-evidence] Read failed:', error);
+    return NextResponse.json({ error: 'Could not load fuel evidence' }, { status: 500 });
+  }
+}

--- a/app/tower/fuel-evidence/fuel-evidence-client.tsx
+++ b/app/tower/fuel-evidence/fuel-evidence-client.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+
+type FuelEvidenceRow = {
+  checkinId: string;
+  regnr: string;
+  completedAt: string;
+  station: string | null;
+  liters: number | null;
+  pricePerLiter: number | null;
+  currency: string;
+  calculatedTotal: number | null;
+  hasReceipt: boolean;
+  receipt: { url: string; uploadedAt: string | null } | null;
+  vagnkort: string;
+};
+
+type FuelEvidenceData = {
+  generatedAt: string;
+  hours: number;
+  since: string;
+  summary: {
+    tankedCheckins: number;
+    withReceipt: number;
+    withoutReceipt: number;
+    coveragePercent: number | null;
+  };
+  interpretation: {
+    receiptIsOptional: boolean;
+    monetaryInterpretation: boolean;
+    message: string;
+  };
+  rows: FuelEvidenceRow[];
+};
+
+const WINDOWS = [
+  { hours: 24, label: '24 timmar' },
+  { hours: 72, label: '72 timmar' },
+  { hours: 168, label: '7 dagar' },
+] as const;
+
+const card: React.CSSProperties = {
+  background: '#fff',
+  borderRadius: 14,
+  padding: '1rem 1.1rem',
+  boxShadow: '0 8px 30px rgba(0,0,0,0.08)',
+};
+
+function formatDate(value: string | null) {
+  if (!value) return '—';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('sv-SE');
+}
+
+function money(value: number | null, currency: string) {
+  if (value == null) return '—';
+  return `${value.toLocaleString('sv-SE', { maximumFractionDigits: 2 })} ${currency}`;
+}
+
+async function fetchEvidence(hours: number): Promise<FuelEvidenceData> {
+  const response = await fetch(`/api/operator-fuel-evidence?hours=${hours}`, { cache: 'no-store' });
+  const payload = await response.json();
+  if (!response.ok) throw new Error(payload?.error ?? 'Kunde inte läsa tankningsevidens');
+  return payload.data as FuelEvidenceData;
+}
+
+export default function FuelEvidenceClient() {
+  const [hours, setHours] = useState(168);
+  const [data, setData] = useState<FuelEvidenceData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (windowHours: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      setData(await fetchEvidence(windowHours));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Kunde inte läsa tankningsevidens');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    void fetchEvidence(168)
+      .then((next) => {
+        if (!active) return;
+        setData(next);
+      })
+      .catch((loadError: unknown) => {
+        if (!active) return;
+        setError(loadError instanceof Error ? loadError.message : 'Kunde inte läsa tankningsevidens');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => { active = false; };
+  }, []);
+
+  return (
+    <main style={{ minHeight: '100vh', background: '#f2f4f5', padding: '1.5rem' }}>
+      <div style={{ maxWidth: 1200, margin: '0 auto', display: 'grid', gap: '1rem' }}>
+        <header style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'center', flexWrap: 'wrap' }}>
+          <div>
+            <div style={{ fontSize: 13, textTransform: 'uppercase', letterSpacing: '.08em', color: '#666' }}>INCHECKAD / DRIFT & EVIDENS</div>
+            <h1 style={{ margin: '.2rem 0' }}>Tankningsevidens</h1>
+            <p style={{ margin: 0 }}>Hur stor del av registrerade tankningar har dokumenterat tankkvitto?</p>
+          </div>
+          <div style={{ display: 'flex', gap: '.6rem', flexWrap: 'wrap' }}>
+            <Link href="/tower" style={{ color: '#111' }}>Tower</Link>
+            <Link href="/tower/metrics" style={{ color: '#111' }}>Driftmätning</Link>
+          </div>
+        </header>
+
+        <section style={{ ...card, background: '#fffbe8' }}>
+          Read-only uppföljning. Kvitto är fortfarande frivilligt och denna vy gör ingen bedömning av kostnadsansvar, ersättning eller monetärt utfall.
+        </section>
+
+        {error ? <section style={{ ...card, color: '#a00' }}>{error}</section> : null}
+
+        <section style={{ ...card, display: 'flex', justifyContent: 'space-between', gap: '1rem', flexWrap: 'wrap', alignItems: 'end' }}>
+          <label>
+            <span style={{ display: 'block', fontSize: 13, color: '#666', marginBottom: '.3rem' }}>Tidsfönster</span>
+            <select value={hours} onChange={(event) => {
+              const next = Number(event.target.value);
+              setHours(next);
+              void load(next);
+            }} style={{ padding: '.6rem', borderRadius: 8 }}>
+              {WINDOWS.map((window) => <option key={window.hours} value={window.hours}>{window.label}</option>)}
+            </select>
+          </label>
+          <div style={{ fontSize: 13, color: '#666' }}>Senast läst: <strong style={{ color: '#111' }}>{formatDate(data?.generatedAt ?? null)}</strong></div>
+        </section>
+
+        <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '1rem' }}>
+          <Metric title="Tankad nu" value={data?.summary.tankedCheckins ?? 0} />
+          <Metric title="Med kvitto" value={data?.summary.withReceipt ?? 0} />
+          <Metric title="Utan kvitto" value={data?.summary.withoutReceipt ?? 0} />
+          <Metric title="Kvittotäckning" value={data?.summary.coveragePercent == null ? '—' : `${data.summary.coveragePercent}%`} />
+        </section>
+
+        <section style={card}>
+          <h2 style={{ marginTop: 0 }}>Registrerade tankningar</h2>
+          {loading && !data ? <p>Läser tankningsevidens…</p> : null}
+          {!loading && data?.rows.length === 0 ? <p>Inga registrerade tankningar i valt tidsfönster.</p> : null}
+          {(data?.rows.length ?? 0) > 0 ? (
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr>
+                    <th style={{ textAlign: 'left', padding: '.55rem' }}>Tid</th>
+                    <th style={{ textAlign: 'left', padding: '.55rem' }}>Fordon</th>
+                    <th style={{ textAlign: 'left', padding: '.55rem' }}>Station</th>
+                    <th style={{ textAlign: 'left', padding: '.55rem' }}>Tankning</th>
+                    <th style={{ textAlign: 'left', padding: '.55rem' }}>Kvitto</th>
+                    <th style={{ textAlign: 'left', padding: '.55rem' }}>Vagnkort</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data!.rows.map((row) => (
+                    <tr key={row.checkinId}>
+                      <td style={{ padding: '.6rem', borderTop: '1px solid #eee' }}>{formatDate(row.completedAt)}</td>
+                      <td style={{ padding: '.6rem', borderTop: '1px solid #eee', fontWeight: 700 }}>{row.regnr}</td>
+                      <td style={{ padding: '.6rem', borderTop: '1px solid #eee' }}>{row.station ?? '—'}</td>
+                      <td style={{ padding: '.6rem', borderTop: '1px solid #eee' }}>
+                        {row.liters ?? '—'} L · {row.pricePerLiter ?? '—'} /L
+                        <div style={{ fontSize: 12, color: '#666' }}>Beräknat: {money(row.calculatedTotal, row.currency)}</div>
+                      </td>
+                      <td style={{ padding: '.6rem', borderTop: '1px solid #eee' }}>
+                        {row.receipt ? <a href={row.receipt.url} target="_blank" rel="noreferrer">Visa kvitto →</a> : <strong style={{ color: '#a00' }}>Saknas</strong>}
+                      </td>
+                      <td style={{ padding: '.6rem', borderTop: '1px solid #eee' }}><Link href={row.vagnkort}>Öppna →</Link></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+        </section>
+
+        <section style={card}>
+          <h2 style={{ marginTop: 0 }}>Tolkning</h2>
+          <p style={{ marginBottom: 0 }}>{data?.interpretation.message ?? 'Kvittotäckning beskriver endast dokumenterad evidens.'}</p>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function Metric({ title, value }: { title: string; value: number | string }) {
+  return (
+    <div style={card}>
+      <span style={{ display: 'block', color: '#666', fontSize: 13 }}>{title}</span>
+      <strong style={{ fontSize: 30 }}>{value}</strong>
+    </div>
+  );
+}

--- a/app/tower/fuel-evidence/page.tsx
+++ b/app/tower/fuel-evidence/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+import FuelEvidenceClient from './fuel-evidence-client';
+
+export const metadata: Metadata = {
+  title: 'Tankningsevidens | Incheckad',
+  description: 'Read-only uppföljning av tankningar och dokumenterade tankkvitton',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default function FuelEvidencePage() {
+  return <FuelEvidenceClient />;
+}

--- a/tests/operator-fuel-evidence-contract.test.ts
+++ b/tests/operator-fuel-evidence-contract.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const route = readFileSync('app/api/operator-fuel-evidence/route.ts', 'utf8');
+const client = readFileSync('app/tower/fuel-evidence/fuel-evidence-client.tsx', 'utf8');
+
+test('fuel evidence endpoint is authenticated and read-only', () => {
+  assert.match(route, /verifyApiUser/);
+  assert.doesNotMatch(route, /\.insert\(/);
+  assert.doesNotMatch(route, /\.update\(/);
+  assert.doesNotMatch(route, /\.delete\(/);
+  assert.doesNotMatch(route, /\.rpc\(/);
+});
+
+test('fuel evidence uses existing checkin and receipt evidence only', () => {
+  assert.match(route, /from\('checkins'\)/);
+  assert.match(route, /fuel_level', 'tankad_nu'/);
+  assert.match(route, /from\('vehicle_receipts'\)/);
+  assert.match(route, /receipt_type', 'tankning'/);
+});
+
+test('fuel evidence does not claim monetary consequence', () => {
+  assert.match(route, /monetaryInterpretation: false/);
+  assert.match(client, /gör ingen bedömning av kostnadsansvar/);
+  assert.match(client, /Kvittotäckning/);
+  assert.match(client, /Visa kvitto/);
+  assert.match(client, /Vagnkort/);
+});


### PR DESCRIPTION
## Syfte
Fortsätta Fas 3 med en read-only mätning av hur stor andel registrerade `tankad_nu`-incheckningar som faktiskt har dokumenterat tankkvitto.

## Verkligt Production-underlag före byggstart
Senaste 7 dagarna: 26 `tankad_nu`-incheckningar, 12 med kvitto och 14 utan kvitto, dvs 46,2% dokumenterad kvittotäckning.

## Ändring
- nytt autentiserat read-only API `/api/operator-fuel-evidence`
- ny vy `/tower/fuel-evidence`
- fasta tidsfönster 24h / 72h / 7 dagar
- visar antal tankningar, med/utan kvitto och kvittotäckning
- radnivå visar datum, fordon, station, liter, pris/liter, beräknat totalbelopp, kvittolänk och Vagnkort
- beräknat totalbelopp är endast aritmetisk presentation av registrerade liter × pris/liter; ingen ekonomisk tolkning

## Arkitekturgräns
- ingen databasändring
- ingen mutation av Check-in, Lager 1 eller Lager 2
- inget krav görs på att kvitto måste finnas
- ingen Kistan
- ingen bedömning av kostnadsansvar, ersättning eller monetärt utfall

## Test
Kontraktstest låser auth, read-only, befintliga evidenskällor och den icke-monetära gränsen.