### PR TITLE
Vagnkort: document intelligence and exact duplicate detection

### DIFF
--- a/app/api/vehicle-documents/route.ts
+++ b/app/api/vehicle-documents/route.ts
@@ -53,6 +53,59 @@ function cleanContextId(value: unknown): string | null {
   return UUID_RE.test(contextId) ? contextId : null;
 }
 
+function cleanText(value: unknown, maxLength = 200): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxLength) : null;
+}
+
+function cleanAmount(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const normalized = typeof value === 'string' ? value.replace(',', '.') : value;
+  const amount = Number(normalized);
+  if (!Number.isFinite(amount) || amount < 0 || amount > 100_000_000) return null;
+  return Math.round(amount * 100) / 100;
+}
+
+function cleanDate(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return null;
+  const parsed = new Date(`${trimmed}T00:00:00Z`);
+  return Number.isNaN(parsed.getTime()) ? null : trimmed;
+}
+
+function cleanCurrency(value: unknown): string {
+  const currency = typeof value === 'string' ? value.trim().toUpperCase() : 'SEK';
+  return /^[A-Z]{3}$/.test(currency) ? currency : 'SEK';
+}
+
+function cleanFingerprint(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const cleaned = value.replaceAll('"', '').trim().toLowerCase();
+  return /^[a-f0-9]{16,128}$/.test(cleaned) ? cleaned : null;
+}
+
+function cleanSourceFacts(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const supplier = cleanText(raw.supplier);
+  const invoiceNumber = cleanText(raw.invoiceNumber, 100);
+  const documentDate = cleanDate(raw.documentDate);
+  const totalAmount = cleanAmount(raw.totalAmount);
+  const currency = cleanCurrency(raw.currency);
+  if (!supplier && !invoiceNumber && !documentDate && totalAmount === null) return null;
+  return {
+    supplier,
+    invoiceNumber,
+    documentDate,
+    totalAmount,
+    currency,
+    provenance: 'USER_ENTERED',
+    monetaryInterpretation: false,
+  };
+}
+
 function createAdminClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -263,9 +316,10 @@ export async function POST(request: Request) {
       const path = typeof body.path === 'string' ? body.path.trim() : '';
       const fileName = cleanFileName(body.fileName);
       const documentType = cleanDocumentType(body.documentType);
-      const title = typeof body.title === 'string' && body.title.trim() ? body.title.trim().slice(0, 200) : null;
-      const mimeType = typeof body.mimeType === 'string' && body.mimeType.trim() ? body.mimeType.trim().slice(0, 200) : null;
+      const title = cleanText(body.title);
+      const mimeType = cleanText(body.mimeType);
       const expectedSize = Number(body.sizeBytes);
+      const sourceFacts = cleanSourceFacts(body.sourceFacts);
       const context = await resolveDocumentContext(admin, regnr, body.contextType, body.contextId);
       if (!context.ok) {
         return NextResponse.json({ error: context.error }, { status: context.status });
@@ -295,6 +349,42 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'Uploaded file size mismatch' }, { status: 409 });
       }
 
+      const contentFingerprint = cleanFingerprint(storedObject.metadata?.eTag);
+      if (contentFingerprint) {
+        const { data: duplicate, error: duplicateError } = await admin
+          .from('vehicle_documents')
+          .select('document_id,file_name,document_type,uploaded_at')
+          .eq('regnr', regnr)
+          .contains('metadata', { contentFingerprint })
+          .order('uploaded_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        if (duplicateError) {
+          console.error('[vehicle-documents] Duplicate lookup failed:', duplicateError);
+          return NextResponse.json({ error: 'Could not verify document uniqueness' }, { status: 500 });
+        }
+        if (duplicate) {
+          const { error: cleanupError } = await admin.storage.from(BUCKET).remove([path]);
+          if (cleanupError) console.error('[vehicle-documents] Could not remove duplicate upload:', cleanupError);
+          return NextResponse.json({
+            error: `Exakt samma fil finns redan på Vagnkortet som ${duplicate.file_name}.`,
+            duplicate: {
+              documentId: duplicate.document_id,
+              fileName: duplicate.file_name,
+              documentType: duplicate.document_type,
+              uploadedAt: duplicate.uploaded_at,
+            },
+          }, { status: 409 });
+        }
+      }
+
+      const metadata = {
+        uploadedVia: 'VAGNKORT',
+        context: context.payload,
+        ...(contentFingerprint ? { contentFingerprint, fingerprintSource: 'SUPABASE_STORAGE_ETAG' } : {}),
+        ...(sourceFacts ? { sourceFacts } : {}),
+      };
+
       const { data: document, error: documentError } = await admin
         .from('vehicle_documents')
         .insert({
@@ -309,10 +399,7 @@ export async function POST(request: Request) {
           ...context.links,
           source_system: 'VAGNKORT',
           source_record_id: path,
-          metadata: {
-            uploadedVia: 'VAGNKORT',
-            context: context.payload,
-          },
+          metadata,
           uploaded_by: verification.user.id,
           uploaded_by_email: verification.user.email,
         })
@@ -347,6 +434,8 @@ export async function POST(request: Request) {
             mimeType,
             sizeBytes: document.size_bytes,
             context: context.payload,
+            contentFingerprint,
+            sourceFacts,
           },
         })
         .select('event_id')

--- a/app/vagnkort/document-upload.tsx
+++ b/app/vagnkort/document-upload.tsx
@@ -42,7 +42,11 @@ type PrepareResponse = {
   error?: string;
 };
 
-type CompleteResponse = { data?: { document_id: string }; error?: string };
+type CompleteResponse = {
+  data?: { document_id: string };
+  error?: string;
+  duplicate?: { documentId: string; fileName: string; documentType: string; uploadedAt: string };
+};
 
 function text(value: unknown): string {
   return typeof value === 'string' ? value : '';
@@ -54,9 +58,16 @@ export default function DocumentUpload({ regnr, damages, checkpoints, childProce
   const [title, setTitle] = useState('');
   const [contextType, setContextType] = useState('VEHICLE');
   const [contextId, setContextId] = useState('');
+  const [supplier, setSupplier] = useState('');
+  const [invoiceNumber, setInvoiceNumber] = useState('');
+  const [documentDate, setDocumentDate] = useState('');
+  const [totalAmount, setTotalAmount] = useState('');
+  const [currency, setCurrency] = useState('SEK');
   const [uploading, setUploading] = useState(false);
   const [dragging, setDragging] = useState(false);
   const [message, setMessage] = useState('');
+
+  const isEconomicSource = documentType === 'LEVERANTORSFAKTURA' || documentType === 'KVITTO';
 
   const damageOptions = useMemo<ContextOption[]>(() => damages.map((damage) => ({
     value: damage.id,
@@ -138,6 +149,13 @@ export default function DocumentUpload({ regnr, damages, checkpoints, childProce
             title: title.trim() || null,
             contextType,
             contextId: contextType === 'VEHICLE' ? null : contextId,
+            sourceFacts: isEconomicSource ? {
+              supplier: supplier.trim() || null,
+              invoiceNumber: invoiceNumber.trim() || null,
+              documentDate: documentDate || null,
+              totalAmount: totalAmount.trim() || null,
+              currency,
+            } : null,
           }),
         });
         const completed = (await completeResponse.json()) as CompleteResponse;
@@ -148,6 +166,11 @@ export default function DocumentUpload({ regnr, damages, checkpoints, childProce
 
       setMessage(files.length === 1 ? 'Dokumentet är sparat på Vagnkortet.' : `${files.length} dokument är sparade på Vagnkortet.`);
       setTitle('');
+      setSupplier('');
+      setInvoiceNumber('');
+      setDocumentDate('');
+      setTotalAmount('');
+      setCurrency('SEK');
       if (inputRef.current) inputRef.current.value = '';
       onUploaded();
     } catch (error) {
@@ -201,6 +224,38 @@ export default function DocumentUpload({ regnr, damages, checkpoints, childProce
         </label>
       </div>
 
+      {isEconomicSource && (
+        <div style={{ border: '1px solid #d7d7d7', borderRadius: 10, padding: '.8rem', background: '#fafafa' }}>
+          <div style={{ fontWeight: 700, marginBottom: '.5rem' }}>Källfakta från dokumentet</div>
+          <div style={{ color: '#666', fontSize: 12, marginBottom: '.65rem' }}>Fälten är källregistrering, inte kostnadsansvar eller ekonomisk tolkning.</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '.6rem' }}>
+            <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+              Leverantör
+              <input value={supplier} onChange={(event) => setSupplier(event.target.value)} disabled={uploading} placeholder="Leverantör" style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
+            </label>
+            <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+              Faktura-/kvittonummer
+              <input value={invoiceNumber} onChange={(event) => setInvoiceNumber(event.target.value)} disabled={uploading} placeholder="Nummer" style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
+            </label>
+            <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+              Dokumentdatum
+              <input type="date" value={documentDate} onChange={(event) => setDocumentDate(event.target.value)} disabled={uploading} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
+            </label>
+            <label style={{ display: 'grid', gap: '.25rem', fontSize: 13 }}>
+              Totalbelopp
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 74px', gap: '.4rem' }}>
+                <input type="number" min="0" step="0.01" value={totalAmount} onChange={(event) => setTotalAmount(event.target.value)} disabled={uploading} placeholder="0,00" style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }} />
+                <select value={currency} onChange={(event) => setCurrency(event.target.value)} disabled={uploading} style={{ padding: '.65rem', border: '1px solid #bbb', borderRadius: 8 }}>
+                  <option value="SEK">SEK</option>
+                  <option value="EUR">EUR</option>
+                  <option value="USD">USD</option>
+                </select>
+              </div>
+            </label>
+          </div>
+        </div>
+      )}
+
       <div
         onDragEnter={(event) => { event.preventDefault(); setDragging(true); }}
         onDragOver={(event) => { event.preventDefault(); setDragging(true); }}
@@ -224,7 +279,7 @@ export default function DocumentUpload({ regnr, damages, checkpoints, childProce
         <input ref={inputRef} type="file" multiple onChange={onFileInput} disabled={uploading} style={{ display: 'none' }} />
       </div>
 
-      {message && <div style={{ fontSize: 13, color: message.includes('misslyck') || message.includes('Kunde') || message.includes('större') || message.includes('Välj') ? '#a00' : '#176b2c' }}>{message}</div>}
+      {message && <div style={{ fontSize: 13, color: message.includes('misslyck') || message.includes('Kunde') || message.includes('större') || message.includes('Välj') || message.includes('redan') ? '#a00' : '#176b2c' }}>{message}</div>}
     </div>
   );
 }

--- a/app/vagnkort/vagnkort-client.tsx
+++ b/app/vagnkort/vagnkort-client.tsx
@@ -26,11 +26,24 @@ type JourneyEvent = {
   actor_name: string | null;
 };
 
+type DocumentSourceFacts = {
+  supplier?: string | null;
+  invoiceNumber?: string | null;
+  documentDate?: string | null;
+  totalAmount?: number | null;
+  currency?: string | null;
+  provenance?: string | null;
+  monetaryInterpretation?: boolean | null;
+};
+
 type VehicleDocument = {
   document_id: string;
   document_type: string;
   title: string | null;
   file_name: string;
+  mime_type?: string | null;
+  size_bytes?: number | null;
+  source_system?: string | null;
   external_url: string | null;
   uploaded_at: string;
   journey_event_id?: string | null;
@@ -40,6 +53,9 @@ type VehicleDocument = {
   salu_checkpoint_id?: string | null;
   salu_child_process_id?: string | null;
   metadata?: {
+    contentFingerprint?: string | null;
+    fingerprintSource?: string | null;
+    sourceFacts?: DocumentSourceFacts | null;
     context?: {
       type?: string;
       id?: string | null;
@@ -144,6 +160,24 @@ function formatDate(value: string | null | undefined) {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString('sv-SE');
 }
 
+function formatDocumentDate(value: string | null | undefined) {
+  if (!value) return '—';
+  const date = new Date(`${value}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString('sv-SE');
+}
+
+function formatMoney(value: number | null | undefined, currency = 'SEK') {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—';
+  return new Intl.NumberFormat('sv-SE', { style: 'currency', currency, maximumFractionDigits: 2 }).format(value);
+}
+
+function formatFileSize(value: number | null | undefined) {
+  if (!value || value < 1) return '—';
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${Math.round((value / 1024) * 10) / 10} KB`;
+  return `${Math.round((value / (1024 * 1024)) * 10) / 10} MB`;
+}
+
 function hours(value: number | undefined) {
   if (!value) return '0 h';
   return value >= 24 ? `${Math.round((value / 24) * 10) / 10} dygn` : `${value} h`;
@@ -221,6 +255,16 @@ export default function VagnkortClient() {
       current: current[key],
       changed: baseline[key] !== undefined && current[key] !== undefined && baseline[key] !== current[key],
     }));
+  }, [data]);
+
+  const fingerprintCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const document of data?.documents ?? []) {
+      const fingerprint = document.metadata?.contentFingerprint;
+      if (!fingerprint) continue;
+      counts.set(fingerprint, (counts.get(fingerprint) ?? 0) + 1);
+    }
+    return counts;
   }, [data]);
 
   function submit(event: FormEvent) {
@@ -338,23 +382,49 @@ export default function VagnkortClient() {
                   childProcesses={data.salu.childProcesses}
                   onUploaded={() => setRefreshNonce((value) => value + 1)}
                 />
-                <div style={{ marginTop: '1rem' }}>
-                  {data.documents.length === 0 ? <p>Inga dokument registrerade ännu.</p> : data.documents.slice(0, 20).map((document) => (
-                    <div key={document.document_id} style={{ padding: '.55rem 0', borderBottom: '1px solid #eee', display: 'flex', gap: '.7rem', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <div style={{ minWidth: 0 }}>
-                        <strong style={{ overflowWrap: 'anywhere' }}>{document.title || document.file_name}</strong>
-                        <div style={{ color: '#666', fontSize: 13, marginTop: '.1rem' }}>{document.document_type} · {formatDate(document.uploaded_at)}</div>
-                        <div style={{ marginTop: '.3rem', display: 'flex', gap: '.35rem', flexWrap: 'wrap' }}>
+                <div style={{ marginTop: '1rem', display: 'grid', gap: '.65rem' }}>
+                  {data.documents.length === 0 ? <p>Inga dokument registrerade ännu.</p> : data.documents.slice(0, 20).map((document) => {
+                    const sourceFacts = document.metadata?.sourceFacts;
+                    const fingerprint = document.metadata?.contentFingerprint;
+                    const duplicateCount = fingerprint ? fingerprintCounts.get(fingerprint) ?? 0 : 0;
+                    return (
+                      <div key={document.document_id} style={{ padding: '.8rem', border: '1px solid #e3e3e3', borderRadius: 10, background: duplicateCount > 1 ? '#fff7ed' : '#fff', display: 'grid', gap: '.6rem' }}>
+                        <div style={{ display: 'flex', gap: '.7rem', justifyContent: 'space-between', alignItems: 'start' }}>
+                          <div style={{ minWidth: 0 }}>
+                            <div style={{ display: 'flex', gap: '.35rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                              <strong style={{ overflowWrap: 'anywhere' }}>{document.title || document.file_name}</strong>
+                              {duplicateCount > 1 && <span style={{ background: '#fed7aa', color: '#9a3412', borderRadius: 999, padding: '.15rem .45rem', fontSize: 11, fontWeight: 700 }}>EXAKT FIL-DUBBLETT · {duplicateCount} st</span>}
+                            </div>
+                            <div style={{ color: '#666', fontSize: 13, marginTop: '.15rem' }}>{document.document_type} · {formatDate(document.uploaded_at)} · {formatFileSize(document.size_bytes)}</div>
+                            <div style={{ color: '#777', fontSize: 12, marginTop: '.15rem' }}>{document.source_system || (document.sourceKind === 'legacy_receipt' ? 'LEGACY_RECEIPTS' : 'INCHECKAD')}</div>
+                          </div>
+                          <button type="button" onClick={() => void openDocument(document)} disabled={openingDocument === document.document_id} style={{ border: '1px solid #bbb', borderRadius: 7, background: '#fff', padding: '.45rem .7rem', cursor: 'pointer', whiteSpace: 'nowrap' }}>
+                            {openingDocument === document.document_id ? 'Öppnar…' : 'Visa dokument'}
+                          </button>
+                        </div>
+
+                        <div style={{ display: 'flex', gap: '.35rem', flexWrap: 'wrap' }}>
                           <span style={{ display: 'inline-flex', alignItems: 'center', background: '#f0f0f0', borderRadius: 999, padding: '.18rem .5rem', fontSize: 12 }}>
                             Kopplat till: {documentContextLabel(document)}
                           </span>
+                          {fingerprint && <span style={{ display: 'inline-flex', alignItems: 'center', background: '#eef6ff', borderRadius: 999, padding: '.18rem .5rem', fontSize: 12 }}>Filfingeravtryck finns</span>}
                         </div>
+
+                        {sourceFacts && (
+                          <div style={{ borderTop: '1px solid #eee', paddingTop: '.6rem' }}>
+                            <div style={{ fontSize: 12, color: '#666', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '.04em', marginBottom: '.35rem' }}>Källfakta från dokument</div>
+                            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: '.45rem' }}>
+                              <div><span style={{ display: 'block', fontSize: 11, color: '#777' }}>Leverantör</span><strong>{sourceFacts.supplier || '—'}</strong></div>
+                              <div><span style={{ display: 'block', fontSize: 11, color: '#777' }}>Faktura-/kvittonr</span><strong>{sourceFacts.invoiceNumber || '—'}</strong></div>
+                              <div><span style={{ display: 'block', fontSize: 11, color: '#777' }}>Dokumentdatum</span><strong>{formatDocumentDate(sourceFacts.documentDate)}</strong></div>
+                              <div><span style={{ display: 'block', fontSize: 11, color: '#777' }}>Dokumentbelopp</span><strong>{formatMoney(sourceFacts.totalAmount, sourceFacts.currency || 'SEK')}</strong></div>
+                            </div>
+                            <div style={{ marginTop: '.35rem', fontSize: 11, color: '#777' }}>Källregistrerat belopp · ingen bedömning av kostnadsansvar eller ekonomiskt utfall.</div>
+                          </div>
+                        )}
                       </div>
-                      <button type="button" onClick={() => void openDocument(document)} disabled={openingDocument === document.document_id} style={{ border: '1px solid #bbb', borderRadius: 7, background: '#fff', padding: '.45rem .7rem', cursor: 'pointer', whiteSpace: 'nowrap' }}>
-                        {openingDocument === document.document_id ? 'Öppnar…' : 'Öppna'}
-                      </button>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </section>
             </div>

--- a/migrations/20260825152000_backfill_vehicle_document_fingerprint.sql
+++ b/migrations/20260825152000_backfill_vehicle_document_fingerprint.sql
@@ -1,0 +1,17 @@
+begin;
+
+set local lock_timeout = '5s';
+set local statement_timeout = '30s';
+
+update public.vehicle_documents as document
+set metadata = document.metadata || jsonb_build_object(
+  'contentFingerprint', lower(replace(coalesce(object.metadata->>'eTag', ''), '"', '')),
+  'fingerprintSource', 'SUPABASE_STORAGE_ETAG'
+)
+from storage.objects as object
+where document.storage_bucket = object.bucket_id
+  and document.storage_path = object.name
+  and not (document.metadata ? 'contentFingerprint')
+  and coalesce(replace(object.metadata->>'eTag', '"', ''), '') ~ '^[A-Fa-f0-9]{16,128}$';
+
+commit;

--- a/tests/vehicle-document-intelligence.test.ts
+++ b/tests/vehicle-document-intelligence.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const route = readFileSync('app/api/vehicle-documents/route.ts', 'utf8');
+const upload = readFileSync('app/vagnkort/document-upload.tsx', 'utf8');
+const vagnkort = readFileSync('app/vagnkort/vagnkort-client.tsx', 'utf8');
+const migration = readFileSync('migrations/20260825152000_backfill_vehicle_document_fingerprint.sql', 'utf8');
+
+test('document uploads retain source evidence and reject exact duplicate files', () => {
+  assert.match(route, /verifyApiUser/);
+  assert.match(route, /contentFingerprint/);
+  assert.match(route, /SUPABASE_STORAGE_ETAG/);
+  assert.match(route, /\.contains\('metadata', \{ contentFingerprint \}\)/);
+  assert.match(route, /Exakt samma fil finns redan på Vagnkortet/);
+  assert.match(route, /storage\.from\(BUCKET\)\.remove\(\[path\]\)/);
+});
+
+test('historical vehicle documents can be fingerprinted without deleting evidence', () => {
+  assert.match(migration, /update public\.vehicle_documents/);
+  assert.match(migration, /from storage\.objects/);
+  assert.match(migration, /contentFingerprint/);
+  assert.doesNotMatch(migration, /delete\s+from/i);
+});
+
+test('invoice and receipt source facts are explicitly non-monetary interpretation', () => {
+  assert.match(upload, /Källfakta från dokumentet/);
+  assert.match(upload, /Leverantör/);
+  assert.match(upload, /Faktura-\/kvittonummer/);
+  assert.match(upload, /Totalbelopp/);
+  assert.match(route, /provenance: 'USER_ENTERED'/);
+  assert.match(route, /monetaryInterpretation: false/);
+  assert.match(vagnkort, /Dokumentbelopp/);
+  assert.match(vagnkort, /ingen bedömning av kostnadsansvar eller ekonomiskt utfall/);
+});
+
+test('Vagnkort surfaces exact duplicate evidence instead of silently merging records', () => {
+  assert.match(vagnkort, /EXAKT FIL-DUBBLETT/);
+  assert.match(vagnkort, /fingerprintCounts/);
+  assert.match(vagnkort, /Visa dokument/);
+});


### PR DESCRIPTION
## Syfte
Gör Vagnkortets dokumentdel till en tydligare evidensyta utan att skapa ekonomisk tolkning eller parallell sanning.

## Ändringar
- Exakt dubblettkontroll för nya dokument via lagringsobjektets fingerprint/eTag per fordon.
- Ny uppladdad exakt dubblett registreras inte; den nyuppladdade kopian tas bort från Storage och befintligt dokument bevaras.
- Befintliga fordonsdokument kan backfillas med fingerprint från Storage metadata utan att något dokument raderas.
- Leverantörsfaktura/Kvitto kan få källfakta: leverantör, faktura-/kvittonummer, dokumentdatum, totalbelopp och valuta.
- Källfakta märks uttryckligen USER_ENTERED och monetaryInterpretation=false.
- Vagnkort visar rikare dokumentkort med filstorlek, källa, kontext, dokumentbelopp och exakt-dubblettindikering.

## Arkitekturgräns
- Originaldokumentet är evidensen.
- Registrerade dokumentfält är källfakta, inte kostnadsansvar eller ekonomiskt utfall.
- Ingen OCR/AI-avläsning i detta steg.
- Ingen Kistan-logik.
- Ingen automatisk leverantörsmapp/integration i detta steg.
- Inga befintliga dokument raderas eller slås ihop.

## Test
Ny kontraktstest låser autentisering, fingerprint/dubblettbeteende, historisk backfill utan delete samt icke-monetär tolkning.