### PR TITLE
Garage v2: Lager 1-kontroll och Ny bil-överlämning

### DIFF
--- a/app/api/garage/lager1-sources/route.ts
+++ b/app/api/garage/lager1-sources/route.ts
@@ -1,0 +1,223 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+const DIRECTIONS = new Set(['IN', 'UT']);
+
+function adminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Missing Supabase server configuration');
+  return createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } });
+}
+
+function text(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const next = value.trim();
+  return next || null;
+}
+
+function upper(value: unknown): string | null {
+  const next = text(value);
+  return next ? next.toUpperCase().replace(/\s+/g, '') : null;
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) return NextResponse.json({ error: verification.error }, { status: verification.status });
+
+  const admin = adminClient();
+  const [periodResponse, importedResponse, stationResponse] = await Promise.all([
+    admin
+      .from('vehicle_journey_periods')
+      .select('period_id,regnr,period_type,started_at,reason_code,reason_text,source_event_id')
+      .is('ended_at', null)
+      .order('started_at', { ascending: false }),
+    admin
+      .from('garage_items')
+      .select('garage_item_id,source_journey_period_id')
+      .eq('source_kind', 'LAGER1'),
+    admin
+      .from('planning_stations')
+      .select('station_code,display_name,sort_order')
+      .eq('is_active', true)
+      .order('sort_order', { ascending: true })
+      .order('station_code', { ascending: true }),
+  ]);
+
+  if (periodResponse.error) {
+    console.error('[garage/lager1-sources] periods failed', periodResponse.error);
+    return NextResponse.json({ error: 'Kunde inte läsa Lager 1' }, { status: 500 });
+  }
+  if (importedResponse.error) {
+    console.error('[garage/lager1-sources] Garage lookup failed', importedResponse.error);
+    return NextResponse.json({ error: 'Kunde inte läsa Garage-kopplingar' }, { status: 500 });
+  }
+  if (stationResponse.error) {
+    console.error('[garage/lager1-sources] stations failed', stationResponse.error);
+    return NextResponse.json({ error: 'Kunde inte läsa stationer' }, { status: 500 });
+  }
+
+  const periods = periodResponse.data ?? [];
+  const regnrs = [...new Set(periods.map((row) => row.regnr).filter(Boolean))];
+  const imported = new Map((importedResponse.data ?? []).map((row) => [row.source_journey_period_id, row.garage_item_id]));
+
+  let vehicleRows: Array<{ regnr: string; brand: string | null; model: string | null }> = [];
+  let nybilRows: Array<{ regnr: string; bilmarke: string | null; modell: string | null; created_at: string }> = [];
+
+  if (regnrs.length > 0) {
+    const [vehicleResponse, nybilResponse] = await Promise.all([
+      admin.from('vehicles').select('regnr,brand,model').in('regnr', regnrs),
+      admin.from('nybil_inventering').select('regnr,bilmarke,modell,created_at').in('regnr', regnrs).order('created_at', { ascending: false }),
+    ]);
+    if (vehicleResponse.error) {
+      console.error('[garage/lager1-sources] vehicles failed', vehicleResponse.error);
+      return NextResponse.json({ error: 'Kunde inte läsa fordonsregister' }, { status: 500 });
+    }
+    if (nybilResponse.error) {
+      console.error('[garage/lager1-sources] Nybil lookup failed', nybilResponse.error);
+      return NextResponse.json({ error: 'Kunde inte läsa Ny bil-baslinjer' }, { status: 500 });
+    }
+    vehicleRows = vehicleResponse.data ?? [];
+    nybilRows = nybilResponse.data ?? [];
+  }
+
+  const vehicleByReg = new Map(vehicleRows.map((row) => [row.regnr, row]));
+  const nybilByReg = new Map<string, (typeof nybilRows)[number]>();
+  for (const row of nybilRows) if (!nybilByReg.has(row.regnr)) nybilByReg.set(row.regnr, row);
+
+  return NextResponse.json({
+    data: periods.map((period) => {
+      const vehicle = vehicleByReg.get(period.regnr);
+      const nybil = nybilByReg.get(period.regnr);
+      return {
+        ...period,
+        brand: nybil?.bilmarke ?? vehicle?.brand ?? null,
+        model: nybil?.modell ?? vehicle?.model ?? null,
+        imported: imported.has(period.period_id),
+        garage_item_id: imported.get(period.period_id) ?? null,
+      };
+    }),
+    stations: stationResponse.data ?? [],
+  });
+}
+
+export async function POST(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) return NextResponse.json({ error: verification.error }, { status: verification.status });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Ogiltig JSON' }, { status: 400 });
+  }
+
+  const periodId = text(body.period_id);
+  const direction = upper(body.garage_direction);
+  const plannedStation = text(body.planned_station);
+  if (!periodId || !direction || !DIRECTIONS.has(direction) || !plannedStation) {
+    return NextResponse.json({ error: 'period_id, riktning och station krävs' }, { status: 400 });
+  }
+
+  const admin = adminClient();
+  const [periodResponse, stationResponse] = await Promise.all([
+    admin
+      .from('vehicle_journey_periods')
+      .select('period_id,regnr,period_type,started_at,reason_code,reason_text,source_event_id')
+      .eq('period_id', periodId)
+      .is('ended_at', null)
+      .maybeSingle(),
+    admin
+      .from('planning_stations')
+      .select('station_code')
+      .eq('station_code', plannedStation)
+      .eq('is_active', true)
+      .maybeSingle(),
+  ]);
+
+  if (periodResponse.error) {
+    console.error('[garage/lager1-sources] period lookup failed', periodResponse.error);
+    return NextResponse.json({ error: 'Kunde inte läsa Lager 1-perioden' }, { status: 500 });
+  }
+  if (!periodResponse.data) return NextResponse.json({ error: 'Lager 1-perioden är inte längre öppen' }, { status: 409 });
+  if (stationResponse.error) {
+    console.error('[garage/lager1-sources] station lookup failed', stationResponse.error);
+    return NextResponse.json({ error: 'Kunde inte verifiera station' }, { status: 500 });
+  }
+  if (!stationResponse.data) return NextResponse.json({ error: 'Ogiltig station' }, { status: 400 });
+
+  const period = periodResponse.data;
+  const regnr = upper(period.regnr);
+  if (!regnr) return NextResponse.json({ error: 'Lager 1-perioden saknar regnr' }, { status: 409 });
+
+  const [existingResponse, vehicleResponse, nybilResponse] = await Promise.all([
+    admin
+      .from('garage_items')
+      .select('garage_item_id')
+      .eq('source_kind', 'LAGER1')
+      .eq('source_journey_period_id', period.period_id)
+      .maybeSingle(),
+    admin.from('vehicles').select('brand,model').eq('regnr', regnr).maybeSingle(),
+    admin
+      .from('nybil_inventering')
+      .select('bilmarke,modell')
+      .eq('regnr', regnr)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  if (existingResponse.error || vehicleResponse.error || nybilResponse.error) {
+    console.error('[garage/lager1-sources] identity lookup failed', existingResponse.error ?? vehicleResponse.error ?? nybilResponse.error);
+    return NextResponse.json({ error: 'Kunde inte verifiera fordonsidentiteten' }, { status: 500 });
+  }
+  if (existingResponse.data) {
+    return NextResponse.json({ error: 'Den här Lager 1-perioden finns redan i Garaget', garage_item_id: existingResponse.data.garage_item_id }, { status: 409 });
+  }
+
+  const model = text(nybilResponse.data?.modell) ?? text(vehicleResponse.data?.model);
+  if (!model) {
+    return NextResponse.json({ error: `Modell saknas för ${regnr}; komplettera fordonsinformationen innan bilen läggs i Garaget` }, { status: 409 });
+  }
+
+  const now = new Date().toISOString();
+  const month = now.slice(0, 7);
+  const payload = {
+    planning_period: month,
+    model,
+    garage_direction: direction,
+    planning_reason: 'ANNAT',
+    regnr,
+    source_regnr: regnr,
+    planned_station: plannedStation,
+    confirmation_status: 'PLANERAD',
+    transport_status: 'EJ_BOKAD',
+    source_kind: 'LAGER1',
+    source_journey_period_id: period.period_id,
+    source_journey_event_id: period.source_event_id,
+    created_at: now,
+    updated_at: now,
+    created_by: verification.user.id,
+    updated_by: verification.user.id,
+  };
+
+  const { data, error } = await admin.from('garage_items').insert(payload).select('*').single();
+  if (error) {
+    console.error('[garage/lager1-sources] Garage insert failed', error);
+    if (error.code === '23505') return NextResponse.json({ error: 'Den här Lager 1-perioden finns redan i Garaget' }, { status: 409 });
+    return NextResponse.json({ error: 'Kunde inte lägga bilen i Garaget' }, { status: 500 });
+  }
+
+  const { error: auditError } = await admin.from('garage_direction_events').insert({
+    garage_item_id: data.garage_item_id,
+    from_direction: null,
+    to_direction: direction,
+    reason: `Lager 1 → Garage från ${period.period_type}`,
+    changed_at: now,
+    changed_by: verification.user.id,
+  });
+  if (auditError) console.error('[garage/lager1-sources] initial direction audit failed', auditError);
+
+  return NextResponse.json({ data }, { status: 201 });
+}

--- a/app/api/garage/nybil-handoff/route.ts
+++ b/app/api/garage/nybil-handoff/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { verifyApiUser } from '@/lib/server-auth';
+
+function adminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Missing Supabase server configuration');
+  return createClient(url, key, { auth: { persistSession: false, autoRefreshToken: false } });
+}
+
+function text(value: string | null): string | null {
+  const next = value?.trim();
+  return next || null;
+}
+
+export async function GET(request: Request) {
+  const verification = await verifyApiUser(request);
+  if (!verification.ok) return NextResponse.json({ error: verification.error }, { status: verification.status });
+
+  const admin = adminClient();
+  const params = new URL(request.url).searchParams;
+  const garageItemId = text(params.get('garage_item_id'));
+
+  if (!garageItemId) {
+    const { data, error } = await admin
+      .from('garage_items')
+      .select('garage_item_id,regnr,vin,model,planned_station,supplier,order_reference,source_kind,garage_direction,handed_off_nybil_id,handed_off_at,updated_at')
+      .eq('garage_direction', 'IN')
+      .not('regnr', 'is', null)
+      .order('updated_at', { ascending: false });
+    if (error) {
+      console.error('[garage/nybil-handoff] list failed', error);
+      return NextResponse.json({ error: 'Kunde inte läsa Garage → Ny bil' }, { status: 500 });
+    }
+    return NextResponse.json({ data: data ?? [] });
+  }
+
+  const { data: item, error } = await admin
+    .from('garage_items')
+    .select('garage_item_id,regnr,vin,model,planned_station,supplier,order_reference,source_kind,garage_direction,handed_off_nybil_id,handed_off_at')
+    .eq('garage_item_id', garageItemId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[garage/nybil-handoff] item lookup failed', error);
+    return NextResponse.json({ error: 'Kunde inte läsa Garage-objektet' }, { status: 500 });
+  }
+  if (!item) return NextResponse.json({ error: 'Garage-objektet finns inte' }, { status: 404 });
+  if (item.garage_direction !== 'IN') {
+    return NextResponse.json({ error: 'Endast UTVECKLA / IN kan överlämnas till Ny bil' }, { status: 409 });
+  }
+  if (!item.regnr) {
+    return NextResponse.json({ error: 'Registreringsnummer krävs före överlämning till Ny bil' }, { status: 409 });
+  }
+  if (item.handed_off_nybil_id) {
+    return NextResponse.json({
+      error: 'Garage-objektet är redan överlämnat till Ny bil',
+      handed_off_nybil_id: item.handed_off_nybil_id,
+      handed_off_at: item.handed_off_at,
+    }, { status: 409 });
+  }
+
+  let stationDisplayName: string | null = null;
+  if (item.planned_station) {
+    const { data: station, error: stationError } = await admin
+      .from('planning_stations')
+      .select('display_name')
+      .eq('station_code', item.planned_station)
+      .maybeSingle();
+    if (stationError) console.error('[garage/nybil-handoff] station lookup failed', stationError);
+    stationDisplayName = station?.display_name ?? null;
+  }
+
+  return NextResponse.json({
+    data: {
+      ...item,
+      station_display_name: stationDisplayName,
+    },
+  });
+}

--- a/app/garage/garage-v2-panel.tsx
+++ b/app/garage/garage-v2-panel.tsx
@@ -81,7 +81,33 @@ export default function GarageV2Panel() {
     }
   }, []);
 
-  useEffect(() => { void load(); }, [load]);
+  useEffect(() => {
+    let active = true;
+    void Promise.all([
+      fetch('/api/garage/lager1-sources', { cache: 'no-store' }),
+      fetch('/api/garage/nybil-handoff', { cache: 'no-store' }),
+    ])
+      .then(async ([lager1Response, handoffResponse]) => {
+        const lager1Payload = await lager1Response.json();
+        const handoffPayload = await handoffResponse.json();
+        if (!lager1Response.ok) throw new Error(lager1Payload?.error ?? 'Kunde inte läsa Lager 1');
+        if (!handoffResponse.ok) throw new Error(handoffPayload?.error ?? 'Kunde inte läsa Garage → Ny bil');
+        if (!active) return;
+        setLager1(lager1Payload.data ?? []);
+        setHandoffs(handoffPayload.data ?? []);
+        const nextStations = lager1Payload.stations ?? [];
+        setStations(nextStations);
+        setStation((current) => current || nextStations[0]?.station_code || '');
+        setError(null);
+      })
+      .catch((loadError: unknown) => {
+        if (active) setError(loadError instanceof Error ? loadError.message : 'Kunde inte läsa Garage v2');
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => { active = false; };
+  }, []);
 
   const importFromLager1 = async (source: Lager1Source) => {
     if (!station) return setError('Välj station.');

--- a/app/garage/garage-v2-panel.tsx
+++ b/app/garage/garage-v2-panel.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type GarageDirection = 'IN' | 'UT';
+type Station = { station_code: string; display_name: string | null; sort_order: number };
+type Lager1Source = {
+  period_id: string;
+  regnr: string;
+  period_type: string;
+  started_at: string;
+  reason_code: string | null;
+  reason_text: string | null;
+  source_event_id: string | null;
+  brand: string | null;
+  model: string | null;
+  imported: boolean;
+  garage_item_id: string | null;
+};
+type HandoffItem = {
+  garage_item_id: string;
+  regnr: string;
+  vin: string | null;
+  model: string;
+  planned_station: string | null;
+  supplier: string | null;
+  order_reference: string | null;
+  source_kind: string;
+  garage_direction: 'IN';
+  handed_off_nybil_id: string | null;
+  handed_off_at: string | null;
+};
+
+const shell: React.CSSProperties = {
+  maxWidth: 1500,
+  margin: '0 auto 20px',
+  padding: '18px',
+  border: '1px solid #d7d7d7',
+  borderRadius: 14,
+  background: 'rgba(255,255,255,0.96)',
+  boxShadow: '0 6px 24px rgba(0,0,0,0.06)',
+};
+const grid: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(360px,1fr))', gap: 16 };
+const panel: React.CSSProperties = { border: '1px solid #e3e3e3', borderRadius: 12, padding: 14, minWidth: 0 };
+const row: React.CSSProperties = { display: 'grid', gridTemplateColumns: 'minmax(110px,1fr) minmax(130px,1.4fr) auto', gap: 10, alignItems: 'center', padding: '10px 0', borderTop: '1px solid #eee' };
+const button: React.CSSProperties = { border: 0, borderRadius: 8, padding: '9px 12px', fontWeight: 700, cursor: 'pointer', background: '#111', color: '#fff', textDecoration: 'none', display: 'inline-block', whiteSpace: 'nowrap' };
+const secondary: React.CSSProperties = { ...button, background: '#ececec', color: '#111' };
+const select: React.CSSProperties = { padding: '9px 10px', border: '1px solid #ccc', borderRadius: 8, background: '#fff' };
+
+export default function GarageV2Panel() {
+  const [lager1, setLager1] = useState<Lager1Source[]>([]);
+  const [handoffs, setHandoffs] = useState<HandoffItem[]>([]);
+  const [stations, setStations] = useState<Station[]>([]);
+  const [station, setStation] = useState('');
+  const [direction, setDirection] = useState<GarageDirection>('IN');
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [lager1Response, handoffResponse] = await Promise.all([
+        fetch('/api/garage/lager1-sources', { cache: 'no-store' }),
+        fetch('/api/garage/nybil-handoff', { cache: 'no-store' }),
+      ]);
+      const lager1Payload = await lager1Response.json();
+      const handoffPayload = await handoffResponse.json();
+      if (!lager1Response.ok) throw new Error(lager1Payload?.error ?? 'Kunde inte läsa Lager 1');
+      if (!handoffResponse.ok) throw new Error(handoffPayload?.error ?? 'Kunde inte läsa Garage → Ny bil');
+      setLager1(lager1Payload.data ?? []);
+      setHandoffs(handoffPayload.data ?? []);
+      const nextStations = lager1Payload.stations ?? [];
+      setStations(nextStations);
+      setStation((current) => current || nextStations[0]?.station_code || '');
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Kunde inte läsa Garage v2');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const importFromLager1 = async (source: Lager1Source) => {
+    if (!station) return setError('Välj station.');
+    setBusy(source.period_id);
+    setError(null);
+    try {
+      const response = await fetch('/api/garage/lager1-sources', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ period_id: source.period_id, garage_direction: direction, planned_station: station }),
+      });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload?.error ?? 'Kunde inte lägga bilen i Garaget');
+      await load();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Kunde inte lägga bilen i Garaget');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const availableSources = lager1.filter((source) => !source.imported);
+
+  return (
+    <section style={shell} aria-label="Garage v2">
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, alignItems: 'baseline', flexWrap: 'wrap', marginBottom: 14 }}>
+        <div>
+          <div style={{ fontSize: 12, fontWeight: 800, letterSpacing: '.08em' }}>GARAGE V2</div>
+          <h2 style={{ margin: '3px 0 0' }}>Fordonsöverlämningar</h2>
+          <p style={{ margin: '5px 0 0', color: '#555' }}>Lager 1 behåller verkligheten. Garaget styr dispositionen. Ny bil verifierar faktisk mottagning.</p>
+        </div>
+        <button type="button" style={secondary} onClick={() => void load()} disabled={loading}>{loading ? 'Läser…' : 'Uppdatera'}</button>
+      </div>
+
+      {error ? <div style={{ marginBottom: 12, padding: 10, borderRadius: 8, background: '#fff1f1', color: '#a40000', fontWeight: 650 }}>{error}</div> : null}
+
+      <div style={grid}>
+        <div style={panel}>
+          <h3 style={{ marginTop: 0 }}>Lager 1 → Lägg i Garaget</h3>
+          <p style={{ color: '#666', marginTop: -4 }}>Skapar en Garage-disposition som refererar till aktuell Lager 1-period. Lager 1 ändras inte.</p>
+          <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 8 }}>
+            <label style={{ display: 'grid', gap: 4 }}><span style={{ fontSize: 12, fontWeight: 700 }}>Riktning</span><select style={select} value={direction} onChange={(e) => setDirection(e.target.value as GarageDirection)}><option value="IN">UTVECKLA / IN</option><option value="UT">AVVECKLA / UT</option></select></label>
+            <label style={{ display: 'grid', gap: 4 }}><span style={{ fontSize: 12, fontWeight: 700 }}>Station</span><select style={select} value={station} onChange={(e) => setStation(e.target.value)}><option value="">Välj</option>{stations.map((value) => <option key={value.station_code} value={value.station_code}>{value.display_name || value.station_code}</option>)}</select></label>
+          </div>
+          {availableSources.length === 0 ? <div style={{ color: '#666', padding: '10px 0' }}>{loading ? 'Läser Lager 1…' : 'Inga öppna Lager 1-perioder kvar att lägga i Garaget.'}</div> : availableSources.map((source) => (
+            <div key={source.period_id} style={row}>
+              <div><strong>{source.regnr}</strong><div style={{ fontSize: 12, color: '#666' }}>{source.period_type}</div></div>
+              <div><strong>{[source.brand, source.model].filter(Boolean).join(' ') || 'Modell saknas'}</strong><div style={{ fontSize: 12, color: '#666' }}>{source.reason_text || source.reason_code || `Start ${new Date(source.started_at).toLocaleString('sv-SE')}`}</div></div>
+              <button type="button" style={button} disabled={busy === source.period_id || !source.model} onClick={() => void importFromLager1(source)}>{busy === source.period_id ? 'Lägger…' : 'Lägg i Garaget'}</button>
+            </div>
+          ))}
+        </div>
+
+        <div style={panel}>
+          <h3 style={{ marginTop: 0 }}>Garage → Ny bil</h3>
+          <p style={{ color: '#666', marginTop: -4 }}>Endast UTVECKLA / IN med känt regnr. Överlämningen skapar inte Lager 1; Ny bil-kontrollen gör det när den sparas.</p>
+          {handoffs.length === 0 ? <div style={{ color: '#666', padding: '10px 0' }}>{loading ? 'Läser Garaget…' : 'Inga IN-bilar med regnr att överlämna.'}</div> : handoffs.map((item) => (
+            <div key={item.garage_item_id} style={row}>
+              <div><strong>{item.regnr}</strong><div style={{ fontSize: 12, color: '#666' }}>{item.source_kind}</div></div>
+              <div><strong>{item.model}</strong><div style={{ fontSize: 12, color: '#666' }}>Stn {item.planned_station || '—'}{item.order_reference ? ` · Order ${item.order_reference}` : ''}</div></div>
+              {item.handed_off_nybil_id ? <div style={{ fontWeight: 750, color: '#176b33' }}>Överlämnad</div> : <a style={button} href={`/nybil?garage_item_id=${encodeURIComponent(item.garage_item_id)}`}>Överlämna till Ny bil</a>}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/garage/page.tsx
+++ b/app/garage/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import GarageClient from './garage-client';
+import GarageV2Panel from './garage-v2-panel';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,5 +10,10 @@ export const metadata: Metadata = {
 };
 
 export default function GaragePage() {
-  return <GarageClient />;
+  return (
+    <>
+      <GarageV2Panel />
+      <GarageClient />
+    </>
+  );
 }

--- a/app/nybil/garage-prefill-bridge.tsx
+++ b/app/nybil/garage-prefill-bridge.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type GaragePrefill = {
+  garage_item_id: string;
+  regnr: string;
+  vin: string | null;
+  model: string;
+  planned_station: string | null;
+  station_display_name: string | null;
+  supplier: string | null;
+  order_reference: string | null;
+  source_kind: string;
+};
+
+function setNativeValue(element: HTMLInputElement | HTMLSelectElement, value: string) {
+  const prototype = element instanceof HTMLSelectElement ? HTMLSelectElement.prototype : HTMLInputElement.prototype;
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, 'value');
+  descriptor?.set?.call(element, value);
+  element.dispatchEvent(new Event(element instanceof HTMLSelectElement ? 'change' : 'input', { bubbles: true }));
+}
+
+function applyPrefill(data: GaragePrefill): boolean {
+  const regInputs = Array.from(document.querySelectorAll<HTMLInputElement>('input.reg-input'));
+  const modelInput = document.querySelector<HTMLInputElement>('input[placeholder="t.ex. T-Cross"]');
+  if (regInputs.length < 2 || !modelInput) return false;
+
+  setNativeValue(regInputs[0], data.regnr);
+  setNativeValue(regInputs[1], data.regnr);
+  setNativeValue(modelInput, data.model || '');
+
+  const cards = Array.from(document.querySelectorAll<HTMLElement>('.card'));
+  const plannedStationCard = cards.find((card) => card.querySelector('.section-header h2')?.textContent?.trim() === 'Planerad station');
+  const plannedStationSelect = plannedStationCard?.querySelector<HTMLSelectElement>('select');
+  if (plannedStationSelect && (data.station_display_name || data.planned_station)) {
+    const candidates = [data.station_display_name, data.planned_station].filter(Boolean) as string[];
+    const option = Array.from(plannedStationSelect.options).find((value) => candidates.includes(value.value) || candidates.includes(value.text));
+    if (option) setNativeValue(plannedStationSelect, option.value);
+  }
+
+  return true;
+}
+
+export default function GarageNybilPrefillBridge() {
+  const [data, setData] = useState<GaragePrefill | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const garageItemId = new URLSearchParams(window.location.search).get('garage_item_id');
+    if (!garageItemId) return;
+
+    let cancelled = false;
+    void fetch(`/api/garage/nybil-handoff?garage_item_id=${encodeURIComponent(garageItemId)}`, { cache: 'no-store' })
+      .then(async (response) => {
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload?.error ?? 'Kunde inte läsa Garage-överlämningen');
+        if (cancelled) return;
+        setData(payload.data);
+
+        let attempts = 0;
+        const tryApply = () => {
+          if (cancelled) return;
+          attempts += 1;
+          if (applyPrefill(payload.data)) return;
+          if (attempts < 20) window.setTimeout(tryApply, 50);
+          else setError('Garage-data kunde läsas men formuläret kunde inte förifyllas.');
+        };
+        tryApply();
+      })
+      .catch((loadError: unknown) => {
+        if (!cancelled) setError(loadError instanceof Error ? loadError.message : 'Kunde inte läsa Garage-överlämningen');
+      });
+
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!data && !error) return null;
+
+  return (
+    <div style={{ maxWidth: 700, margin: '0 auto 12px', padding: '12px 14px', borderRadius: 10, border: `1px solid ${error ? '#d33' : '#b9c4b9'}`, background: error ? '#fff1f1' : 'rgba(247,250,247,0.97)', boxSizing: 'border-box' }}>
+      {error ? <strong style={{ color: '#a40000' }}>{error}</strong> : (
+        <>
+          <strong>Överlämnad från Garaget · UTVECKLA / IN</strong>
+          <div style={{ marginTop: 5, fontSize: 14 }}>
+            <span><b>Reg.nr:</b> {data?.regnr}</span>
+            <span> · <b>Modell:</b> {data?.model}</span>
+            {data?.vin ? <span> · <b>VIN:</b> {data.vin}</span> : null}
+          </div>
+          {(data?.supplier || data?.order_reference) ? <div style={{ marginTop: 3, fontSize: 13, color: '#555' }}>{data.supplier ? `Leverantör: ${data.supplier}` : ''}{data.supplier && data.order_reference ? ' · ' : ''}{data.order_reference ? `Order: ${data.order_reference}` : ''}</div> : null}
+          <div style={{ marginTop: 5, fontSize: 12, color: '#666' }}>Reg.nr, modell och planerad station förifylls. Faktisk mottagningsplats och övriga kontrollpunkter ska verifieras här i Ny bil.</div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/nybil/page.tsx
+++ b/app/nybil/page.tsx
@@ -1,8 +1,14 @@
 // app/nybil/page.tsx
 import FormClient from './form-client';
+import GarageNybilPrefillBridge from './garage-prefill-bridge';
 
 export const dynamic = 'force-dynamic';
 
 export default function NybilPage() {
-  return <FormClient />;
+  return (
+    <>
+      <GarageNybilPrefillBridge />
+      <FormClient />
+    </>
+  );
 }

--- a/lib/nybil-api-client.ts
+++ b/lib/nybil-api-client.ts
@@ -43,10 +43,17 @@ export async function countNybilDuplicatesForDate(regnr: string, registrationDat
 }
 
 export async function createNybilRegistration(inventoryData: Record<string, unknown>): Promise<string | number | null> {
+  const garageItemId = typeof window !== 'undefined'
+    ? new URLSearchParams(window.location.search).get('garage_item_id')?.trim() || null
+    : null;
+  const payloadInventory = garageItemId
+    ? { ...inventoryData, source_garage_item_id: garageItemId }
+    : inventoryData;
+
   const response = await fetch('/api/nybil', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ inventoryData }),
+    body: JSON.stringify({ inventoryData: payloadInventory }),
   });
   const data = await readJson<{ id: string | number | null }>(response, 'Kunde inte spara nybilsregistreringen');
   return data.id;

--- a/migrations/20260826014500_add_garage_v2_handoffs.sql
+++ b/migrations/20260826014500_add_garage_v2_handoffs.sql
@@ -1,0 +1,156 @@
+-- Garage v2: Lager 1 -> Garage and Garage -> Ny bil handoffs.
+-- regnr remains the permanent vehicle identity. UUIDs below identify episodes/records only.
+
+alter table public.garage_items
+  add column if not exists source_journey_period_id uuid,
+  add column if not exists source_journey_event_id uuid,
+  add column if not exists handed_off_nybil_id uuid,
+  add column if not exists handed_off_at timestamptz;
+
+alter table public.nybil_inventering
+  add column if not exists source_garage_item_id uuid;
+
+alter table public.garage_items
+  drop constraint if exists garage_items_source_journey_period_id_fkey,
+  add constraint garage_items_source_journey_period_id_fkey
+    foreign key (source_journey_period_id)
+    references public.vehicle_journey_periods(period_id)
+    on delete restrict;
+
+alter table public.garage_items
+  drop constraint if exists garage_items_source_journey_event_id_fkey,
+  add constraint garage_items_source_journey_event_id_fkey
+    foreign key (source_journey_event_id)
+    references public.vehicle_journey_events(event_id)
+    on delete restrict;
+
+alter table public.garage_items
+  drop constraint if exists garage_items_handed_off_nybil_id_fkey,
+  add constraint garage_items_handed_off_nybil_id_fkey
+    foreign key (handed_off_nybil_id)
+    references public.nybil_inventering(id)
+    on delete restrict;
+
+alter table public.nybil_inventering
+  drop constraint if exists nybil_inventering_source_garage_item_id_fkey,
+  add constraint nybil_inventering_source_garage_item_id_fkey
+    foreign key (source_garage_item_id)
+    references public.garage_items(garage_item_id)
+    on delete restrict;
+
+alter table public.garage_items
+  drop constraint if exists garage_items_source_kind_check;
+
+alter table public.garage_items
+  add constraint garage_items_source_kind_check
+  check (source_kind = any (array['MANUELL'::text, 'PLANERING'::text, 'SALU'::text, 'LAGER1'::text]));
+
+alter table public.garage_items
+  drop constraint if exists garage_items_source_consistency_check;
+
+alter table public.garage_items
+  add constraint garage_items_source_consistency_check
+  check (
+    (
+      source_kind = 'MANUELL'
+      and source_planning_cell_id is null
+      and source_planning_unit_no is null
+      and source_salu_flag_id is null
+      and source_journey_period_id is null
+      and source_journey_event_id is null
+    )
+    or (
+      source_kind = 'PLANERING'
+      and source_planning_cell_id is not null
+      and source_planning_unit_no is not null
+      and source_salu_flag_id is null
+      and source_journey_period_id is null
+      and source_journey_event_id is null
+    )
+    or (
+      source_kind = 'SALU'
+      and source_planning_cell_id is null
+      and source_planning_unit_no is null
+      and source_salu_flag_id is not null
+      and source_journey_period_id is null
+      and source_journey_event_id is null
+    )
+    or (
+      source_kind = 'LAGER1'
+      and regnr is not null
+      and source_planning_cell_id is null
+      and source_planning_unit_no is null
+      and source_salu_flag_id is null
+      and source_journey_period_id is not null
+    )
+  );
+
+create unique index if not exists garage_items_lager1_source_uidx
+  on public.garage_items(source_journey_period_id)
+  where source_kind = 'LAGER1';
+
+create unique index if not exists garage_items_handoff_nybil_uidx
+  on public.garage_items(handed_off_nybil_id)
+  where handed_off_nybil_id is not null;
+
+create unique index if not exists nybil_inventering_source_garage_uidx
+  on public.nybil_inventering(source_garage_item_id)
+  where source_garage_item_id is not null;
+
+create or replace function public.sync_nybil_garage_handoff()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_item public.garage_items%rowtype;
+begin
+  if new.source_garage_item_id is null then
+    return new;
+  end if;
+
+  select *
+    into v_item
+    from public.garage_items
+   where garage_item_id = new.source_garage_item_id
+   for update;
+
+  if not found then
+    raise exception 'Garage item % does not exist', new.source_garage_item_id;
+  end if;
+
+  if v_item.garage_direction <> 'IN' then
+    raise exception 'Garage item % is not UTVECKLA / IN', new.source_garage_item_id;
+  end if;
+
+  if v_item.regnr is null or upper(regexp_replace(v_item.regnr, '\s+', '', 'g')) <> upper(regexp_replace(new.regnr, '\s+', '', 'g')) then
+    raise exception 'Garage/Nybil regnr mismatch for Garage item %', new.source_garage_item_id;
+  end if;
+
+  if v_item.handed_off_nybil_id is not null and v_item.handed_off_nybil_id <> new.id then
+    raise exception 'Garage item % is already handed off to Nybil %', new.source_garage_item_id, v_item.handed_off_nybil_id;
+  end if;
+
+  update public.garage_items
+     set handed_off_nybil_id = new.id,
+         handed_off_at = coalesce(handed_off_at, now()),
+         updated_at = now()
+   where garage_item_id = new.source_garage_item_id;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists nybil_garage_handoff_sync on public.nybil_inventering;
+create trigger nybil_garage_handoff_sync
+after insert on public.nybil_inventering
+for each row
+when (new.source_garage_item_id is not null)
+execute function public.sync_nybil_garage_handoff();
+
+comment on column public.garage_items.source_journey_period_id is
+  'Lager 1 period that was active when BK created this Garage disposition. Does not move or rewrite Lager 1.';
+comment on column public.garage_items.source_journey_event_id is
+  'Optional exact Lager 1 source event for the Garage disposition.';
+comment on column public.nybil_inventering.source_garage_item_id is
+  'Garage disposition that handed the vehicle to the authoritative Ny bil control.';

--- a/migrations/20260826014500_add_garage_v2_handoffs.sql
+++ b/migrations/20260826014500_add_garage_v2_handoffs.sql
@@ -141,6 +141,8 @@ begin
 end;
 $$;
 
+revoke all on function public.sync_nybil_garage_handoff() from public, anon, authenticated;
+
 drop trigger if exists nybil_garage_handoff_sync on public.nybil_inventering;
 create trigger nybil_garage_handoff_sync
 after insert on public.nybil_inventering

--- a/tests/garage-v2-contract.test.ts
+++ b/tests/garage-v2-contract.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const migration = readFileSync('migrations/20260826014500_add_garage_v2_handoffs.sql', 'utf8');
+const lager1Api = readFileSync('app/api/garage/lager1-sources/route.ts', 'utf8');
+const handoffApi = readFileSync('app/api/garage/nybil-handoff/route.ts', 'utf8');
+const garagePanel = readFileSync('app/garage/garage-v2-panel.tsx', 'utf8');
+const nybilBridge = readFileSync('app/nybil/garage-prefill-bridge.tsx', 'utf8');
+const nybilPage = readFileSync('app/nybil/page.tsx', 'utf8');
+const nybilClient = readFileSync('lib/nybil-api-client.ts', 'utf8');
+
+test('Garage v2 keeps regnr as vehicle identity and UUIDs as episode references', () => {
+  assert.match(migration, /regnr remains the permanent vehicle identity/i);
+  assert.match(migration, /source_journey_period_id uuid/);
+  assert.match(migration, /source_journey_event_id uuid/);
+  assert.doesNotMatch(migration, /source_vehicle_id/);
+  assert.doesNotMatch(lager1Api, /source_vehicle_id/);
+});
+
+test('Lager 1 can create a Garage disposition without mutating Layer 1', () => {
+  assert.match(migration, /'LAGER1'/);
+  assert.match(migration, /garage_items_lager1_source_uidx/);
+  assert.match(lager1Api, /from\('vehicle_journey_periods'\)/);
+  assert.match(lager1Api, /\.is\('ended_at', null\)/);
+  assert.match(lager1Api, /source_kind: 'LAGER1'/);
+  assert.match(lager1Api, /source_journey_period_id: period\.period_id/);
+  assert.match(lager1Api, /source_journey_event_id: period\.source_event_id/);
+  assert.doesNotMatch(lager1Api, /from\('vehicle_journey_periods'\)\s*\.update/s);
+  assert.doesNotMatch(lager1Api, /from\('vehicle_journey_events'\)\s*\.insert/s);
+  assert.match(garagePanel, /Lager 1 behåller verkligheten/);
+  assert.match(garagePanel, /Lägg i Garaget/);
+});
+
+test('Garage to Ny bil is allowed only for UTVECKLA IN with a real regnr', () => {
+  assert.match(handoffApi, /garage_direction !== 'IN'/);
+  assert.match(handoffApi, /Registreringsnummer krävs före överlämning till Ny bil/);
+  assert.match(garagePanel, /Överlämna till Ny bil/);
+  assert.match(garagePanel, /\/nybil\?garage_item_id=/);
+});
+
+test('Ny bil carries the exact Garage source and database validates the handoff atomically', () => {
+  assert.match(nybilClient, /garage_item_id/);
+  assert.match(nybilClient, /source_garage_item_id: garageItemId/);
+  assert.match(migration, /source_garage_item_id uuid/);
+  assert.match(migration, /sync_nybil_garage_handoff/);
+  assert.match(migration, /v_item\.garage_direction <> 'IN'/);
+  assert.match(migration, /Garage\/Nybil regnr mismatch/);
+  assert.match(migration, /handed_off_nybil_id = new\.id/);
+  assert.match(migration, /nybil_inventering_source_garage_uidx/);
+});
+
+test('Garage handoff trigger is not exposed as a callable public API', () => {
+  assert.match(migration, /revoke all on function public\.sync_nybil_garage_handoff\(\) from public, anon, authenticated/);
+  assert.doesNotMatch(migration, /security definer/i);
+});
+
+test('Ny bil prefill carries known planning facts but does not claim actual receipt location', () => {
+  assert.match(nybilPage, /GarageNybilPrefillBridge/);
+  assert.match(nybilBridge, /input\.reg-input/);
+  assert.match(nybilBridge, /t\.ex\. T-Cross/);
+  assert.match(nybilBridge, /Planerad station/);
+  assert.match(nybilBridge, /Faktisk mottagningsplats/);
+  assert.doesNotMatch(nybilBridge, /setOrt\(/);
+  assert.doesNotMatch(nybilBridge, /setStation\(/);
+  assert.doesNotMatch(nybilBridge, /Plats för mottagning av ny bil/);
+});
+
+test('Garage v2 does not invent ANKOMST or directly create Layer 1 truth', () => {
+  for (const source of [lager1Api, handoffApi, garagePanel, nybilBridge, nybilClient]) {
+    assert.doesNotMatch(source, /ANKOMMEN/);
+    assert.doesNotMatch(source, /transition_vehicle_journey_state/);
+  }
+  assert.match(garagePanel, /Ny bil-kontrollen gör det när den sparas/);
+});


### PR DESCRIPTION
## Garage v2

Bygger de två låsta länkarna ovanpå #431 utan att ändra Lager 1-semantiken.

### 1. Lager 1 → Garage
- `regnr` är fortsatt permanent fordonsidentitet.
- BK kan skapa ett Garage-objekt från en aktuell öppen Lager 1-period.
- Garage sparar `source_journey_period_id` och vid behov `source_journey_event_id` för episodspårning.
- Lager 1 uppdateras inte när bilen läggs i Garaget.
- `source_kind = LAGER1` med dublettskydd per källperiod.

### 2. Garage → Ny bil → Lager 1
- Endast `UTVECKLA / IN` med känt regnr kan överlämnas.
- Ny bil öppnas från Garage med säkra förhandsuppgifter: regnr, modell och planerad station.
- Faktisk mottagningsplats och övriga verkliga kontrollpunkter måste fortfarande verifieras i Ny bil.
- Nybil-posten sparar `source_garage_item_id`.
- DB-trigger verifierar samma regnr + IN-riktning och kvitterar exakt `nybil_inventering.id` tillbaka till Garage.
- Befintlig Nybil-write-through fortsätter vara enda vägen som etablerar/verifierar Lager 1-verklighet.

### Integritet och säkerhet
- Inget nytt `vehicle_id`; `regnr` följer bilen genom hela resan.
- Garage skapar inte ANKOMST och anropar inte Lager 1-transition direkt.
- Handoff-triggern är inte `SECURITY DEFINER` och EXECUTE är återkallat från PUBLIC/anon/authenticated.
- Unika index hindrar dubbla länkar mellan samma Garage-episod och Nybil-post.

### Verifiering
- Nytt Garage v2-kontraktstest täcker identitet, Lager 1-immutability, IN-regeln, atomisk Nybil-kvittens och frånvaro av direkt Lager 1-write.

**Ingen Production-migration är körd. PR:n ska granskas/verifieras före merge.**