### PR TITLE
UI: modernisera Vagnkort och bevara Tower-kontext

### DIFF
--- a/app/vagnkort/page.tsx
+++ b/app/vagnkort/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import VagnkortClient from './vagnkort-client';
+import VagnkortClient from './vagnkort-client-loader';
 import OperationalStateBanner from './operational-state-banner';
 import styles from './vagnkort-shell.module.css';
 

--- a/app/vagnkort/page.tsx
+++ b/app/vagnkort/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import VagnkortClient from './vagnkort-client';
 import OperationalStateBanner from './operational-state-banner';
+import styles from './vagnkort-shell.module.css';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,9 +13,67 @@ export const metadata: Metadata = {
 
 export default function VagnkortPage() {
   return (
-    <>
-      <OperationalStateBanner />
-      <VagnkortClient />
-    </>
+    <div className={styles.shell}>
+      <aside className={styles.sidebar}>
+        <div className={styles.brand}>
+          <strong>INCHECKAD</strong>
+          <span>BY INVISTO / IT</span>
+          <i />
+        </div>
+        <nav className={styles.nav} aria-label="Vagnkort navigation">
+          <Link href="/">Startsida</Link>
+          <Link href="/tower">Tower</Link>
+          <Link href="/planning">Planering</Link>
+          <Link href="/garage">Garaget</Link>
+          <Link href="/ankomst">Ankomst</Link>
+          <Link href="/check">Incheckning</Link>
+          <Link href="/nybil">Ny bil</Link>
+          <Link className={styles.active} href="/vagnkort">Vagnkort</Link>
+        </nav>
+        <div className={styles.sidebarFoot}>
+          <span>INVISTO</span>
+          <small>CORE / VEHICLE RECORD</small>
+        </div>
+      </aside>
+
+      <section className={styles.surface}>
+        <header className={styles.topbar}>
+          <div className={styles.topbarTitle}>
+            <strong>Vagnkort</strong>
+            <span>FORDONSIDENTITET / HISTORIK / EVIDENS</span>
+          </div>
+          <div className={styles.topbarSpacer} />
+          <Link className={styles.towerLink} href="/tower">← TOWER</Link>
+          <Link className={styles.homeLink} href="/">START</Link>
+        </header>
+
+        <section className={styles.hero}>
+          <div className={styles.heroCopy}>
+            <span className={styles.eyebrow}>INVISTO CORE / VEHICLE DOSSIER</span>
+            <h1>Bilens digitala pärm.</h1>
+            <p>Verifierad fordonsresa, dokumentation, avvikelser och evidens samlat på en plats. Vagnkortet visar vad som faktiskt har hänt utan att skriva om källornas verklighet.</p>
+          </div>
+          <div className={styles.heroMeta}>
+            <span>PRINCIP</span>
+            <strong>IDENTITY → HISTORY → EVIDENCE</strong>
+            <span>STATUS</span>
+            <strong>READ VERIFIED TRUTH</strong>
+          </div>
+        </section>
+
+        <div className={styles.state}>
+          <OperationalStateBanner />
+        </div>
+
+        <div className={styles.content}>
+          <VagnkortClient />
+        </div>
+
+        <footer className={styles.footer}>
+          <span>INCHECKAD / BY INVISTO / IT</span>
+          <strong>FORDONSRESAN SKA KUNNA BEVISAS.</strong>
+        </footer>
+      </section>
+    </div>
   );
 }

--- a/app/vagnkort/vagnkort-client-loader.tsx
+++ b/app/vagnkort/vagnkort-client-loader.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const ClientVagnkort = dynamic(() => import('./vagnkort-client'), {
+  ssr: false,
+  loading: () => null,
+});
+
+export default function VagnkortClient() {
+  return <ClientVagnkort />;
+}

--- a/app/vagnkort/vagnkort-shell.module.css
+++ b/app/vagnkort/vagnkort-shell.module.css
@@ -1,0 +1,475 @@
+.shell {
+  --ink: #111315;
+  --stone: #b7b3ae;
+  --ivory: #f5f4f0;
+  --taupe: #a69485;
+  --steel: #60666a;
+  --paper: rgba(255, 255, 255, 0.74);
+  --line: rgba(183, 179, 174, 0.62);
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 218px minmax(0, 1fr);
+  background:
+    radial-gradient(circle at 78% -10%, rgba(166, 148, 133, 0.13), transparent 34%),
+    var(--ivory);
+  color: var(--ink);
+  font-family: Aeonik, Arial, Helvetica, sans-serif;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 28px 22px 24px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent 24%),
+    #111315;
+  color: #f5f4f0;
+  border-right: 1px solid rgba(183, 179, 174, 0.24);
+}
+
+.brand {
+  display: grid;
+  gap: 3px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid rgba(183, 179, 174, 0.22);
+}
+
+.brand strong {
+  font-size: 18px;
+  letter-spacing: 0.04em;
+}
+
+.brand span,
+.sidebarFoot small {
+  color: rgba(245, 244, 240, 0.54);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.brand i {
+  width: 42px;
+  height: 1px;
+  margin-top: 10px;
+  background: var(--taupe);
+}
+
+.nav {
+  display: grid;
+  gap: 5px;
+  margin-top: 28px;
+}
+
+.nav a {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 10px 0 15px;
+  border-radius: 8px;
+  color: rgba(245, 244, 240, 0.6);
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 680;
+  letter-spacing: 0.035em;
+  transition: background 140ms ease, color 140ms ease, transform 140ms ease;
+}
+
+.nav a:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.055);
+  transform: translateX(2px);
+}
+
+.nav .active {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.075);
+}
+
+.nav .active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 2px;
+  height: 20px;
+  background: var(--taupe);
+}
+
+.sidebarFoot {
+  display: grid;
+  gap: 3px;
+  margin-top: auto;
+  padding-top: 20px;
+  border-top: 1px solid rgba(183, 179, 174, 0.22);
+}
+
+.sidebarFoot span {
+  font-size: 11px;
+  font-weight: 780;
+  letter-spacing: 0.12em;
+}
+
+.surface {
+  min-width: 0;
+}
+
+.topbar {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 clamp(22px, 4vw, 58px);
+  border-bottom: 1px solid var(--line);
+  background: rgba(245, 244, 240, 0.82);
+  backdrop-filter: blur(18px);
+}
+
+.topbarTitle {
+  display: grid;
+  gap: 2px;
+}
+
+.topbarTitle strong {
+  font-size: 14px;
+  letter-spacing: 0.02em;
+}
+
+.topbarTitle span {
+  color: var(--steel);
+  font-size: 9px;
+  font-weight: 760;
+  letter-spacing: 0.16em;
+}
+
+.topbarSpacer {
+  flex: 1;
+}
+
+.towerLink,
+.homeLink {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  border: 1px solid var(--stone);
+  border-radius: 9px;
+  color: var(--ink);
+  text-decoration: none;
+  font-size: 10px;
+  font-weight: 780;
+  letter-spacing: 0.08em;
+  transition: background 140ms ease, border-color 140ms ease;
+}
+
+.towerLink:hover,
+.homeLink:hover {
+  background: rgba(166, 148, 133, 0.12);
+  border-color: var(--taupe);
+}
+
+.hero {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 44px clamp(22px, 4vw, 58px) 24px;
+}
+
+.heroCopy {
+  max-width: 760px;
+}
+
+.eyebrow {
+  color: var(--taupe);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+}
+
+.hero h1 {
+  margin: 8px 0 7px;
+  font-size: clamp(40px, 5vw, 68px);
+  line-height: 0.94;
+  letter-spacing: -0.045em;
+}
+
+.hero p {
+  max-width: 650px;
+  margin: 0;
+  color: var(--steel);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.heroMeta {
+  display: grid;
+  min-width: 210px;
+  gap: 8px;
+  padding-left: 18px;
+  border-left: 1px solid var(--stone);
+}
+
+.heroMeta span {
+  color: var(--steel);
+  font-size: 9px;
+  font-weight: 760;
+  letter-spacing: 0.15em;
+}
+
+.heroMeta strong {
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.state,
+.content {
+  padding: 0 clamp(22px, 4vw, 58px);
+}
+
+.state {
+  margin-bottom: 18px;
+}
+
+.state > section {
+  max-width: 1560px !important;
+  margin: 0 !important;
+  padding: 18px 20px !important;
+  border: 1px solid var(--stone) !important;
+  border-left: 3px solid var(--ink) !important;
+  border-radius: 16px !important;
+  background: rgba(255, 255, 255, 0.58) !important;
+  box-shadow: none !important;
+}
+
+.content {
+  padding-bottom: 64px;
+}
+
+.content > main {
+  min-height: 0 !important;
+  padding: 0 !important;
+  background: transparent !important;
+}
+
+.content > main > div {
+  max-width: 1560px !important;
+  margin: 0 !important;
+}
+
+.content > main > div > header {
+  display: none !important;
+}
+
+.content > main > div > form {
+  position: sticky;
+  top: 84px;
+  z-index: 8;
+  display: grid !important;
+  grid-template-columns: minmax(180px, 1fr) auto;
+  gap: 10px !important;
+  margin-bottom: 18px !important;
+  padding: 12px !important;
+  border: 1px solid rgba(183, 179, 174, 0.74) !important;
+  border-radius: 14px !important;
+  background: rgba(245, 244, 240, 0.86) !important;
+  box-shadow: 0 16px 34px rgba(17, 19, 21, 0.07) !important;
+  backdrop-filter: blur(18px);
+}
+
+.content > main > div > form input {
+  min-height: 46px;
+  padding: 0 14px !important;
+  border: 0 !important;
+  border-bottom: 1px solid var(--stone) !important;
+  border-radius: 7px 7px 0 0 !important;
+  outline: none;
+  background: rgba(255, 255, 255, 0.38) !important;
+  color: var(--ink);
+  font-size: 16px !important;
+  font-weight: 760;
+  letter-spacing: 0.06em;
+}
+
+.content > main > div > form input:focus {
+  border-bottom-color: var(--ink) !important;
+  background: rgba(255, 255, 255, 0.76) !important;
+}
+
+.content > main > div > form button {
+  min-height: 46px;
+  padding: 0 18px !important;
+  border: 1px solid var(--ink) !important;
+  border-radius: 9px !important;
+  background: var(--ink) !important;
+  color: #fff !important;
+  font-size: 11px;
+  letter-spacing: 0.035em;
+}
+
+.content main section,
+.content main > div > div[style*='background'] {
+  border: 1px solid var(--line) !important;
+  border-radius: 16px !important;
+  background: var(--paper) !important;
+  box-shadow: 0 12px 34px rgba(17, 19, 21, 0.055) !important;
+}
+
+.content main section {
+  position: relative;
+  overflow: hidden;
+}
+
+.content main section::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 58px;
+  height: 1px;
+  background: var(--taupe);
+}
+
+.content main h2 {
+  font-size: 17px !important;
+  line-height: 1.15;
+  letter-spacing: -0.018em;
+}
+
+.content main p,
+.content main td,
+.content main th,
+.content main div {
+  line-height: 1.42;
+}
+
+.content main table {
+  border-spacing: 0;
+}
+
+.content main th {
+  color: var(--steel);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.content main td,
+.content main th {
+  border-color: rgba(183, 179, 174, 0.48) !important;
+}
+
+.content main button,
+.content main a {
+  transition: opacity 140ms ease, background 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.content main button:hover:not(:disabled),
+.content main a:hover {
+  transform: translateY(-1px);
+}
+
+.content main button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.content main [style*='border-radius: 999'],
+.content main [style*='borderRadius: 999'] {
+  border-radius: 7px !important;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px clamp(22px, 4vw, 58px) 28px;
+  border-top: 1px solid var(--line);
+  color: var(--steel);
+  font-size: 9px;
+  font-weight: 760;
+  letter-spacing: 0.13em;
+}
+
+.footer strong {
+  color: var(--ink);
+}
+
+@media (max-width: 980px) {
+  .shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: relative;
+    height: auto;
+    padding: 18px 20px;
+  }
+
+  .brand {
+    padding-bottom: 14px;
+  }
+
+  .nav {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    margin-top: 14px;
+  }
+
+  .nav a {
+    justify-content: center;
+    padding: 0 6px;
+    text-align: center;
+  }
+
+  .nav .active::before,
+  .sidebarFoot {
+    display: none;
+  }
+
+  .content > main > div > form {
+    top: 12px;
+  }
+}
+
+@media (max-width: 700px) {
+  .topbar {
+    min-height: auto;
+    flex-wrap: wrap;
+    padding-top: 14px;
+    padding-bottom: 14px;
+  }
+
+  .topbarSpacer {
+    display: none;
+  }
+
+  .hero {
+    align-items: start;
+    flex-direction: column;
+    padding-top: 30px;
+  }
+
+  .heroMeta {
+    width: 100%;
+    min-width: 0;
+    padding: 12px 0 0;
+    border-left: 0;
+    border-top: 1px solid var(--stone);
+  }
+
+  .nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .content > main > div > form {
+    position: relative;
+    top: auto;
+    grid-template-columns: 1fr;
+  }
+
+  .footer {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Syfte
Gör övergången Tower → Vagnkort sammanhängande både visuellt och funktionellt.

## Innehåll
- nytt INVISTO CORE / IT-skal för Vagnkort
- samma produktnavigation och visuella disciplin som Tower
- tydligare hierarki för fordonsidentitet, historik och evidens
- behåller befintlig Vagnkort-logik och read-model
- fixar Tower→Vagnkort-kontexten genom att låta Vagnkortets klient mounta i browsern, så `?reg=` faktiskt används vid direktnavigering från Tower

## Avgränsning
Ingen API-, databas-, Layer 1-, Layer 2- eller behörighetslogik ändras.

## Production gate
Preview/CI först. Ingen merge utan separat beslut.