### PR TITLE
Planering v2: gemensam planeringsmånad

### DIFF
--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import CoreProductShell from '@/components/CoreProductShell';
-import FleetPlanningClient from './planning-client';
-import SaluOverview from './salu-overview';
+import PlanningWorkspace from './planning-workspace';
 
 export const dynamic = 'force-dynamic';
 
@@ -18,8 +17,7 @@ export default function PlanningPage() {
       descriptor="VAGNPARK / FRAMTIDA INTENT / STATIONER"
       eyebrow="INVISTO CORE / FLEET PLANNING"
     >
-      <SaluOverview />
-      <FleetPlanningClient />
+      <PlanningWorkspace />
     </CoreProductShell>
   );
 }

--- a/app/planning/planning-client.tsx
+++ b/app/planning/planning-client.tsx
@@ -19,6 +19,7 @@ type PlanningModel = { model_code: string; display_name: string; sort_order: num
 type ApiCell = Counts & { planning_cell_id: string; period_code: string; model: string; station: string; note: string | null; updated_at: string };
 type ModelRow = { key: string; model: string; note: string; stations: Record<string, Counts>; dirty: boolean };
 type DraftEnvelope = { version: 1 | 2; savedAt: string; rows: ModelRow[] };
+type Props = { selectedPeriod: string; onPeriodChange: (period: string) => void };
 
 const emptyCounts = (): Counts => ({ salu_count: 0, behov_count: 0, utok_count: 0, minskning_count: 0, ordered_count: 0 });
 const defaultPeriod = () => new Date().toISOString().slice(0, 7);
@@ -84,10 +85,9 @@ function restoreDraft(period: string, serverRows: ModelRow[], stations: Planning
   } catch { return { rows: serverRows, restored: 0 }; }
 }
 
-export default function FleetPlanningClient() {
-  const [initialPeriod] = useState(defaultPeriod);
-  const [period, setPeriod] = useState(initialPeriod);
-  const [periodInput, setPeriodInput] = useState(initialPeriod);
+export default function FleetPlanningClient({ selectedPeriod, onPeriodChange }: Props) {
+  const [period, setPeriod] = useState(selectedPeriod);
+  const [periodInput, setPeriodInput] = useState(selectedPeriod);
   const [metric, setMetric] = useState<DecisionMetric>('behov_count');
   const [stations, setStations] = useState<PlanningStation[]>([]);
   const [models, setModels] = useState<PlanningModel[]>([]);
@@ -132,7 +132,10 @@ export default function FleetPlanningClient() {
 
   useEffect(() => {
     let active = true;
-    void fetch(`/api/fleet-planning?period=${encodeURIComponent(initialPeriod)}`, { cache: 'no-store' })
+    setLoading(true);
+    setError(null);
+    setStatus(null);
+    void fetch(`/api/fleet-planning?period=${encodeURIComponent(selectedPeriod)}`, { cache: 'no-store' })
       .then(async (response) => {
         const payload = await response.json();
         if (!response.ok) throw new Error(payload?.error ?? 'Kunde inte läsa planeringen');
@@ -140,13 +143,13 @@ export default function FleetPlanningClient() {
       })
       .then((payload) => {
         if (!active) return;
-        applyPayload(payload, initialPeriod);
+        applyPayload(payload, selectedPeriod);
         setError(null);
       })
       .catch((reason: unknown) => { if (active) setError(reason instanceof Error ? reason.message : 'Kunde inte läsa planeringen'); })
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
-  }, [applyPayload, initialPeriod]);
+  }, [applyPayload, selectedPeriod]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -217,6 +220,15 @@ export default function FleetPlanningClient() {
     finally { setSavingAll(false); }
   };
 
+  const openPeriod = () => {
+    const nextPeriod = periodInput || defaultPeriod();
+    if (nextPeriod === selectedPeriod) {
+      void load(nextPeriod);
+      return;
+    }
+    onPeriodChange(nextPeriod);
+  };
+
   const moveFocus = (event: KeyboardEvent<HTMLInputElement>, direction: number) => {
     if (event.key !== 'Enter') return;
     event.preventDefault();
@@ -234,7 +246,7 @@ export default function FleetPlanningClient() {
 
       <section className={styles.toolbar}>
         <label className={styles.periodControl}><span>Månad</span><input type="month" value={periodInput} onChange={(event) => setPeriodInput(event.target.value)} /></label>
-        <button type="button" className={styles.secondaryButton} onClick={() => void load(periodInput || defaultPeriod())}>Öppna</button>
+        <button type="button" className={styles.secondaryButton} onClick={openPeriod}>Öppna</button>
         <div className={styles.decisionTabs} role="tablist" aria-label="Planeringsbeslut">
           {DECISIONS.map(([key, label]) => <button key={key} type="button" role="tab" aria-selected={metric === key} className={metric === key ? styles.decisionTabActive : styles.decisionTab} onClick={() => setMetric(key)}>{label}</button>)}
         </div>

--- a/app/planning/planning-client.tsx
+++ b/app/planning/planning-client.tsx
@@ -105,6 +105,7 @@ export default function FleetPlanningClient({ selectedPeriod, onPeriodChange }: 
   const totalForRow = (row: ModelRow) => stations.reduce((sum, station) => sum + (row.stations[station.station_code] ?? emptyCounts())[metric], 0);
   const stationTotals = useMemo(() => Object.fromEntries(stations.map((station) => [station.station_code, rows.reduce((sum, row) => sum + (row.stations[station.station_code] ?? emptyCounts())[metric], 0)])), [metric, rows, stations]);
   const grandTotal = useMemo(() => Object.values(stationTotals).reduce((sum, value) => sum + value, 0), [stationTotals]);
+  const periodChanging = period !== selectedPeriod && !error;
 
   const applyPayload = useCallback((payload: { data?: ApiCell[]; stations?: PlanningStation[]; models?: PlanningModel[] }, nextPeriod: string, recover = true) => {
     const nextStations = payload.stations ?? [];
@@ -132,9 +133,6 @@ export default function FleetPlanningClient({ selectedPeriod, onPeriodChange }: 
 
   useEffect(() => {
     let active = true;
-    setLoading(true);
-    setError(null);
-    setStatus(null);
     void fetch(`/api/fleet-planning?period=${encodeURIComponent(selectedPeriod)}`, { cache: 'no-store' })
       .then(async (response) => {
         const payload = await response.json();
@@ -145,6 +143,7 @@ export default function FleetPlanningClient({ selectedPeriod, onPeriodChange }: 
         if (!active) return;
         applyPayload(payload, selectedPeriod);
         setError(null);
+        setStatus(null);
       })
       .catch((reason: unknown) => { if (active) setError(reason instanceof Error ? reason.message : 'Kunde inte läsa planeringen'); })
       .finally(() => { if (active) setLoading(false); });
@@ -261,7 +260,7 @@ export default function FleetPlanningClient({ selectedPeriod, onPeriodChange }: 
 
       <section className={styles.gridSection}>
         <div className={styles.gridHeading}><div><strong>{metricLabel} — {period}</strong><span>Modell | stationer | totalt</span></div><strong>{dirtyRows.length ? `${dirtyRows.length} osparade · ` : ''}{rows.length} modeller</strong></div>
-        {loading ? <div className={styles.empty}>Läser planering…</div> : stations.length === 0 ? <div className={styles.empty}>Inga aktiva planeringsstationer finns.</div> : (
+        {loading || periodChanging ? <div className={styles.empty}>Läser planering…</div> : stations.length === 0 ? <div className={styles.empty}>Inga aktiva planeringsstationer finns.</div> : (
           <div className={styles.tableWrap}><table className={styles.simplePlanningTable}>
             <thead><tr><th className={styles.modelColumn}>Modell</th>{stations.map((station) => <th key={station.station_code}>{station.station_code}<small>{station.display_name && station.display_name !== station.station_code ? station.display_name : ''}</small></th>)}<th>Totalt</th><th className={styles.noteColumn}>Kommentar</th><th className={styles.actionColumn}>Spara</th></tr></thead>
             <tbody>

--- a/app/planning/planning-workspace.tsx
+++ b/app/planning/planning-workspace.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import SaluOverview from './salu-overview';
+import FleetPlanningClient from './planning-client';
+
+export default function PlanningWorkspace() {
+  return (
+    <>
+      <SaluOverview />
+      <FleetPlanningClient />
+    </>
+  );
+}

--- a/app/planning/planning-workspace.tsx
+++ b/app/planning/planning-workspace.tsx
@@ -1,13 +1,18 @@
 'use client';
 
+import { useState } from 'react';
 import SaluOverview from './salu-overview';
 import FleetPlanningClient from './planning-client';
 
+const currentPeriod = () => new Date().toISOString().slice(0, 7);
+
 export default function PlanningWorkspace() {
+  const [period, setPeriod] = useState(currentPeriod);
+
   return (
     <>
-      <SaluOverview />
-      <FleetPlanningClient />
+      <SaluOverview period={period} onPeriodChange={setPeriod} />
+      <FleetPlanningClient selectedPeriod={period} onPeriodChange={setPeriod} />
     </>
   );
 }

--- a/app/planning/salu-overview.tsx
+++ b/app/planning/salu-overview.tsx
@@ -36,11 +36,7 @@ type DecisionRow = {
 };
 type DecisionReadPayload = { data?: DecisionRow[]; storageReady?: boolean; error?: string };
 type DecisionWritePayload = { data?: DecisionRow; storageReady?: boolean; error?: string };
-
-type Props = {
-  period: string;
-  onPeriodChange: (period: string) => void;
-};
+type Props = { period: string; onPeriodChange: (period: string) => void };
 
 function currentPeriod() { return new Date().toISOString().slice(0, 7); }
 
@@ -56,27 +52,20 @@ export default function SaluOverview({ period, onPeriodChange }: Props) {
 
   useEffect(() => {
     let active = true;
-    setLoading(true);
-    setError(null);
-    setData(null);
-    setSelectedModel(null);
-    setDecisions({});
-    setDecisionStorageReady(null);
-    setDecisionNotice(null);
-
     void fetch(`/api/planning/salu-overview?period=${encodeURIComponent(period)}`, { cache: 'no-store' })
       .then(async (response) => {
         const body = await response.json();
         if (!response.ok) throw new Error(body?.error ?? 'Kunde inte läsa SALU-översikten');
         if (!active) return;
         const nextData = body.data as Payload;
+        setError(null);
+        setSelectedModel(null);
+        setDecisionNotice(null);
+        setDecisions({});
+        setDecisionStorageReady(null);
         setData(nextData);
         const regnrs = nextData.items.map((item) => item.regnr);
-        if (regnrs.length === 0) {
-          setDecisions({});
-          setDecisionStorageReady(null);
-          return;
-        }
+        if (regnrs.length === 0) return;
         const decisionResponse = await fetch(`/api/planning/replacement-decisions?regnrs=${encodeURIComponent(regnrs.join(','))}`, { cache: 'no-store' });
         const decisionBody = await decisionResponse.json() as DecisionReadPayload;
         if (!decisionResponse.ok) throw new Error(decisionBody.error ?? 'Kunde inte läsa ersättningsbeslut');
@@ -98,6 +87,8 @@ export default function SaluOverview({ period, onPeriodChange }: Props) {
     () => Object.values(decisions).filter((decision) => decision.decision_status === 'REPLACE').length,
     [decisions],
   );
+
+  const periodChanging = data?.period !== period && !error;
 
   const changePeriod = (nextPeriod: string) => {
     onPeriodChange(nextPeriod || currentPeriod());
@@ -146,7 +137,7 @@ export default function SaluOverview({ period, onPeriodChange }: Props) {
       {error ? <div className={styles.error}>{error}</div> : null}
       {decisionNotice ? <div className={styles.notice}>{decisionNotice}</div> : null}
       {decisionStorageReady === false ? <div className={styles.storageWarning}>ERSÄTT är färdigbyggt i grenen men väntar på databasaktivering. Inget beslut kan sparas förrän den lagringen är godkänd.</div> : null}
-      {loading ? <div className={styles.loading}>Läser kommande SALU…</div> : data ? (
+      {loading || periodChanging ? <div className={styles.loading}>Läser kommande SALU…</div> : data ? (
         <>
           <div className={styles.horizonGrid}>
             {data.months.map((month) => (

--- a/app/planning/salu-overview.tsx
+++ b/app/planning/salu-overview.tsx
@@ -37,10 +37,14 @@ type DecisionRow = {
 type DecisionReadPayload = { data?: DecisionRow[]; storageReady?: boolean; error?: string };
 type DecisionWritePayload = { data?: DecisionRow; storageReady?: boolean; error?: string };
 
+type Props = {
+  period: string;
+  onPeriodChange: (period: string) => void;
+};
+
 function currentPeriod() { return new Date().toISOString().slice(0, 7); }
 
-export default function SaluOverview() {
-  const [period, setPeriod] = useState(currentPeriod());
+export default function SaluOverview({ period, onPeriodChange }: Props) {
   const [data, setData] = useState<Payload | null>(null);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -52,6 +56,14 @@ export default function SaluOverview() {
 
   useEffect(() => {
     let active = true;
+    setLoading(true);
+    setError(null);
+    setData(null);
+    setSelectedModel(null);
+    setDecisions({});
+    setDecisionStorageReady(null);
+    setDecisionNotice(null);
+
     void fetch(`/api/planning/salu-overview?period=${encodeURIComponent(period)}`, { cache: 'no-store' })
       .then(async (response) => {
         const body = await response.json();
@@ -88,14 +100,7 @@ export default function SaluOverview() {
   );
 
   const changePeriod = (nextPeriod: string) => {
-    setLoading(true);
-    setError(null);
-    setData(null);
-    setSelectedModel(null);
-    setDecisions({});
-    setDecisionStorageReady(null);
-    setDecisionNotice(null);
-    setPeriod(nextPeriod || currentPeriod());
+    onPeriodChange(nextPeriod || currentPeriod());
   };
 
   const setReplacementDecision = async (item: SaluItem, nextStatus: 'REPLACE' | 'CANCELLED') => {
@@ -135,7 +140,7 @@ export default function SaluOverview() {
           <h2>Kommande SALU — 1 till 4 månader</h2>
           <p>SALU informerar. Den skapar inte BEHOV, UTÖKNING, MINSKNING eller BESTÄLLT.</p>
         </div>
-        <label className={styles.period}><span>Från månad</span><input type="month" value={period} onChange={(event) => changePeriod(event.target.value)} /></label>
+        <label className={styles.period}><span>Planeringsmånad</span><input type="month" value={period} onChange={(event) => changePeriod(event.target.value)} /></label>
       </div>
 
       {error ? <div className={styles.error}>{error}</div> : null}

--- a/tests/planning-v2-period-sync.test.ts
+++ b/tests/planning-v2-period-sync.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const page = readFileSync('app/planning/page.tsx', 'utf8');
+const workspace = readFileSync('app/planning/planning-workspace.tsx', 'utf8');
+const salu = readFileSync('app/planning/salu-overview.tsx', 'utf8');
+const matrix = readFileSync('app/planning/planning-client.tsx', 'utf8');
+
+test('Planering v2 has one shared planning month for SALU and decision matrix', () => {
+  assert.match(page, /<PlanningWorkspace \/>/);
+  assert.match(workspace, /const \[period, setPeriod\] = useState\(currentPeriod\)/);
+  assert.match(workspace, /<SaluOverview period=\{period\} onPeriodChange=\{setPeriod\} \/>/);
+  assert.match(workspace, /<FleetPlanningClient selectedPeriod=\{period\} onPeriodChange=\{setPeriod\} \/>/);
+  assert.match(salu, /Planeringsmånad/);
+  assert.match(matrix, /selectedPeriod/);
+  assert.match(matrix, /onPeriodChange\(nextPeriod\)/);
+});
+
+test('changing shared month reloads both read support and planning cells', () => {
+  assert.match(salu, /salu-overview\?period=\$\{encodeURIComponent\(period\)\}/);
+  assert.match(matrix, /fleet-planning\?period=\$\{encodeURIComponent\(selectedPeriod\)\}/);
+});


### PR DESCRIPTION
Synkroniserar Planering v2 så SALU-beslutsstödet och beslutsmatrisen arbetar mot samma valda månad.

- gemensam periodstate i PlanningWorkspace
- SALU använder samma planeringsmånad som matrisen
- byte via SALU laddar om matrisen
- byte via matrisen laddar om SALU
- befintlig utkastlogik och sparmodell behålls
- inga DB- eller API-kontraktsändringar